### PR TITLE
[codex] Add overdue dashboard checklist coverage

### DIFF
--- a/src/lib/overdue-utils.ts
+++ b/src/lib/overdue-utils.ts
@@ -1,0 +1,47 @@
+/**
+ * Pure helpers extracted from Dashboard.tsx for the overdue computation.
+ * Keeping these as standalone functions enables unit-testing without React.
+ */
+
+export interface ScheduledChecklist {
+  id: string;
+  title: string;
+  due_time: string | null;
+}
+
+export interface ActionWithDue {
+  id: string;
+  status: string;
+  due: string | null;
+}
+
+/**
+ * Returns checklists whose due_time has already passed today and have no
+ * completion log today.
+ */
+export function computeMissedChecklists<T extends ScheduledChecklist>(
+  checklists: T[],
+  completedTodayIds: Set<string>,
+  nowMinutes: number
+): T[] {
+  return checklists.filter((checklist) => {
+    if (!checklist.due_time) return false;
+    const [hours, minutes] = checklist.due_time.split(":").map(Number);
+    return (hours * 60 + minutes) < nowMinutes && !completedTodayIds.has(checklist.id);
+  });
+}
+
+/**
+ * Returns unresolved actions whose due date is strictly before todayStartMs.
+ */
+export function computeOverdueActions<T extends ActionWithDue>(
+  actions: T[],
+  todayStartMs: number
+): T[] {
+  return actions.filter(
+    (action) =>
+      action.status !== "resolved" &&
+      action.due != null &&
+      new Date(action.due).getTime() < todayStartMs
+  );
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -7,7 +7,9 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useAlerts } from "@/hooks/useAlerts";
 import { useChecklistLogs } from "@/hooks/useChecklistLogs";
 import { useActions, useSaveAction } from "@/hooks/useActions";
+import { useChecklists } from "@/hooks/useChecklists";
 import { useLocations } from "@/hooks/useLocations";
+import { computeMissedChecklists, computeOverdueActions } from "@/lib/overdue-utils";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -204,6 +206,7 @@ export default function Dashboard() {
   const { data: allAlerts = [] }    = useAlerts();
   const { data: logs      = [] }    = useChecklistLogs();
   const { data: actions   = [] }    = useActions();
+  const { data: checklists = [] }   = useChecklists();
   const { data: locations = [] }    = useLocations();
 
   // ── Date strings — use LOCAL date arithmetic to avoid UTC midnight shifting ──
@@ -290,10 +293,13 @@ export default function Dashboard() {
 
   // ── Overdue open actions ──
   const todayStart = new Date(today); todayStart.setHours(0, 0, 0, 0);
-  const overdueActions = actions.filter(a =>
-    a.status !== "resolved" && a.due && new Date(a.due).getTime() < todayStart.getTime()
+  const overdueActions = computeOverdueActions(actions, todayStart.getTime());
+  const nowMinutes = today.getHours() * 60 + today.getMinutes();
+  const todayCompletedIds = new Set(
+    logs.filter((log) => log.created_at.startsWith(todayStr)).map((log) => log.checklist_id).filter(Boolean)
   );
-  const overdueCount = overdueActions.length;
+  const missedChecklists = computeMissedChecklists(checklists, todayCompletedIds, nowMinutes);
+  const overdueCount = overdueActions.length + missedChecklists.length;
 
   // ── Alerts ──
   const visibleAlerts = allAlerts.slice(0, 3);
@@ -421,6 +427,7 @@ export default function Dashboard() {
             <div className="flex items-center bg-muted rounded-full p-0.5 text-xs shrink-0">
               {(["yesterday", "today", "overdue"] as ComplianceTab[]).map(tab => (
                 <button key={tab}
+                  data-testid={`compliance-tab-${tab}`}
                   onClick={() => { setComplianceTab(tab); setPage(0); setDrillLocationId(null); }}
                   className={cn(
                     "relative px-2.5 py-1 rounded-full transition-colors capitalize whitespace-nowrap",
@@ -458,6 +465,7 @@ export default function Dashboard() {
                   {pagedLocationItems.map(loc => (
                     <button
                       key={loc.locationId ?? "unassigned"}
+                      data-testid="location-card"
                       onClick={() => { setDrillLocationId(loc.locationId ?? "unassigned"); setPage(0); }}
                       className="bg-card border border-border rounded-2xl p-4 flex flex-col items-center gap-3 hover:bg-muted/30 transition-colors text-center active:scale-[0.98]"
                     >
@@ -514,7 +522,7 @@ export default function Dashboard() {
               </>
             )
           ) : (
-            overdueActions.length === 0 ? (
+            overdueActions.length === 0 && missedChecklists.length === 0 ? (
               <div className="bg-card border border-border rounded-2xl p-8 flex flex-col items-center gap-3 text-center">
                 <div className="w-12 h-12 rounded-full bg-sage-light flex items-center justify-center">
                   <TrendingUp size={20} className="text-sage" />
@@ -525,25 +533,53 @@ export default function Dashboard() {
                 </div>
               </div>
             ) : (
-              <div className="bg-card border border-border rounded-2xl divide-y divide-border overflow-hidden">
-                {overdueActions.map(task => (
-                  <button key={task.id} onClick={() => navigate("/checklists")}
-                    className="w-full flex items-start gap-3 px-4 py-4 text-left hover:bg-muted/30 transition-colors">
-                    <div className="w-9 h-9 rounded-xl bg-status-error/10 flex items-center justify-center shrink-0 mt-0.5">
-                      <AlertTriangle size={16} className="text-status-error" />
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <p className="text-sm font-semibold text-foreground">{task.title}</p>
-                      <p className="text-xs text-muted-foreground mt-0.5">
-                        {task.checklist_title ?? "—"}{task.assigned_to ? ` · ${task.assigned_to}` : ""}
-                      </p>
-                      {task.due && (
-                        <p className="text-xs text-status-error mt-1 font-medium">Due {task.due}</p>
-                      )}
-                    </div>
-                    <ChevronRight size={16} className="text-muted-foreground shrink-0 mt-2" />
-                  </button>
-                ))}
+              <div className="space-y-3">
+                {missedChecklists.length > 0 && (
+                  <div className="bg-card border border-border rounded-2xl divide-y divide-border overflow-hidden">
+                    {missedChecklists.map((checklist) => (
+                      <button
+                        key={checklist.id}
+                        data-testid="overdue-checklist-item"
+                        onClick={() => navigate("/checklists")}
+                        className="w-full flex items-start gap-3 px-4 py-4 text-left hover:bg-muted/30 transition-colors"
+                      >
+                        <div className="w-9 h-9 rounded-xl bg-status-warn/10 flex items-center justify-center shrink-0 mt-0.5">
+                          <AlertTriangle size={16} className="text-status-warn" />
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm font-semibold text-foreground">{checklist.title}</p>
+                          <p className="text-xs text-muted-foreground mt-0.5">Scheduled checklist</p>
+                          <p className="text-xs text-status-warn mt-1 font-medium">
+                            Due by {checklist.due_time} - not completed
+                          </p>
+                        </div>
+                        <ChevronRight size={16} className="text-muted-foreground shrink-0 mt-2" />
+                      </button>
+                    ))}
+                  </div>
+                )}
+                {overdueActions.length > 0 && (
+                  <div className="bg-card border border-border rounded-2xl divide-y divide-border overflow-hidden">
+                    {overdueActions.map(task => (
+                      <button key={task.id} onClick={() => navigate("/checklists")}
+                        className="w-full flex items-start gap-3 px-4 py-4 text-left hover:bg-muted/30 transition-colors">
+                        <div className="w-9 h-9 rounded-xl bg-status-error/10 flex items-center justify-center shrink-0 mt-0.5">
+                          <AlertTriangle size={16} className="text-status-error" />
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm font-semibold text-foreground">{task.title}</p>
+                          <p className="text-xs text-muted-foreground mt-0.5">
+                            {task.checklist_title ?? "—"}{task.assigned_to ? ` · ${task.assigned_to}` : ""}
+                          </p>
+                          {task.due && (
+                            <p className="text-xs text-status-error mt-1 font-medium">Due {task.due}</p>
+                          )}
+                        </div>
+                        <ChevronRight size={16} className="text-muted-foreground shrink-0 mt-2" />
+                      </button>
+                    ))}
+                  </div>
+                )}
               </div>
             )
           )}

--- a/src/test/lib/overdue-utils.test.ts
+++ b/src/test/lib/overdue-utils.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { computeMissedChecklists, computeOverdueActions } from "@/lib/overdue-utils";
+
+const NOW_MINUTES = 14 * 60;
+const TODAY_START_MS = new Date("2026-03-26T00:00:00").getTime();
+
+describe("computeMissedChecklists", () => {
+  it("includes a checklist with a past due_time that has no log today", () => {
+    const result = computeMissedChecklists(
+      [{ id: "c1", title: "Morning Check", due_time: "09:00" }],
+      new Set(),
+      NOW_MINUTES
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("c1");
+  });
+
+  it("excludes a checklist with a past due_time that already has a log today", () => {
+    const result = computeMissedChecklists(
+      [{ id: "c1", title: "Morning Check", due_time: "09:00" }],
+      new Set(["c1"]),
+      NOW_MINUTES
+    );
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("excludes a checklist with a future due_time", () => {
+    const result = computeMissedChecklists(
+      [{ id: "c1", title: "Evening Close", due_time: "22:00" }],
+      new Set(),
+      NOW_MINUTES
+    );
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("excludes a checklist with no due_time", () => {
+    const result = computeMissedChecklists(
+      [{ id: "c1", title: "Anytime Task", due_time: null }],
+      new Set(),
+      NOW_MINUTES
+    );
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("uses a strict less-than check for the boundary", () => {
+    const result = computeMissedChecklists(
+      [{ id: "c1", title: "Exact Time", due_time: "14:00" }],
+      new Set(),
+      NOW_MINUTES
+    );
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns only missed and uncompleted items from a mixed set", () => {
+    const checklists = [
+      { id: "c1", title: "Overdue not done", due_time: "08:00" },
+      { id: "c2", title: "Overdue but done", due_time: "09:00" },
+      { id: "c3", title: "Future", due_time: "20:00" },
+      { id: "c4", title: "No schedule", due_time: null },
+    ];
+
+    const result = computeMissedChecklists(checklists, new Set(["c2"]), NOW_MINUTES);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("c1");
+  });
+
+  it("returns an empty array when given no checklists", () => {
+    const result = computeMissedChecklists([], new Set(), NOW_MINUTES);
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe("computeOverdueActions", () => {
+  it("includes an unresolved action with a past due date", () => {
+    const result = computeOverdueActions(
+      [{ id: "a1", status: "open", due: "2026-03-25" }],
+      TODAY_START_MS
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("a1");
+  });
+
+  it("excludes a resolved action even if its due date is in the past", () => {
+    const result = computeOverdueActions(
+      [{ id: "a1", status: "resolved", due: "2026-03-25" }],
+      TODAY_START_MS
+    );
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("excludes an action with no due date", () => {
+    const result = computeOverdueActions(
+      [{ id: "a1", status: "open", due: null }],
+      TODAY_START_MS
+    );
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("excludes an action due today", () => {
+    const result = computeOverdueActions(
+      [{ id: "a1", status: "open", due: "2026-03-26" }],
+      TODAY_START_MS
+    );
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("excludes an action due in the future", () => {
+    const result = computeOverdueActions(
+      [{ id: "a1", status: "open", due: "2026-03-28" }],
+      TODAY_START_MS
+    );
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns an empty array when given no actions", () => {
+    const result = computeOverdueActions([], TODAY_START_MS);
+    expect(result).toHaveLength(0);
+  });
+});

--- a/src/test/pages/Dashboard.overdue.test.tsx
+++ b/src/test/pages/Dashboard.overdue.test.tsx
@@ -1,0 +1,291 @@
+import { fireEvent, screen } from "@testing-library/react";
+import Dashboard from "@/pages/Dashboard";
+import { renderWithProviders } from "../test-utils";
+
+const {
+  mockUseChecklistLogs,
+  mockUseChecklists,
+  mockUseLocations,
+  mockUseActions,
+} = vi.hoisted(() => ({
+  mockUseChecklistLogs: vi.fn(),
+  mockUseChecklists: vi.fn(),
+  mockUseLocations: vi.fn(),
+  mockUseActions: vi.fn(),
+}));
+
+vi.mock("@/hooks/useChecklistLogs", () => ({ useChecklistLogs: mockUseChecklistLogs }));
+vi.mock("@/hooks/useChecklists", () => ({
+  useChecklists: mockUseChecklists,
+  useFolders: () => ({ data: [] }),
+  useSaveFolder: () => ({ mutate: vi.fn() }),
+  useDeleteFolder: () => ({ mutate: vi.fn() }),
+}));
+vi.mock("@/hooks/useLocations", () => ({ useLocations: mockUseLocations }));
+vi.mock("@/hooks/useActions", () => ({
+  useActions: mockUseActions,
+  useSaveAction: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock("@/hooks/useAlerts", () => ({
+  useAlerts: () => ({ data: [] }),
+  useCreateAlert: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({
+    user: { id: "u1" },
+    session: null,
+    teamMember: {
+      id: "u1",
+      name: "Test User",
+      organization_id: "org1",
+      role: "Owner",
+      location_ids: [],
+      permissions: {},
+    },
+    loading: false,
+    signOut: vi.fn(),
+  }),
+}));
+vi.mock("@/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getSession: vi.fn().mockResolvedValue({ data: { session: null } }),
+      onAuthStateChange: vi.fn().mockReturnValue({
+        data: { subscription: { unsubscribe: vi.fn() } },
+      }),
+    },
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      then: vi.fn().mockImplementation((cb) => Promise.resolve(cb({ data: [], error: null }))),
+    }),
+  },
+}));
+
+const TODAY_STR = "2026-03-26";
+
+const OVERDUE_CHECKLIST = {
+  id: "ck-overdue",
+  title: "Morning Kitchen Check",
+  due_time: "09:00",
+  folder_id: null,
+  location_id: null,
+  schedule: null,
+  sections: [],
+  time_of_day: "morning" as const,
+  created_at: "",
+  updated_at: "",
+};
+
+const FUTURE_CHECKLIST = {
+  id: "ck-future",
+  title: "Evening Closing Check",
+  due_time: "22:00",
+  folder_id: null,
+  location_id: null,
+  schedule: null,
+  sections: [],
+  time_of_day: "evening" as const,
+  created_at: "",
+  updated_at: "",
+};
+
+const LOG_TODAY = {
+  id: "log-1",
+  checklist_id: "ck-overdue",
+  checklist_title: "Morning Kitchen Check",
+  completed_by: "Ana",
+  score: 100,
+  answers: [],
+  created_at: `${TODAY_STR}T10:00:00+00:00`,
+  location_id: null,
+  started_at: null,
+};
+
+describe("Dashboard - overdue tab", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(`${TODAY_STR}T14:00:00`));
+
+    mockUseChecklistLogs.mockReturnValue({ data: [] });
+    mockUseChecklists.mockReturnValue({ data: [] });
+    mockUseLocations.mockReturnValue({ data: [] });
+    mockUseActions.mockReturnValue({ data: [] });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function clickOverdueTab() {
+    const button = screen.getByTestId("compliance-tab-overdue");
+    fireEvent.click(button);
+  }
+
+  it("shows 'All caught up' when no missed checklists and no overdue actions", () => {
+    renderWithProviders(<Dashboard />);
+    clickOverdueTab();
+    expect(screen.getByText("All caught up")).toBeInTheDocument();
+  });
+
+  it("shows a missed checklist when due_time passed and no log exists today", () => {
+    mockUseChecklists.mockReturnValue({ data: [OVERDUE_CHECKLIST] });
+
+    renderWithProviders(<Dashboard />);
+    clickOverdueTab();
+
+    expect(screen.getByText("Morning Kitchen Check")).toBeInTheDocument();
+    expect(screen.getByText(/Due by 09:00/)).toBeInTheDocument();
+    expect(screen.getByText(/not completed/)).toBeInTheDocument();
+  });
+
+  it("does not show a missed checklist when a log exists for today", () => {
+    mockUseChecklists.mockReturnValue({ data: [OVERDUE_CHECKLIST] });
+    mockUseChecklistLogs.mockReturnValue({ data: [LOG_TODAY] });
+
+    renderWithProviders(<Dashboard />);
+    clickOverdueTab();
+
+    expect(screen.queryByText("Morning Kitchen Check")).not.toBeInTheDocument();
+    expect(screen.getByText("All caught up")).toBeInTheDocument();
+  });
+
+  it("does not show a checklist whose due_time has not passed yet", () => {
+    mockUseChecklists.mockReturnValue({ data: [FUTURE_CHECKLIST] });
+
+    renderWithProviders(<Dashboard />);
+    clickOverdueTab();
+
+    expect(screen.queryByText("Evening Closing Check")).not.toBeInTheDocument();
+    expect(screen.getByText("All caught up")).toBeInTheDocument();
+  });
+
+  it("shows a combined badge count for missed checklists and overdue actions", () => {
+    mockUseChecklists.mockReturnValue({ data: [OVERDUE_CHECKLIST, FUTURE_CHECKLIST] });
+    mockUseActions.mockReturnValue({
+      data: [
+        {
+          id: "a1",
+          title: "Fix fridge",
+          status: "open",
+          due: "2026-03-25",
+          checklist_title: null,
+          assigned_to: null,
+        },
+        {
+          id: "a2",
+          title: "Done task",
+          status: "resolved",
+          due: "2026-03-25",
+          checklist_title: null,
+          assigned_to: null,
+        },
+      ],
+    });
+
+    renderWithProviders(<Dashboard />);
+
+    const badge = document.querySelector(".bg-status-error.text-white");
+    expect(badge?.textContent?.trim()).toBe("2");
+  });
+});
+
+describe("Dashboard - location compliance cards", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(`${TODAY_STR}T14:00:00`));
+
+    mockUseChecklistLogs.mockReturnValue({ data: [] });
+    mockUseChecklists.mockReturnValue({ data: [] });
+    mockUseLocations.mockReturnValue({ data: [] });
+    mockUseActions.mockReturnValue({ data: [] });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows a location card when logs exist for today", () => {
+    mockUseLocations.mockReturnValue({
+      data: [{ id: "loc-1", name: "Main Kitchen" }],
+    });
+    mockUseChecklistLogs.mockReturnValue({
+      data: [
+        {
+          id: "log-1",
+          checklist_id: "ck-1",
+          checklist_title: "Opening Check",
+          completed_by: "Ana",
+          score: 88,
+          answers: [],
+          created_at: `${TODAY_STR}T08:00:00+00:00`,
+          location_id: "loc-1",
+          started_at: null,
+        },
+      ],
+    });
+
+    renderWithProviders(<Dashboard />);
+    expect(screen.getByText("Main Kitchen")).toBeInTheDocument();
+    expect(screen.getByText("Tap to drill in →")).toBeInTheDocument();
+  });
+
+  it("shows 'No submissions yet' when no logs exist for today", () => {
+    renderWithProviders(<Dashboard />);
+    expect(screen.getByText("No submissions yet")).toBeInTheDocument();
+  });
+
+  it("drills into a location to show its checklists", () => {
+    mockUseLocations.mockReturnValue({
+      data: [{ id: "loc-1", name: "Main Kitchen" }],
+    });
+    mockUseChecklistLogs.mockReturnValue({
+      data: [
+        {
+          id: "log-1",
+          checklist_id: "ck-1",
+          checklist_title: "Opening Check",
+          completed_by: "Ana",
+          score: 88,
+          answers: [],
+          created_at: `${TODAY_STR}T08:00:00+00:00`,
+          location_id: "loc-1",
+          started_at: null,
+        },
+      ],
+    });
+
+    renderWithProviders(<Dashboard />);
+    fireEvent.click(screen.getByTestId("location-card"));
+    expect(screen.getByText("Opening Check")).toBeInTheDocument();
+    expect(screen.getByText("Main Kitchen")).toBeInTheDocument();
+  });
+
+  it("returns from drill-down to location cards", () => {
+    mockUseLocations.mockReturnValue({
+      data: [{ id: "loc-1", name: "Main Kitchen" }],
+    });
+    mockUseChecklistLogs.mockReturnValue({
+      data: [
+        {
+          id: "log-1",
+          checklist_id: "ck-1",
+          checklist_title: "Opening Check",
+          completed_by: "Ana",
+          score: 88,
+          answers: [],
+          created_at: `${TODAY_STR}T08:00:00+00:00`,
+          location_id: "loc-1",
+          started_at: null,
+        },
+      ],
+    });
+
+    renderWithProviders(<Dashboard />);
+    fireEvent.click(screen.getByTestId("location-card"));
+    fireEvent.click(screen.getByRole("button", { name: /back to locations/i }));
+
+    expect(screen.getByText("Daily compliance")).toBeInTheDocument();
+    expect(screen.getByText("Tap to drill in →")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- extract pure overdue helpers for actions and scheduled checklists
- include missed scheduled checklists in the Dashboard overdue count and tab
- add targeted unit and page tests for the overdue flow

## Testing
- ~/.bun/bin/bun x vitest run --pool=forks src/test/pages/Dashboard.test.tsx src/test/lib/overdue-utils.test.ts src/test/pages/Dashboard.overdue.test.tsx

Related to #12