### PR TITLE
[codex] Fix Vitest shutdown loop in Infohub training flow

### DIFF
--- a/src/pages/Infohub.tsx
+++ b/src/pages/Infohub.tsx
@@ -575,12 +575,21 @@ function LibraryDocDetail({ doc, folders, onBack }: { doc: DocItem; folders: Fol
 
 // ─── Training Doc Detail ──────────────────────────────────────────────────────
 
-function TrainingDocDetail({ doc, onBack }: { doc: TrainingDoc; onBack: () => void }) {
+function TrainingDocDetail({ doc, onBack, onToggleComplete }: {
+  doc: TrainingDoc;
+  onBack: () => void;
+  onToggleComplete: (completed: boolean) => void;
+}) {
   const [completedSteps, setCompletedSteps] = useState<Set<number>>(
     doc.completed ? new Set(doc.steps.map((_, i) => i)) : new Set()
   );
   const [aiSheet, setAiSheet] = useState(false);
   const allDone = completedSteps.size === doc.steps.length;
+
+  useEffect(() => {
+    onToggleComplete(allDone);
+  }, [allDone, onToggleComplete]);
+
   const toggle = (i: number) => {
     setCompletedSteps(prev => {
       const next = new Set(prev);
@@ -785,7 +794,7 @@ export default function Infohub() {
   const [libFolders, setLibFolders] = useState<FolderItem[]>(initialLibraryFolders);
   const [libDocs, setLibDocs] = useState<DocItem[]>(initialLibraryDocs);
   const [trainFolders, setTrainFolders] = useState<TrainingFolder[]>(initialTrainingFolders);
-  const [trainDocs] = useState<TrainingDoc[]>(initialTrainingDocs);
+  const [trainDocs, setTrainDocs] = useState<TrainingDoc[]>(initialTrainingDocs);
 
   // Navigation state
   const [currentLibFolder, setCurrentLibFolder] = useState<string | null>(null);
@@ -881,7 +890,22 @@ export default function Infohub() {
 
   // Detail views
   if (selectedDoc) return <LibraryDocDetail doc={selectedDoc} folders={libFolders} onBack={() => setSelectedDoc(null)} />;
-  if (selectedTrainingDoc) return <TrainingDocDetail doc={selectedTrainingDoc} onBack={() => setSelectedTrainingDoc(null)} />;
+  if (selectedTrainingDoc) return (
+    <TrainingDocDetail
+      doc={selectedTrainingDoc}
+      onBack={() => setSelectedTrainingDoc(null)}
+      onToggleComplete={(completed) => {
+        setTrainDocs(prev => {
+          const currentDoc = prev.find(d => d.id === selectedTrainingDoc.id);
+          if (!currentDoc || currentDoc.completed === completed) {
+            return prev;
+          }
+
+          return prev.map(d => d.id === selectedTrainingDoc.id ? { ...d, completed } : d);
+        });
+      }}
+    />
+  );
   if (showSearch) return (
     <SearchOverlay libraryDocs={libDocs} trainingDocs={trainDocs} onClose={() => setShowSearch(false)}
       onSelectLibDoc={d => { setShowSearch(false); setSelectedDoc(d); }}

--- a/src/test/pages/Infohub.test.tsx
+++ b/src/test/pages/Infohub.test.tsx
@@ -319,6 +319,48 @@ describe("Infohub page", () => {
     }
   });
 
+  it("completed training modules stay completed after going back and reopening", () => {
+    renderWithProviders(<Infohub />);
+    fireEvent.click(screen.getByRole("button", { name: /training/i }));
+
+    const onboardingFolder = screen.getByText("Onboarding");
+    const folderRow = onboardingFolder.closest("div[class*='flex']") as HTMLElement;
+    if (!folderRow) return;
+    fireEvent.click(folderRow);
+
+    const moduleTitle = screen.queryByText("How to make a latte");
+    if (!moduleTitle) return;
+    const docRow = moduleTitle.closest("div[class*='cursor-pointer']") as HTMLElement;
+    if (!docRow) return;
+    fireEvent.click(docRow);
+
+    let stepIndex = 1;
+    while (true) {
+      const stepLabel = screen.queryByText(`Step ${stepIndex}`);
+      if (!stepLabel) break;
+      const stepBtn = stepLabel.closest("button") as HTMLElement | null;
+      if (!stepBtn) break;
+      fireEvent.click(stepBtn);
+      stepIndex += 1;
+    }
+
+    expect(screen.getByText("Module complete.")).toBeInTheDocument();
+
+    const backBtn = screen.getAllByRole("button").find(btn =>
+      btn.className.includes("rounded-full") && btn.querySelector("svg")
+    );
+    if (!backBtn) return;
+    fireEvent.click(backBtn);
+
+    const reopenedTitle = screen.queryByText("How to make a latte");
+    if (!reopenedTitle) return;
+    const reopenedRow = reopenedTitle.closest("div[class*='cursor-pointer']") as HTMLElement;
+    if (!reopenedRow) return;
+    fireEvent.click(reopenedRow);
+
+    expect(screen.getByText("Module complete.")).toBeInTheDocument();
+  });
+
   it("plus (+) button opens the Plus menu", () => {
     renderWithProviders(<Infohub />);
     const buttons = screen.getAllByRole("button");


### PR DESCRIPTION
## Summary
- persist training completion without recreating Infohub state on every render
- add a focused regression test for reopening a completed training module
- keep the branch scoped to the shutdown-loop fix only

## Testing
- ~/.bun/bin/bun x vitest run --pool=forks src/test/pages/Infohub.test.tsx

Related to #14