### PR TITLE
[codex] Ignore generated workspace artifacts in ESLint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from "eslint-plugin-react-refresh";
 import tseslint from "typescript-eslint";
 
 export default tseslint.config(
-  { ignores: ["dist", ".claude/**"] },
+  { ignores: ["dist", "coverage", "test-results", ".claude/**", ".agents/**"] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ["**/*.{ts,tsx}"],


### PR DESCRIPTION
## Summary
- stop lint from traversing generated coverage and test artifact folders
- ignore local agent workspace content under .agents
- keep lint focused on repo-owned source files

## Testing
- ~/.bun/bin/bun run lint

Related to #16