### PR TITLE
[codex] Add one-command local Supabase dev flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ supabase stop
 
 If you prefer repo scripts, the same workflow is exposed through `bun run supabase:start`, `bun run supabase:status`, `bun run supabase:reset`, and `bun run supabase:stop`.
 
+For the common “boot local Supabase and start the app” flow, use:
+
+```bash
+bun run dev:local
+```
+
 ### GitHub Pages Auth
 
 If you deploy the web app to GitHub Pages or another static host, set these public build-time values in your deployment environment:

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:local": "supabase start && bun run dev",
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",


### PR DESCRIPTION
## Summary
- add a dev:local script that starts local Docker Supabase and then launches the Vite dev server
- document the new one-command local workflow in the README
- keep the existing separate Supabase and app commands unchanged

## Testing
- node -e "const p=require('./package.json'); console.log(p.scripts['dev:local'])"

Closes #65