### PR TITLE
[codex] Update PR test workflow for Node 24 runtime compatibility

### DIFF
--- a/.github/workflows/pr-unit-tests.yml
+++ b/.github/workflows/pr-unit-tests.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary\n- update the PR unit-test workflow to use actions/checkout@v5\n- keep the existing Bun setup and  gate unchanged\n- address the GitHub Actions Node 20 runtime warning with the smallest compatible change\n\n## Testing\n- git diff --check\n\nCloses #57