### PR TITLE
[codex] Align testing policy messaging with live gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:watch": "vitest",
     "test:coverage": "mkdir -p coverage/.tmp && vitest run --coverage",
     "test:ci": "mkdir -p coverage/.tmp && vitest run --coverage",
-    "milestone": "bun run lint && bun run test:ci && bun run build && echo '✅ Milestone gate passed — lint + 95% coverage + build all green'",
+    "milestone": "bun run lint && bun run test:ci && bun run build && echo '✅ Milestone gate passed — lint + current coverage thresholds + build all green'",
     "cap:sync": "bun run build && cap sync",
     "cap:ios": "bun run build && cap sync ios && cap open ios",
     "cap:android": "bun run build && cap sync android && cap open android",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -42,13 +42,10 @@ export default defineConfig({
         "src/vite-env.d.ts",
       ],
 
-      // ── Quality Gate: 95% across all four metrics ─────────────────────
-      // ANY metric below 95% causes `bun run test:ci` to exit with code 1.
       // ── Quality Gate ──────────────────────────────────────────────────
       // True baseline as of March 2026 with the v8 coverage provider.
       // Target is 95% but the codebase is currently at ~56-60%.
       // Raise these incrementally as new tests are added.
-      // TODO: Increase to 95% once large page files are more thoroughly tested.
       thresholds: {
         lines:      60,
         functions:  45,


### PR DESCRIPTION
## Summary
- update the milestone success message to match the live coverage gate
- reword vitest coverage comments to describe the enforced baseline honestly
- keep 95% as the aspirational target without changing thresholds

## Testing
- bun run milestone

Closes #2