### PR TITLE
[codex] Require labels and milestones for new tasks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ If `bun` is not on `PATH`, use `~/.bun/bin/bun`.
 - Prefer small, reviewable PRs over broad mixed branches.
 - Do not revert unrelated user changes in a dirty worktree.
 - Every new task, bug, feature, or cleanup item must be tracked in GitHub before implementation starts.
+- When creating a new GitHub task, apply the appropriate existing labels and assign the best-fit milestone when possible.
 - Prefer linking work to an existing GitHub issue when one already exists; create a new issue only when the work is not already tracked.
 
 ## Quality Expectations

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ supabase db reset --local --no-seed
 - Open a pull request for all work, including small fixes.
 - Treat `main` as protected even if local tooling would allow direct changes.
 - Register every new task in GitHub before implementation starts.
+- When creating a new GitHub task, add appropriate existing labels and assign the best-fit milestone when possible.
 - Reuse an existing GitHub issue when the work is already tracked; create a new issue only for genuinely new work.
 
 ## Quality Gates


### PR DESCRIPTION
## Summary
- update the workflow guidance to require labels when creating new GitHub tasks
- update the workflow guidance to assign the best-fit milestone when possible
- keep the existing issue-registration rule in place

## Testing
- docs-only change

Closes #73