### PR TITLE
[codex] Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,58 @@
+name: GitHub Pages Deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build site
+        run: bun run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: dist
+
+  deploy:
+    name: deploy
+    needs: build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The production build is compatible with GitHub Pages static hosting.
 - In GitHub Actions, Vite automatically uses the repository name as the base path when `GITHUB_REPOSITORY` is present.
 - `public/404.html` rewrites direct deep links back to the app so refreshes and bookmark URLs keep working.
 - If you want to test a Pages-style build locally, set `VITE_BASE_PATH=/olia-your-daily-operations/` before `bun run build`.
+- The repository now includes a GitHub Pages deploy workflow in [`.github/workflows/github-pages.yml`](.github/workflows/github-pages.yml). Enable GitHub Pages with the "GitHub Actions" source in repo settings so the workflow can publish `main`.
 
 ### Supabase Modes
 


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the app with Bun and deploys it to GitHub Pages
- keep the repo-name base path / SPA fallback flow aligned with the existing Pages routing work
- document that GitHub Pages must be enabled with the GitHub Actions source in repo settings

## Testing
- ~/.bun/bin/bun run build
- git diff --check

Closes #58