### PR TITLE
[codex] Reconcile stale tests with current UI

### DIFF
--- a/src/test/pages/Admin.test.tsx
+++ b/src/test/pages/Admin.test.tsx
@@ -489,11 +489,11 @@ describe("Admin page", () => {
     renderWithProviders(<Admin />);
     fireEvent.click(screen.getByText("Account"));
     await waitFor(() => {
-      expect(screen.getByText("Invite")).toBeInTheDocument();
+      expect(screen.getByText("Add")).toBeInTheDocument();
     });
-    fireEvent.click(screen.getByText("Invite"));
+    fireEvent.click(screen.getByText("Add"));
     await waitFor(() => {
-      expect(screen.getByText("Invite team member")).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "Add team member" })).toBeInTheDocument();
     });
   });
 
@@ -501,8 +501,8 @@ describe("Admin page", () => {
   it("team member form has Full name field", async () => {
     renderWithProviders(<Admin />);
     fireEvent.click(screen.getByText("Account"));
-    await waitFor(() => expect(screen.getByText("Invite")).toBeInTheDocument());
-    fireEvent.click(screen.getByText("Invite"));
+    await waitFor(() => expect(screen.getByText("Add")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Add"));
     await waitFor(() => {
       expect(screen.getByText("Full name")).toBeInTheDocument();
     });
@@ -512,8 +512,8 @@ describe("Admin page", () => {
   it("team member form has Email field", async () => {
     renderWithProviders(<Admin />);
     fireEvent.click(screen.getByText("Account"));
-    await waitFor(() => expect(screen.getByText("Invite")).toBeInTheDocument());
-    fireEvent.click(screen.getByText("Invite"));
+    await waitFor(() => expect(screen.getByText("Add")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Add"));
     await waitFor(() => {
       expect(screen.getByText("Email")).toBeInTheDocument();
     });
@@ -617,16 +617,21 @@ describe("Admin page", () => {
   it("My Location tab shows 'Auto-archive threshold' section", async () => {
     renderWithProviders(<Admin />);
     await waitFor(() => {
+      expect(screen.getByRole("button", { name: /^archived$/i })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^archived$/i }));
+    await waitFor(() => {
       expect(screen.getByText("Auto-archive threshold")).toBeInTheDocument();
     });
   });
 
-  // 46. Notifications & Alerts section is visible
-  it("My Location tab shows Notifications & alerts section", async () => {
+  // 46. Notifications section has been removed from the current My Location view
+  it("My Location tab does not show a Notifications & alerts section", async () => {
     renderWithProviders(<Admin />);
     await waitFor(() => {
-      expect(screen.getByText("Notifications & alerts")).toBeInTheDocument();
+      expect(screen.getByText("Location details")).toBeInTheDocument();
     });
+    expect(screen.queryByText("Notifications & alerts")).not.toBeInTheDocument();
   });
 
   // 47. Assigned checklists section is visible

--- a/src/test/pages/Billing.test.tsx
+++ b/src/test/pages/Billing.test.tsx
@@ -78,13 +78,13 @@ describe("Billing page", () => {
 
   it("renders 'Current plan' section label", () => {
     renderWithProviders(<Billing />);
-    expect(screen.getByText("Current plan")).toBeInTheDocument();
+    expect(screen.getByText("Your current plan")).toBeInTheDocument();
   });
 
   it("renders plan price cards for all 3 plans", () => {
     renderWithProviders(<Billing />);
-    expect(screen.getByText(PLAN_LABELS["growth"])).toBeInTheDocument();
-    expect(screen.getByText(PLAN_LABELS["enterprise"])).toBeInTheDocument();
+    expect(screen.getAllByText(PLAN_LABELS["growth"]).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(PLAN_LABELS["enterprise"]).length).toBeGreaterThanOrEqual(1);
   });
 
   it("renders starter plan monthly price", () => {
@@ -121,7 +121,7 @@ describe("Billing page", () => {
 
   it("shows 'Current' badge on the current plan card", () => {
     renderWithProviders(<Billing />);
-    expect(screen.getByText("Current")).toBeInTheDocument();
+    expect(screen.getAllByText("Current plan").length).toBeGreaterThanOrEqual(1);
   });
 
   it("renders growth plan when current plan is growth and shows Stripe link", () => {

--- a/src/test/pages/Signup.test.tsx
+++ b/src/test/pages/Signup.test.tsx
@@ -169,7 +169,14 @@ describe("Signup page", () => {
     fillValidForm();
     fireEvent.click(screen.getByText("Create account"));
     await waitFor(() => expect(mockSignUp).toHaveBeenCalledWith(
-      expect.objectContaining({ options: { data: { full_name: "Sarah Johnson" } } })
+      expect.objectContaining({
+        options: expect.objectContaining({
+          data: expect.objectContaining({
+            full_name: "Sarah Johnson",
+            business_name: "Acme Café",
+          }),
+        }),
+      })
     ));
   });
 

--- a/src/test/pages/checklists/ItemContextMenu.test.tsx
+++ b/src/test/pages/checklists/ItemContextMenu.test.tsx
@@ -33,9 +33,8 @@ describe("ItemContextMenu - folder type", () => {
   it("shows folder-specific actions", () => {
     render(<ItemContextMenu type="folder" onAction={onAction} onClose={onClose} />);
     expect(screen.getByText("Move to folder")).toBeInTheDocument();
-    expect(screen.getByText("Manage access")).toBeInTheDocument();
     expect(screen.getByText("Rename")).toBeInTheDocument();
-    expect(screen.getByText("Archive")).toBeInTheDocument();
+    expect(screen.getByText("Delete")).toBeInTheDocument();
   });
 
   it("does not show checklist-only actions for folder type", () => {
@@ -52,10 +51,10 @@ describe("ItemContextMenu - folder type", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it("clicking Archive calls onAction with 'archive'", () => {
+  it("clicking Delete calls onAction with 'delete'", () => {
     render(<ItemContextMenu type="folder" onAction={onAction} onClose={onClose} />);
-    fireEvent.click(screen.getByText("Archive"));
-    expect(onAction).toHaveBeenCalledWith("archive");
+    fireEvent.click(screen.getByText("Delete"));
+    expect(onAction).toHaveBeenCalledWith("delete");
   });
 
   it("clicking overlay calls onClose", () => {
@@ -84,9 +83,8 @@ describe("ItemContextMenu - checklist type", () => {
     expect(screen.getByText("Edit")).toBeInTheDocument();
     expect(screen.getByText("Duplicate")).toBeInTheDocument();
     expect(screen.getByText("Move to folder")).toBeInTheDocument();
-    expect(screen.getByText("Manage access")).toBeInTheDocument();
     expect(screen.getByText("Download as PDF")).toBeInTheDocument();
-    expect(screen.getByText("Archive")).toBeInTheDocument();
+    expect(screen.getByText("Delete")).toBeInTheDocument();
   });
 
   it("clicking Edit calls onAction with 'edit'", () => {

--- a/src/test/pages/checklists/MoveToFolderSheet.test.tsx
+++ b/src/test/pages/checklists/MoveToFolderSheet.test.tsx
@@ -53,7 +53,7 @@ describe("MoveToFolderSheet", () => {
         onClose={onClose}
       />
     );
-    expect(screen.getByText("Root (no folder)")).toBeInTheDocument();
+    expect(screen.getByText("No folder (unfiled)")).toBeInTheDocument();
   });
 
   it("shows all folders", () => {
@@ -147,7 +147,7 @@ describe("MoveToFolderSheet", () => {
         onClose={onClose}
       />
     );
-    fireEvent.click(screen.getByText("Root (no folder)"));
+    fireEvent.click(screen.getByText("No folder (unfiled)"));
     expect(onMove).toHaveBeenCalledWith(null);
   });
 
@@ -160,6 +160,6 @@ describe("MoveToFolderSheet", () => {
         onClose={onClose}
       />
     );
-    expect(screen.getByText("Root (no folder)")).toBeInTheDocument();
+    expect(screen.getByText("No folder (unfiled)")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- update stale Admin, Billing, Signup, ItemContextMenu, and MoveToFolderSheet tests to match the current shipped UI
- keep the cleanup test-only so milestone verification reflects product behavior already on main
- restore a green Vitest suite after the recent product and UI changes

## Verification
- ~/.bun/bin/bun x vitest run --pool=forks src/test/pages/checklists/ItemContextMenu.test.tsx src/test/pages/checklists/MoveToFolderSheet.test.tsx src/test/pages/Billing.test.tsx src/test/pages/Signup.test.tsx src/test/pages/Admin.test.tsx
- ~/.bun/bin/bun run test:ci
- PATH="$HOME/.bun/bin:$PATH" bun run milestone

## Note
-The milestone script passes, but the current enforced coverage gate is still far below the documented 95% policy. This PR fixes stale tests, not the coverage-policy mismatch.