### PR TITLE
[codex] Harden test signal and remove router warning noise

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import { queryClient } from "@/lib/query-client";
 import { AuthProvider } from "@/contexts/AuthContext";
 import { ProtectedRoute } from "@/components/ProtectedRoute";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { routerFutureFlags } from "@/lib/router-future-flags";
 
 const App = () => (
   <ErrorBoundary>
@@ -26,7 +27,7 @@ const App = () => (
       <TooltipProvider>
         <Toaster />
         <Sonner />
-        <BrowserRouter basename={import.meta.env.BASE_URL}>
+        <BrowserRouter basename={import.meta.env.BASE_URL} future={routerFutureFlags}>
           <ErrorBoundary>
           <Routes>
             {/* Public landing page — unauthenticated */}

--- a/src/lib/router-future-flags.ts
+++ b/src/lib/router-future-flags.ts
@@ -1,0 +1,4 @@
+export const routerFutureFlags = {
+  v7_startTransition: true,
+  v7_relativeSplatPath: true,
+} as const;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -237,25 +237,24 @@ export default function Dashboard() {
     }, {})
   );
 
-  // Helper: map a log to a ChecklistCompliance object
-  const logToChecklist = (log: typeof tabLogs[0]): ChecklistCompliance => {
-    const ans      = Array.isArray(log.answers) ? log.answers : [];
-    const answered = ans.filter(a => a.value !== null && a.value !== "" && a.value !== undefined && a.value !== false);
-    return {
-      id:             log.id,
-      name:           log.checklist_title,
-      completedBy:    log.completed_by,
-      completion:     log.score ?? 0,
-      totalTasks:     ans.length,
-      completedTasks: answered.length,
-      unanswered:     ans.filter(a => !a.value).map(a => String(a.question ?? a.questionId ?? "")),
-      completedAt:    new Date(log.created_at).toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit" }),
-    };
-  };
-
   // ── Group logs by location → location-level compliance cards ──
   const locationComplianceItems: LocationCompliance[] = useMemo(() => {
     const groups: Record<string, { locationId: string | null; name: string; logs: typeof tabLogs }> = {};
+
+    const logToChecklist = (log: typeof tabLogs[0]): ChecklistCompliance => {
+      const ans = Array.isArray(log.answers) ? log.answers : [];
+      const answered = ans.filter(a => a.value !== null && a.value !== "" && a.value !== undefined && a.value !== false);
+      return {
+        id:          log.id,
+        name:        log.checklist_title,
+        completedBy: log.completed_by,
+        completion:  log.score ?? 0,
+        totalTasks:  ans.length,
+        completedTasks: answered.length,
+        unanswered:  ans.filter(a => !a.value).map(a => String(a.question ?? a.questionId ?? "")),
+        completedAt: new Date(log.created_at).toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit" }),
+      };
+    };
 
     for (const log of tabLogs) {
       const key  = log.location_id ?? "unassigned";

--- a/src/test/components/BottomNav.test.tsx
+++ b/src/test/components/BottomNav.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { BottomNav } from "@/components/BottomNav";
+import { routerFutureFlags } from "@/lib/router-future-flags";
 
 // Mock useLocation to return /dashboard as the current path
 vi.mock("react-router-dom", async () => {
@@ -13,7 +14,7 @@ vi.mock("react-router-dom", async () => {
 
 function renderBottomNav() {
   return render(
-    <MemoryRouter initialEntries={["/dashboard"]}>
+    <MemoryRouter initialEntries={["/dashboard"]} future={routerFutureFlags}>
       <BottomNav />
     </MemoryRouter>
   );

--- a/src/test/lib/submission-queue.test.ts
+++ b/src/test/lib/submission-queue.test.ts
@@ -1,10 +1,16 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { enqueueLog, pendingCount, drainQueue } from "@/lib/submission-queue";
 
 const STORAGE_KEY = "olia_pending_logs";
+let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
   localStorage.clear();
+  consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  consoleWarnSpy.mockRestore();
 });
 
 describe("enqueueLog", () => {
@@ -73,6 +79,7 @@ describe("drainQueue", () => {
 
 describe("MAX_ATTEMPTS protection", () => {
   it("drops items that have been attempted 10 or more times", () => {
+    consoleWarnSpy.mockClear();
     // Manually write an over-limit item to localStorage
     const overLimit = [{
       id: "stale-1",
@@ -83,6 +90,9 @@ describe("MAX_ATTEMPTS protection", () => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(overLimit));
     // pendingCount calls loadQueue which filters out the over-limit item
     expect(pendingCount()).toBe(0);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("submission-queue: dropping log stale-1"),
+    );
   });
 
   it("retains items below the attempt limit", () => {
@@ -94,10 +104,21 @@ describe("MAX_ATTEMPTS protection", () => {
     }];
     localStorage.setItem(STORAGE_KEY, JSON.stringify(underLimit));
     expect(pendingCount()).toBe(1);
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
   });
 });
 
 describe("TTL_DAYS protection", () => {
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
   it("drops items older than 7 days", () => {
     const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000;
     const old = [{
@@ -108,6 +129,9 @@ describe("TTL_DAYS protection", () => {
     }];
     localStorage.setItem(STORAGE_KEY, JSON.stringify(old));
     expect(pendingCount()).toBe(0);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("submission-queue: dropping log old-1"),
+    );
   });
 
   it("retains items within the TTL window", () => {
@@ -120,5 +144,6 @@ describe("TTL_DAYS protection", () => {
     }];
     localStorage.setItem(STORAGE_KEY, JSON.stringify(recent));
     expect(pendingCount()).toBe(1);
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/test/pages/NotFound.test.tsx
+++ b/src/test/pages/NotFound.test.tsx
@@ -1,4 +1,5 @@
 import { screen } from "@testing-library/react";
+import { beforeEach, afterEach } from "vitest";
 import NotFound from "@/pages/NotFound";
 import { renderWithProviders } from "../test-utils";
 
@@ -25,6 +26,19 @@ vi.mock("@/lib/supabase", () => ({
 }));
 
 describe("NotFound page", () => {
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
   it("renders without crashing", () => {
     renderWithProviders(<NotFound />);
     expect(document.body).toBeDefined();
@@ -59,13 +73,12 @@ describe("NotFound page", () => {
   });
 
   it("logs a 404 error to console on render", () => {
-    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    consoleErrorSpy.mockClear();
     renderWithProviders(<NotFound />);
-    expect(consoleSpy).toHaveBeenCalledWith(
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining("404 Error"),
       expect.any(String)
     );
-    consoleSpy.mockRestore();
   });
 
   it("renders centered layout with min-h-screen", () => {

--- a/src/test/pages/Signup.test.tsx
+++ b/src/test/pages/Signup.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import Signup from "@/pages/Signup";
+import { routerFutureFlags } from "@/lib/router-future-flags";
 
 // ─── Supabase mock ────────────────────────────────────────────────────────────
 const { mockSignUp } = vi.hoisted(() => ({ mockSignUp: vi.fn() }));
@@ -31,7 +32,7 @@ vi.mock("@/contexts/AuthContext", () => ({
 
 // ─── Router wrapper ────────────────────────────────────────────────────────────
 function wrapper({ children }: { children: React.ReactNode }) {
-  return <MemoryRouter>{children}</MemoryRouter>;
+  return <MemoryRouter future={routerFutureFlags}>{children}</MemoryRouter>;
 }
 
 // ─── Helper: fill all required fields ────────────────────────────────────────

--- a/src/test/pages/checklists/ChecklistsTab.test.tsx
+++ b/src/test/pages/checklists/ChecklistsTab.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactNode } from "react";
 import { ChecklistsTab } from "@/pages/checklists/ChecklistsTab";
+import { routerFutureFlags } from "@/lib/router-future-flags";
 
 vi.mock("@/lib/supabase", () => ({
   supabase: {
@@ -101,7 +102,7 @@ function wrapper({ children }: { children: ReactNode }) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
   return (
     <QueryClientProvider client={qc}>
-      <MemoryRouter>{children}</MemoryRouter>
+      <MemoryRouter future={routerFutureFlags}>{children}</MemoryRouter>
     </QueryClientProvider>
   );
 }

--- a/src/test/pages/checklists/ReportingTab.test.tsx
+++ b/src/test/pages/checklists/ReportingTab.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactNode } from "react";
 import { ReportingTab } from "@/pages/checklists/ReportingTab";
+import { routerFutureFlags } from "@/lib/router-future-flags";
 
 vi.mock("@/lib/supabase", () => ({
   supabase: {
@@ -131,7 +132,7 @@ function wrapper({ children }: { children: ReactNode }) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
   return (
     <QueryClientProvider client={qc}>
-      <MemoryRouter>{children}</MemoryRouter>
+      <MemoryRouter future={routerFutureFlags}>{children}</MemoryRouter>
     </QueryClientProvider>
   );
 }

--- a/src/test/test-utils.tsx
+++ b/src/test/test-utils.tsx
@@ -2,6 +2,7 @@ import { render } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactNode } from "react";
+import { routerFutureFlags } from "@/lib/router-future-flags";
 
 export function renderWithProviders(ui: ReactNode, { initialEntries = ["/"] } = {}) {
   const qc = new QueryClient({
@@ -12,7 +13,7 @@ export function renderWithProviders(ui: ReactNode, { initialEntries = ["/"] } = 
   });
   return render(
     <QueryClientProvider client={qc}>
-      <MemoryRouter initialEntries={initialEntries}>
+      <MemoryRouter initialEntries={initialEntries} future={routerFutureFlags}>
         {ui}
       </MemoryRouter>
     </QueryClientProvider>


### PR DESCRIPTION
## Summary
- fix the Dashboard hook dependency warning in the scorecard compliance memo
- opt the app and test routers into shared React Router future flags to remove warning spam
- normalize expected console noise in NotFound and submission-queue specs

## Verification
- ~/.bun/bin/bun run lint
- ~/.bun/bin/bun run test:ci

Fixes #99
Fixes #100
Fixes #101