### PR TITLE
[codex] Local Docker Supabase workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,14 @@
 # ─── Supabase (required) ──────────────────────────────────────────────────────
-# Copy from: Supabase Dashboard → Project Settings → API
+# Use either:
+#   - a hosted Supabase project for staging/production, or
+#   - a local Docker Supabase stack started with `supabase start`
+#
+# Hosted project values:
+#   Supabase Dashboard → Project Settings → API
+#
+# Local Docker values:
+#   `supabase start`
+#   `supabase status -o env`
 VITE_SUPABASE_URL=https://your-project-ref.supabase.co
 VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.your_anon_key_here
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,36 @@ If `bun` is not on your `PATH`, use `~/.bun/bin/bun`.
 
 The dev server runs at [http://localhost:8080](http://localhost:8080).
 
+### Supabase Modes
+
+This repo supports two safe Supabase setups:
+
+- Hosted Supabase for staging and production, using your remote project values in `.env.local`
+- Local Docker Supabase for development and testing, using `supabase start`
+
+Local prerequisites:
+
+- Docker Desktop or another Docker runtime
+- Supabase CLI installed and available on your `PATH`
+
+Local Supabase workflow:
+
+```bash
+supabase start
+supabase status -o env
+supabase db reset --local --no-seed
+```
+
+The local CLI config lives in [supabase/config.toml](supabase/config.toml). It keeps auth redirects on `http://localhost:8080` and disables the default seed path so local resets do not depend on a missing top-level `seed.sql`.
+
+To stop the local Docker stack:
+
+```bash
+supabase stop
+```
+
+If you prefer repo scripts, the same workflow is exposed through `bun run supabase:start`, `bun run supabase:status`, `bun run supabase:reset`, and `bun run supabase:stop`.
+
 ## Common Commands
 
 ```bash
@@ -40,6 +70,10 @@ bun run milestone
 bun run e2e
 bun run cap:ios
 bun run cap:android
+supabase start
+supabase stop
+supabase status -o env
+supabase db reset --local --no-seed
 ```
 
 ## Workflow

--- a/package.json
+++ b/package.json
@@ -24,7 +24,11 @@
     "e2e:runner": "export JAVA_HOME=\"$HOME/Library/Java/jdk21/Contents/Home\" PATH=\"$JAVA_HOME/bin:$PATH:$HOME/.maestro/bin\" && maestro test .maestro/flows/09-checklist-runner.yaml",
     "e2e:studio": "export JAVA_HOME=\"$HOME/Library/Java/jdk21/Contents/Home\" PATH=\"$JAVA_HOME/bin:$PATH:$HOME/.maestro/bin\" && maestro studio",
     "e2e:playwright": "playwright test --config e2e/playwright.config.ts",
-    "e2e:playwright:headed": "playwright test --config e2e/playwright.config.ts --headed"
+    "e2e:playwright:headed": "playwright test --config e2e/playwright.config.ts --headed",
+    "supabase:start": "supabase start",
+    "supabase:stop": "supabase stop",
+    "supabase:status": "supabase status -o env",
+    "supabase:reset": "supabase db reset --local --no-seed"
   },
   "dependencies": {
     "@capacitor/android": "^8.2.0",

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,103 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# Keep this project ID stable so local Docker services use a predictable name.
+project_id = "olia-local"
+
+[api]
+enabled = true
+port = 54321
+schemas = ["public", "graphql_public"]
+extra_search_path = ["public", "extensions"]
+max_rows = 1000
+
+[api.tls]
+enabled = false
+
+[db]
+port = 54322
+shadow_port = 54320
+health_timeout = "2m"
+major_version = 17
+
+[db.pooler]
+enabled = false
+port = 54329
+pool_mode = "transaction"
+default_pool_size = 20
+max_client_conn = 100
+
+[db.migrations]
+enabled = true
+schema_paths = []
+
+[db.seed]
+# Keep local resets deterministic without requiring a repo-wide seed.sql file.
+enabled = false
+sql_paths = []
+
+[db.network_restrictions]
+enabled = false
+allowed_cidrs = ["0.0.0.0/0"]
+allowed_cidrs_v6 = ["::/0"]
+
+[realtime]
+enabled = true
+
+[studio]
+enabled = true
+port = 54323
+api_url = "http://127.0.0.1"
+openai_api_key = "env(OPENAI_API_KEY)"
+
+[inbucket]
+enabled = true
+port = 54324
+
+[storage]
+enabled = true
+file_size_limit = "50MiB"
+
+[storage.s3_protocol]
+enabled = true
+
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+[storage.vector]
+enabled = false
+max_buckets = 10
+max_indexes = 5
+
+[auth]
+enabled = true
+site_url = "http://localhost:8080"
+additional_redirect_urls = ["http://localhost:8080", "http://127.0.0.1:8080"]
+jwt_expiry = 3600
+enable_refresh_token_rotation = true
+refresh_token_reuse_interval = 10
+enable_signup = true
+enable_anonymous_sign_ins = false
+enable_manual_linking = false
+minimum_password_length = 6
+password_requirements = ""
+
+[auth.rate_limit]
+email_sent = 2
+sms_sent = 30
+anonymous_users = 30
+token_refresh = 150
+sign_in_sign_ups = 30
+token_verifications = 30
+web3 = 30
+
+[auth.email]
+enable_signup = true
+double_confirm_changes = true
+enable_confirmations = false
+secure_password_change = false
+max_frequency = "1s"
+otp_length = 6
+otp_expiry = 3600


### PR DESCRIPTION
Closes #51\n\nAdds a checked-in local Supabase CLI config, docs, and helper scripts so developers can run a Docker-backed Supabase stack for development/testing while keeping hosted Supabase as the production path.