### PR TITLE
[codex] Add local Supabase integration test harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ To run the app locally against hosted services, use:
 bun run dev:prod
 ```
 
+## Integration Tests
+
+Run the first local-Docker-Supabase integration slice with:
+
+```bash
+bun run test:integration
+```
+
+That command starts local Supabase, resets the database to a deterministic state, seeds a kiosk PIN fixture, and runs the Supabase-backed integration tests in `src/test/integration/`.
+
 ### GitHub Pages Auth
 
 If you deploy the web app to GitHub Pages or another static host, set these public build-time values in your deployment environment:

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:watch": "vitest",
     "test:coverage": "mkdir -p coverage/.tmp && vitest run --coverage",
     "test:ci": "mkdir -p coverage/.tmp && vitest run --coverage",
+    "test:integration": "~/.bun/bin/bun scripts/run-local-supabase-integration.mjs",
     "milestone": "bun run lint && bun run test:ci && bun run build && echo '✅ Milestone gate passed — lint + current coverage thresholds + build all green'",
     "cap:sync": "bun run build && cap sync",
     "cap:ios": "bun run build && cap sync ios && cap open ios",

--- a/scripts/run-local-supabase-integration.mjs
+++ b/scripts/run-local-supabase-integration.mjs
@@ -1,0 +1,53 @@
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const envDockerPath = path.join(root, ".env.docker");
+const bunBin = process.env.BUN_BIN || path.join(process.env.HOME || "", ".bun/bin/bun");
+
+if (!fs.existsSync(envDockerPath)) {
+  throw new Error("Missing .env.docker. Create it first, then rerun the integration test command.");
+}
+
+function loadEnvFile(filePath) {
+  const content = fs.readFileSync(filePath, "utf8");
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eqIndex = trimmed.indexOf("=");
+    if (eqIndex === -1) continue;
+    const key = trimmed.slice(0, eqIndex).trim();
+    const value = trimmed.slice(eqIndex + 1).trim().replace(/^"|"$/g, "");
+    process.env[key] = value;
+  }
+}
+
+function loadShellEnv(output) {
+  for (const line of output.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eqIndex = trimmed.indexOf("=");
+    if (eqIndex === -1) continue;
+    const key = trimmed.slice(0, eqIndex).trim();
+    const value = trimmed.slice(eqIndex + 1).trim().replace(/^"|"$/g, "");
+    process.env[key] = value;
+  }
+}
+
+function run(command) {
+  execSync(command, { stdio: "inherit", env: process.env });
+}
+
+loadEnvFile(envDockerPath);
+run(`${bunBin} run env:local`);
+run("supabase start");
+run("supabase db reset --local --no-seed");
+loadShellEnv(execSync("supabase status -o env", { encoding: "utf8" }));
+
+process.env.VITE_SUPABASE_URL ||= process.env.API_URL;
+process.env.VITE_SUPABASE_ANON_KEY ||= process.env.ANON_KEY;
+process.env.SUPABASE_SERVICE_ROLE_KEY ||= process.env.SERVICE_ROLE_KEY;
+
+run(`${bunBin} scripts/seed-local-supabase.mjs`);
+run(`${bunBin} x vitest run --config vitest.integration.config.ts`);

--- a/scripts/seed-local-supabase.mjs
+++ b/scripts/seed-local-supabase.mjs
@@ -1,0 +1,65 @@
+import crypto from "node:crypto";
+import { createClient } from "@supabase/supabase-js";
+
+const supabaseUrl = process.env.API_URL || process.env.VITE_SUPABASE_URL;
+const serviceRoleKey = process.env.SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl) {
+  throw new Error("Missing local Supabase URL. Run this through scripts/run-local-supabase-integration.mjs.");
+}
+
+if (!serviceRoleKey) {
+  throw new Error("Missing local Supabase service role key. Run this through scripts/run-local-supabase-integration.mjs.");
+}
+
+const supabase = createClient(supabaseUrl, serviceRoleKey, {
+  auth: { persistSession: false, autoRefreshToken: false },
+});
+
+const ORG_ID = "11111111-1111-4111-8111-111111111111";
+const LOCATION_ID = "22222222-2222-4222-8222-222222222222";
+const STAFF_ID = "33333333-3333-4333-8333-333333333333";
+const PIN = "1234";
+const HASHED_PIN = crypto.createHash("sha256").update(PIN).digest("hex");
+
+async function seed() {
+  await supabase.from("staff_profiles").delete().eq("id", STAFF_ID);
+  await supabase.from("locations").delete().eq("id", LOCATION_ID);
+  await supabase.from("organizations").delete().eq("id", ORG_ID);
+
+  const { error: orgError } = await supabase.from("organizations").insert({
+    id: ORG_ID,
+    name: "Integration Test Organisation",
+    plan: "starter",
+    plan_status: "active",
+  });
+  if (orgError) throw orgError;
+
+  const { error: locationError } = await supabase.from("locations").insert({
+    id: LOCATION_ID,
+    organization_id: ORG_ID,
+    name: "Integration Kitchen",
+    address: "1 Test Street",
+    archive_threshold_days: 90,
+  });
+  if (locationError) throw locationError;
+
+  const { error: staffError } = await supabase.from("staff_profiles").insert({
+    id: STAFF_ID,
+    organization_id: ORG_ID,
+    location_id: LOCATION_ID,
+    first_name: "Ada",
+    last_name: "Lovelace",
+    role: "Chef",
+    status: "active",
+    pin: HASHED_PIN,
+  });
+  if (staffError) throw staffError;
+
+  console.log("Seeded local Supabase integration data.");
+}
+
+seed().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/test/integration/staff-pin.integration.test.ts
+++ b/src/test/integration/staff-pin.integration.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { supabase } from "@/lib/supabase";
+
+const LOCATION_ID = "22222222-2222-4222-8222-222222222222";
+
+describe("local Supabase integration", () => {
+  it("validates the kiosk staff PIN through the real RPC", async () => {
+    const { data, error } = await supabase.rpc("validate_staff_pin", {
+      p_pin: "1234",
+      p_location_id: LOCATION_ID,
+    });
+
+    expect(error).toBeNull();
+    expect(data).toHaveLength(1);
+    expect(data?.[0]).toMatchObject({
+      first_name: "Ada",
+      last_name: "Lovelace",
+      role: "Chef",
+    });
+  });
+
+  it("rejects an incorrect PIN", async () => {
+    const { data, error } = await supabase.rpc("validate_staff_pin", {
+      p_pin: "9999",
+      p_location_id: LOCATION_ID,
+    });
+
+    expect(error).toBeNull();
+    expect(data).toEqual([]);
+  });
+});

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["src/test/integration/**/*.integration.test.ts"],
+    testTimeout: 30000,
+    hookTimeout: 30000,
+  },
+  resolve: {
+    alias: { "@": path.resolve(__dirname, "./src") },
+  },
+});


### PR DESCRIPTION
Implements the first integration-test slice for issue #64.

What changed:
- adds a deterministic local Supabase seed script
- adds an integration Vitest config
- adds an initial real Supabase-backed integration test for validate_staff_pin
- adds a wrapper command to start/reset local Supabase, seed test data, and run the integration suite
- documents how to run the integration tests locally

Validation:
- bun run test:integration