### PR TITLE
[codex] Require GitHub issue tracking for new tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,8 @@ If `bun` is not on `PATH`, use `~/.bun/bin/bun`.
 - Treat `main` as protected, even if local tooling would technically allow direct edits.
 - Prefer small, reviewable PRs over broad mixed branches.
 - Do not revert unrelated user changes in a dirty worktree.
+- Every new task, bug, feature, or cleanup item must be tracked in GitHub before implementation starts.
+- Prefer linking work to an existing GitHub issue when one already exists; create a new issue only when the work is not already tracked.
 
 ## Quality Expectations
 
@@ -36,7 +38,7 @@ If `bun` is not on `PATH`, use `~/.bun/bin/bun`.
 - `bun run test:ci` is the unit/integration gate.
 - `bun run e2e` is the manual mobile release gate.
 
-The aspirational coverage target is 95%, but the exact live enforced thresholds can change while the repo is being stabilized. Always treat [vitest.config.ts](/Users/doraangelov/Desktop/OLIA%20%E2%9C%A8/olia-docs/vitest.config.ts) as the source of truth for the current enforced thresholds.
+The aspirational coverage target is 95%, but the exact live enforced thresholds can change while the repo is being stabilized. Always treat `vitest.config.ts` as the source of truth for the current enforced thresholds.
 
 ## Architecture Snapshot
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ bun run cap:android
 - Create a branch for every change.
 - Open a pull request for all work, including small fixes.
 - Treat `main` as protected even if local tooling would allow direct changes.
+- Register every new task in GitHub before implementation starts.
+- Reuse an existing GitHub issue when the work is already tracked; create a new issue only for genuinely new work.
 
 ## Quality Gates
 
@@ -58,7 +60,7 @@ The intended milestone gate is:
 3. `bun run build`
 4. `bun run e2e` on a simulator or emulator
 
-The current enforced unit-test thresholds live in [vitest.config.ts](/Users/doraangelov/Desktop/OLIA%20%E2%9C%A8/olia-docs/vitest.config.ts). Treat that file as the source of truth for the exact live gate while coverage is being ratcheted upward.
+The current enforced unit-test thresholds live in `vitest.config.ts`. Treat that file as the source of truth for the exact live gate while coverage is being ratcheted upward.
 
 ## App Areas
 


### PR DESCRIPTION
## Summary
- require every new task to be tracked in GitHub before implementation starts
- clarify that existing issues should be reused instead of creating duplicates
- update both README and AGENTS guidance so the rule is visible to humans and agents

## Verification
- reviewed README.md
- reviewed AGENTS.md

Related to #51