### PR TITLE
[codex] Add local vs prod env profile commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ dist-ssr
 # Environment files — .env.local contains real keys and must NEVER be committed
 # .env.example (no secrets) is safe to commit and documents required variables
 .env.local
+.env.docker
+.env.prod
 .env.*.local
 
 # Claude Code internal workspace — never commit

--- a/README.md
+++ b/README.md
@@ -65,10 +65,23 @@ supabase stop
 
 If you prefer repo scripts, the same workflow is exposed through `bun run supabase:start`, `bun run supabase:status`, `bun run supabase:reset`, and `bun run supabase:stop`.
 
-For the common “boot local Supabase and start the app” flow, use:
+For one-command profile switching, keep these local-only files on your machine:
+
+- `.env.docker` for local Docker Supabase development
+- `.env.prod` for local app development against hosted production-like services
+
+The app still reads `.env.local`, and the helper commands below copy the chosen profile into that active file before startup.
+
+To boot local Supabase and start the app, use:
 
 ```bash
 bun run dev:local
+```
+
+To run the app locally against hosted services, use:
+
+```bash
+bun run dev:prod
 ```
 
 ### GitHub Pages Auth

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "dev:local": "supabase start && bun run dev",
+    "env:local": "./scripts/activate-env-profile.sh docker",
+    "env:prod": "./scripts/activate-env-profile.sh prod",
+    "dev:local": "bun run env:local && supabase start && bun run dev",
+    "dev:prod": "bun run env:prod && bun run dev",
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",

--- a/scripts/activate-env-profile.sh
+++ b/scripts/activate-env-profile.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -eu
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <docker|prod>" >&2
+  exit 1
+fi
+
+profile="$1"
+source_file=".env.$profile"
+target_file=".env.local"
+
+if [ ! -f "$source_file" ]; then
+  echo "Missing $source_file" >&2
+  echo "Create $source_file with the correct values, then rerun the command." >&2
+  exit 1
+fi
+
+cp "$source_file" "$target_file"
+echo "Activated $source_file -> $target_file"


### PR DESCRIPTION
## Summary
- add stored env profile support for local Docker Supabase vs hosted production-like services
- make dev:local activate .env.docker before starting Supabase and the app
- add a dev:prod command that activates .env.prod before starting the app
- document the profile workflow and ignore the local profile files in git

## Testing
- sh -n scripts/activate-env-profile.sh
- node -e "const p=require('./package.json'); console.log(JSON.stringify({envLocal:p.scripts['env:local'],envProd:p.scripts['env:prod'],devLocal:p.scripts['dev:local'],devProd:p.scripts['dev:prod']}, null, 2))"

Closes #72