### PR TITLE
[codex] Wire GitHub Pages build to repo variables

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -36,6 +36,10 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Build site
+        env:
+          VITE_SUPABASE_URL: ${{ vars.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ vars.VITE_SUPABASE_ANON_KEY }}
+          VITE_PUBLIC_SITE_URL: ${{ vars.VITE_PUBLIC_SITE_URL }}
         run: bun run build
 
       - name: Upload Pages artifact


### PR DESCRIPTION
## Summary
- pass the repo-level GitHub Actions variables into the GitHub Pages build step
- make the Pages workflow use the configured Supabase URL, anon key, and public site URL during build
- keep the deployment workflow otherwise unchanged

## Testing
- git diff --check

Related to #58