### PR TITLE
Fix hosted passwordless auth flow

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -3,15 +3,15 @@ import { Link, useNavigate } from "react-router-dom";
 import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/contexts/AuthContext";
 import { cn } from "@/lib/utils";
+import { getRuntimeConfig } from "@/lib/runtime-config";
 
-type Step = "email" | "code";
+type Step = "email" | "check-email";
 
 export default function Login() {
   const navigate = useNavigate();
   const { user } = useAuth();
   const [step, setStep] = useState<Step>("email");
   const [email, setEmail] = useState("");
-  const [code, setCode] = useState("");
   const [loading, setLoading] = useState(false);
   const [resending, setResending] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -34,6 +34,7 @@ export default function Login() {
       email: emailValue,
       options: {
         shouldCreateUser: false,
+        emailRedirectTo: `${getRuntimeConfig().publicSiteUrl}/auth/callback`,
       },
     });
 
@@ -44,39 +45,13 @@ export default function Login() {
       return;
     }
 
-    setStep("code");
-    setInfo(`We sent a one-time code to ${emailValue}.`);
-  };
-
-  const verifyCode = async () => {
-    if (!emailValue || code.length < 4) return;
-
-    setLoading(true);
-    setError(null);
-
-    const { error: authError } = await supabase.auth.verifyOtp({
-      email: emailValue,
-      token: code.trim(),
-      type: "email",
-    });
-
-    setLoading(false);
-
-    if (authError) {
-      setError(authError.message);
-      return;
-    }
-
-    navigate("/admin", { replace: true });
+    setStep("check-email");
+    setInfo(`We sent a magic link to ${emailValue}.`);
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (step === "email") {
-      await sendCode();
-      return;
-    }
-    await verifyCode();
+    await sendCode();
   };
 
   const handleResend = async () => {
@@ -84,7 +59,10 @@ export default function Login() {
     setError(null);
     const { error: authError } = await supabase.auth.signInWithOtp({
       email: emailValue,
-      options: { shouldCreateUser: false },
+      options: {
+        shouldCreateUser: false,
+        emailRedirectTo: `${getRuntimeConfig().publicSiteUrl}/auth/callback`,
+      },
     });
     setResending(false);
 
@@ -93,7 +71,7 @@ export default function Login() {
       return;
     }
 
-    setInfo(`We sent a fresh code to ${emailValue}.`);
+    setInfo(`We sent a fresh magic link to ${emailValue}.`);
   };
 
   return (
@@ -104,7 +82,7 @@ export default function Login() {
             <span className="text-white font-display text-2xl font-bold">O</span>
           </div>
           <h1 className="font-display text-2xl text-foreground">Sign in</h1>
-          <p className="text-sm text-muted-foreground mt-1">Use a one-time code from your inbox.</p>
+          <p className="text-sm text-muted-foreground mt-1">Use a magic link from your inbox.</p>
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-4">
@@ -121,21 +99,6 @@ export default function Login() {
             />
           </div>
 
-          {step === "code" && (
-            <div>
-              <label className="text-xs text-muted-foreground mb-1 block">One-time code</label>
-              <input
-                type="text"
-                inputMode="numeric"
-                autoComplete="one-time-code"
-                value={code}
-              onChange={e => setCode(e.target.value.replace(/\s/g, "").slice(0, 6))}
-              placeholder="Enter the code from your email"
-              className="w-full border border-border rounded-xl px-4 py-3 text-sm bg-card focus:outline-none focus:ring-1 focus:ring-ring"
-            />
-          </div>
-          )}
-
           {info && (
             <p className="text-xs text-sage-deep bg-sage/10 border border-sage/20 rounded-xl px-3 py-2">
               {info}
@@ -148,19 +111,19 @@ export default function Login() {
 
           <button
             type="submit"
-            disabled={loading || !emailValue || (step === "code" && code.trim().length < 6)}
+            disabled={loading || !emailValue}
             className={cn(
               "w-full py-3 rounded-xl text-sm font-semibold transition-colors",
-              !loading && emailValue && (step === "email" || code.trim().length >= 6)
+              !loading && emailValue
                 ? "bg-sage text-primary-foreground hover:bg-sage-deep"
                 : "bg-muted text-muted-foreground cursor-not-allowed",
             )}
           >
-            {loading ? (step === "email" ? "Sending code…" : "Verifying…") : (step === "email" ? "Send code" : "Sign in")}
+            {loading ? "Sending magic link…" : "Send magic link"}
           </button>
         </form>
 
-        {step === "code" && (
+        {step === "check-email" && (
           <div className="flex items-center justify-between gap-3">
             <button
               type="button"
@@ -168,13 +131,12 @@ export default function Login() {
               disabled={resending || loading || !emailValue}
               className="text-xs font-medium text-sage hover:underline disabled:opacity-50"
             >
-              {resending ? "Resending…" : "Resend code"}
+              {resending ? "Resending…" : "Resend link"}
             </button>
             <button
               type="button"
               onClick={() => {
                 setStep("email");
-                setCode("");
                 setError(null);
                 setInfo(null);
               }}

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -15,7 +15,6 @@ export default function Signup() {
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
   const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -28,8 +27,7 @@ export default function Signup() {
     businessName.trim().length > 0 &&
     firstName.trim().length > 0 &&
     lastName.trim().length > 0 &&
-    email.trim().length > 0 &&
-    password.length >= 8;
+    email.trim().length > 0;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -50,18 +48,11 @@ export default function Signup() {
       })
     );
 
-    const { data, error: authError } = await supabase.auth.signUp({
-      email: email.trim(),
-      password,
+    const { data, error: authError } = await supabase.auth.signInWithOtp({
+      email: email.trim().toLowerCase(),
       options: {
-        // After email confirmation, Supabase redirects here. The callback
-        // page processes the auth tokens and sends the user to /admin.
-        // Hosted deployments can override the callback origin via
-        // VITE_PUBLIC_SITE_URL (for example, a GitHub Pages URL).
         emailRedirectTo: `${getRuntimeConfig().publicSiteUrl}/auth/callback`,
-        // Store both fields in auth user metadata so AuthContext can call
-        // setup_new_organization even if localStorage is cleared (e.g.
-        // when email is confirmed on a different device or browser).
+        shouldCreateUser: true,
         data: {
           full_name: ownerName,
           business_name: businessName.trim(),
@@ -78,12 +69,8 @@ export default function Signup() {
     }
 
     if (data.session) {
-      // Email confirmation is disabled in Supabase settings.
-      // AuthContext onAuthStateChange will fire → fetchTeamMember →
-      // sees pending onboarding data → calls setup_new_organization.
-      // The useEffect above will redirect to /dashboard once user is set.
+      // Some environments may sign the user in immediately.
     } else {
-      // Email confirmation required — show instructions.
       setStep("check-email");
     }
   };
@@ -98,9 +85,9 @@ export default function Signup() {
           <div>
             <h1 className="font-display text-2xl text-foreground">Check your email</h1>
             <p className="text-sm text-muted-foreground mt-2 leading-relaxed">
-              We sent a confirmation link to{" "}
+              We sent a magic link to{" "}
               <span className="text-foreground font-medium">{email}</span>.
-              Click it and you'll land straight in your workspace.
+              Open it on this device and you'll land straight in your workspace.
             </p>
           </div>
           <p className="text-xs text-muted-foreground">
@@ -123,7 +110,7 @@ export default function Signup() {
             <span className="text-white font-display text-2xl font-bold">O</span>
           </div>
           <h1 className="font-display text-2xl text-foreground">Create your account</h1>
-          <p className="text-sm text-muted-foreground mt-1">Set up Olia for your business</p>
+          <p className="text-sm text-muted-foreground mt-1">Set up Olia for your business with a magic link</p>
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-4">
@@ -186,20 +173,6 @@ export default function Signup() {
             />
           </div>
 
-          <div>
-            <label className="text-xs text-muted-foreground mb-1 block">Password</label>
-            <input
-              id="signup-password"
-              type="password"
-              value={password}
-              onChange={e => setPassword(e.target.value)}
-              placeholder="At least 8 characters"
-              minLength={8}
-              required
-              className="w-full border border-border rounded-xl px-4 py-3 text-sm bg-card focus:outline-none focus:ring-1 focus:ring-ring"
-            />
-          </div>
-
           {error && (
             <p id="signup-error" className="text-xs text-status-error">{error}</p>
           )}
@@ -215,7 +188,7 @@ export default function Signup() {
                 : "bg-muted text-muted-foreground cursor-not-allowed"
             )}
           >
-            {loading ? "Creating account…" : "Create account"}
+            {loading ? "Sending magic link…" : "Create account"}
           </button>
         </form>
 

--- a/src/test/pages/Login.test.tsx
+++ b/src/test/pages/Login.test.tsx
@@ -2,16 +2,14 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import Login from "@/pages/Login";
 
-const { mockSignInWithOtp, mockVerifyOtp } = vi.hoisted(() => ({
+const { mockSignInWithOtp } = vi.hoisted(() => ({
   mockSignInWithOtp: vi.fn(),
-  mockVerifyOtp: vi.fn(),
 }));
 
 vi.mock("@/lib/supabase", () => ({
   supabase: {
     auth: {
       signInWithOtp: mockSignInWithOtp,
-      verifyOtp: mockVerifyOtp,
       getSession: vi.fn().mockResolvedValue({ data: { session: null } }),
       onAuthStateChange: vi.fn().mockReturnValue({
         data: { subscription: { unsubscribe: vi.fn() } },
@@ -54,7 +52,6 @@ describe("Login page", () => {
     vi.clearAllMocks();
     mockUseAuth.mockReturnValue({ user: null, loading: false });
     mockSignInWithOtp.mockResolvedValue({ data: {}, error: null });
-    mockVerifyOtp.mockResolvedValue({ data: { session: { user: { id: "u1" } } }, error: null });
   });
 
   it("renders an email-only sign-in form", () => {
@@ -64,47 +61,25 @@ describe("Login page", () => {
     expect(screen.queryByPlaceholderText(/Enter the code from your email/i)).not.toBeInTheDocument();
   });
 
-  it("sends a one-time code to the email address", async () => {
+  it("sends a magic link to the email address", async () => {
     renderPage();
     fireEvent.change(screen.getByPlaceholderText("you@yourbusiness.com"), {
       target: { value: "owner@olia.app" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Send code" }));
+    fireEvent.click(screen.getByRole("button", { name: "Send magic link" }));
 
     await waitFor(() => {
       expect(mockSignInWithOtp).toHaveBeenCalledWith(expect.objectContaining({
         email: "owner@olia.app",
-        options: expect.objectContaining({ shouldCreateUser: false }),
+        options: expect.objectContaining({
+          shouldCreateUser: false,
+          emailRedirectTo: expect.stringContaining("/auth/callback"),
+        }),
       }));
     });
 
-    expect(screen.getByPlaceholderText(/Enter the code from your email/i)).toBeInTheDocument();
-    expect(screen.getByText(/one-time code to owner@olia.app/i)).toBeInTheDocument();
-  });
-
-  it("verifies the code and goes to admin", async () => {
-    renderPage();
-    fireEvent.change(screen.getByPlaceholderText("you@yourbusiness.com"), {
-      target: { value: "owner@olia.app" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: "Send code" }));
-
-    await waitFor(() => expect(screen.getByPlaceholderText(/Enter the code from your email/i)).toBeInTheDocument());
-
-    fireEvent.change(screen.getByPlaceholderText(/Enter the code from your email/i), {
-      target: { value: "123456" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: "Sign in" }));
-
-    await waitFor(() => {
-      expect(mockVerifyOtp).toHaveBeenCalledWith(expect.objectContaining({
-        email: "owner@olia.app",
-        token: "123456",
-        type: "email",
-      }));
-    });
-
-    expect(mockNavigate).toHaveBeenCalledWith("/admin", { replace: true });
+    expect(screen.getByText(/magic link to owner@olia.app/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /resend link/i })).toBeInTheDocument();
   });
 
   it("shows a create-account link", () => {

--- a/src/test/pages/Signup.test.tsx
+++ b/src/test/pages/Signup.test.tsx
@@ -4,12 +4,12 @@ import Signup from "@/pages/Signup";
 import { routerFutureFlags } from "@/lib/router-future-flags";
 
 // ─── Supabase mock ────────────────────────────────────────────────────────────
-const { mockSignUp } = vi.hoisted(() => ({ mockSignUp: vi.fn() }));
+const { mockSignInWithOtp } = vi.hoisted(() => ({ mockSignInWithOtp: vi.fn() }));
 
 vi.mock("@/lib/supabase", () => ({
   supabase: {
     auth: {
-      signUp: mockSignUp,
+      signInWithOtp: mockSignInWithOtp,
       getSession: vi.fn().mockResolvedValue({ data: { session: null } }),
       onAuthStateChange: vi.fn().mockReturnValue({
         data: { subscription: { unsubscribe: vi.fn() } },
@@ -41,7 +41,6 @@ function fillValidForm() {
   fireEvent.change(screen.getByPlaceholderText(/^Sarah$/i), { target: { value: "Sarah" } });
   fireEvent.change(screen.getByPlaceholderText(/^Johnson$/i), { target: { value: "Johnson" } });
   fireEvent.change(screen.getByPlaceholderText(/yourbusiness\.com/i), { target: { value: "sarah@acme.com" } });
-  fireEvent.change(screen.getByPlaceholderText(/At least 8 characters/i), { target: { value: "securepass1" } });
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
@@ -50,7 +49,7 @@ describe("Signup page", () => {
     vi.clearAllMocks();
     localStorage.clear();
     delete import.meta.env.VITE_PUBLIC_SITE_URL;
-    mockSignUp.mockResolvedValue({
+    mockSignInWithOtp.mockResolvedValue({
       data: {
         user: { id: "new-user-1" },
         session: { access_token: "tok", refresh_token: "ref" },
@@ -91,9 +90,9 @@ describe("Signup page", () => {
     expect(screen.getByPlaceholderText(/yourbusiness\.com/i)).toBeInTheDocument();
   });
 
-  it("shows password input", () => {
+  it("does not show a password input", () => {
     render(<Signup />, { wrapper });
-    expect(screen.getByPlaceholderText(/At least 8 characters/i)).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/At least 8 characters/i)).toBeNull();
   });
 
   it("does NOT show a location name field", () => {
@@ -107,9 +106,9 @@ describe("Signup page", () => {
     expect(screen.getByText("Create account")).toBeInTheDocument();
   });
 
-  it("shows 'Set up Olia for your business' subtitle", () => {
+  it("shows the magic-link signup subtitle", () => {
     render(<Signup />, { wrapper });
-    expect(screen.getByText("Set up Olia for your business")).toBeInTheDocument();
+    expect(screen.getByText("Set up Olia for your business with a magic link")).toBeInTheDocument();
   });
 
   // ── Validation ──────────────────────────────────────────────────────────────
@@ -125,7 +124,6 @@ describe("Signup page", () => {
     // skip first name
     fireEvent.change(screen.getByPlaceholderText(/^Johnson$/i), { target: { value: "Smith" } });
     fireEvent.change(screen.getByPlaceholderText(/yourbusiness\.com/i), { target: { value: "a@b.com" } });
-    fireEvent.change(screen.getByPlaceholderText(/At least 8 characters/i), { target: { value: "password1" } });
     expect(screen.getByText("Create account").closest("button")).toBeDisabled();
   });
 
@@ -135,17 +133,14 @@ describe("Signup page", () => {
     fireEvent.change(screen.getByPlaceholderText(/^Sarah$/i), { target: { value: "Sarah" } });
     // skip last name
     fireEvent.change(screen.getByPlaceholderText(/yourbusiness\.com/i), { target: { value: "a@b.com" } });
-    fireEvent.change(screen.getByPlaceholderText(/At least 8 characters/i), { target: { value: "password1" } });
     expect(screen.getByText("Create account").closest("button")).toBeDisabled();
   });
 
-  it("Create account button is disabled when password is too short", () => {
+  it("Create account button is disabled when email is missing", () => {
     render(<Signup />, { wrapper });
     fireEvent.change(screen.getByPlaceholderText(/Crown Restaurant/i), { target: { value: "Acme" } });
     fireEvent.change(screen.getByPlaceholderText(/^Sarah$/i), { target: { value: "Sarah" } });
     fireEvent.change(screen.getByPlaceholderText(/^Johnson$/i), { target: { value: "Smith" } });
-    fireEvent.change(screen.getByPlaceholderText(/yourbusiness\.com/i), { target: { value: "a@b.com" } });
-    fireEvent.change(screen.getByPlaceholderText(/At least 8 characters/i), { target: { value: "short" } });
     expect(screen.getByText("Create account").closest("button")).toBeDisabled();
   });
 
@@ -157,22 +152,23 @@ describe("Signup page", () => {
 
   // ── Submission ──────────────────────────────────────────────────────────────
 
-  it("calls supabase.auth.signUp with correct email and password", async () => {
+  it("calls supabase.auth.signInWithOtp with the signup email", async () => {
     render(<Signup />, { wrapper });
     fillValidForm();
     fireEvent.click(screen.getByText("Create account"));
-    await waitFor(() => expect(mockSignUp).toHaveBeenCalledWith(
-      expect.objectContaining({ email: "sarah@acme.com", password: "securepass1" })
+    await waitFor(() => expect(mockSignInWithOtp).toHaveBeenCalledWith(
+      expect.objectContaining({ email: "sarah@acme.com" })
     ));
   });
 
-  it("passes full_name as 'First Last' in signUp metadata", async () => {
+  it("passes full_name as 'First Last' in sign-in metadata", async () => {
     render(<Signup />, { wrapper });
     fillValidForm();
     fireEvent.click(screen.getByText("Create account"));
-    await waitFor(() => expect(mockSignUp).toHaveBeenCalledWith(
+    await waitFor(() => expect(mockSignInWithOtp).toHaveBeenCalledWith(
       expect.objectContaining({
         options: expect.objectContaining({
+          shouldCreateUser: true,
           data: expect.objectContaining({
             full_name: "Sarah Johnson",
             business_name: "Acme Café",
@@ -187,7 +183,7 @@ describe("Signup page", () => {
     render(<Signup />, { wrapper });
     fillValidForm();
     fireEvent.click(screen.getByText("Create account"));
-    await waitFor(() => expect(mockSignUp).toHaveBeenCalledWith(
+    await waitFor(() => expect(mockSignInWithOtp).toHaveBeenCalledWith(
       expect.objectContaining({
         options: expect.objectContaining({
           emailRedirectTo: "https://dora.github.io/olia/auth/callback",
@@ -200,7 +196,7 @@ describe("Signup page", () => {
     render(<Signup />, { wrapper });
     fillValidForm();
     fireEvent.click(screen.getByText("Create account"));
-    await waitFor(() => expect(mockSignUp).toHaveBeenCalled());
+    await waitFor(() => expect(mockSignInWithOtp).toHaveBeenCalled());
     // If payload was already cleared by AuthContext that's fine — signUp was called
     const raw = localStorage.getItem("olia_pending_onboarding");
     if (raw !== null) {
@@ -214,7 +210,7 @@ describe("Signup page", () => {
   // ── Check-email screen ──────────────────────────────────────────────────────
 
   it("shows check-email screen when signUp returns no session", async () => {
-    mockSignUp.mockResolvedValue({ data: { user: { id: "u1" }, session: null }, error: null });
+    mockSignInWithOtp.mockResolvedValue({ data: { user: { id: "u1" }, session: null }, error: null });
     render(<Signup />, { wrapper });
     fillValidForm();
     fireEvent.click(screen.getByText("Create account"));
@@ -222,25 +218,25 @@ describe("Signup page", () => {
   });
 
   it("shows the user's email on the check-email screen", async () => {
-    mockSignUp.mockResolvedValue({ data: { user: { id: "u1" }, session: null }, error: null });
+    mockSignInWithOtp.mockResolvedValue({ data: { user: { id: "u1" }, session: null }, error: null });
     render(<Signup />, { wrapper });
     fillValidForm();
     fireEvent.click(screen.getByText("Create account"));
     await waitFor(() => expect(screen.getByText("sarah@acme.com")).toBeInTheDocument());
   });
 
-  it("check-email screen says 'workspace' not 'dashboard'", async () => {
-    mockSignUp.mockResolvedValue({ data: { user: { id: "u1" }, session: null }, error: null });
+  it("check-email screen explains that a magic link was sent", async () => {
+    mockSignInWithOtp.mockResolvedValue({ data: { user: { id: "u1" }, session: null }, error: null });
     render(<Signup />, { wrapper });
     fillValidForm();
     fireEvent.click(screen.getByText("Create account"));
-    await waitFor(() => expect(screen.getByText(/workspace/i)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/magic link/i)).toBeInTheDocument());
   });
 
   // ── Error handling ──────────────────────────────────────────────────────────
 
-  it("shows auth error message on signUp failure", async () => {
-    mockSignUp.mockResolvedValue({
+  it("shows auth error message on signup magic-link failure", async () => {
+    mockSignInWithOtp.mockResolvedValue({
       data: { user: null, session: null },
       error: { message: "Email already registered" },
     });
@@ -251,7 +247,7 @@ describe("Signup page", () => {
   });
 
   it("clears onboarding data from localStorage on auth failure", async () => {
-    mockSignUp.mockResolvedValue({
+    mockSignInWithOtp.mockResolvedValue({
       data: { user: null, session: null },
       error: { message: "Something went wrong" },
     });


### PR DESCRIPTION
## Summary\n- remove the password field from signup and use the same passwordless magic-link auth path as login\n- align login copy with the actual Supabase magic-link email flow\n- set emailRedirectTo for both auth flows so hosted emails return to /auth/callback instead of localhost\n\n## Testing\n- bun run test src/test/pages/Signup.test.tsx src/test/pages/Login.test.tsx\n- bun run build\n\nCloses #81