### PR TITLE
Fix GitHub Pages auth callback redirects

### DIFF
--- a/src/lib/github-pages-routing.ts
+++ b/src/lib/github-pages-routing.ts
@@ -7,6 +7,10 @@ function normalizeFallbackRoute(fallbackRoute: string): string {
   return fallbackRoute.startsWith("/") ? fallbackRoute : `/${fallbackRoute}`;
 }
 
+function isGitHubPagesUrl(publicSiteUrl: string) {
+  return new URL(publicSiteUrl).hostname.endsWith("github.io");
+}
+
 export function buildGitHubPagesRoute(search: string, basePath: string): string | null {
   const searchParams = new URLSearchParams(search);
   const fallbackRoute = searchParams.get("p");
@@ -17,6 +21,22 @@ export function buildGitHubPagesRoute(search: string, basePath: string): string 
   return `${normalizedBasePath}${normalizedRoute}`;
 }
 
-export function restoreGitHubPagesRoute(search: string, basePath: string) {
-  return buildGitHubPagesRoute(search, basePath);
+export function restoreGitHubPagesRoute(search: string, basePath: string, hash = "") {
+  const restoredRoute = buildGitHubPagesRoute(search, basePath);
+  if (!restoredRoute) return null;
+
+  return hash ? `${restoredRoute}${hash}` : restoredRoute;
+}
+
+export function buildPublicAuthRedirectUrl(publicSiteUrl: string, route: string) {
+  const normalizedRoute = normalizeFallbackRoute(route);
+
+  if (isGitHubPagesUrl(publicSiteUrl)) {
+    const url = new URL(publicSiteUrl);
+    url.searchParams.set("p", normalizedRoute);
+    url.hash = "";
+    return url.toString();
+  }
+
+  return new URL(normalizedRoute, publicSiteUrl.endsWith("/") ? publicSiteUrl : `${publicSiteUrl}/`).toString();
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,7 +11,11 @@ import { Capacitor } from "@capacitor/core";
 import { restoreGitHubPagesRoute as restoreGitHubPagesRoutePath } from "@/lib/github-pages-routing";
 
 function restoreGitHubPagesRoute() {
-  const targetRoute = restoreGitHubPagesRoutePath(window.location.search, import.meta.env.BASE_URL);
+  const targetRoute = restoreGitHubPagesRoutePath(
+    window.location.search,
+    import.meta.env.BASE_URL,
+    window.location.hash,
+  );
   if (targetRoute) {
     window.history.replaceState(null, "", targetRoute);
   }

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -4,6 +4,7 @@ import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/contexts/AuthContext";
 import { cn } from "@/lib/utils";
 import { getRuntimeConfig } from "@/lib/runtime-config";
+import { buildPublicAuthRedirectUrl } from "@/lib/github-pages-routing";
 
 type Step = "email" | "check-email";
 
@@ -22,6 +23,7 @@ export default function Login() {
   }, [user, navigate]);
 
   const emailValue = email.trim().toLowerCase();
+  const authRedirectUrl = buildPublicAuthRedirectUrl(getRuntimeConfig().publicSiteUrl, "/auth/callback");
 
   const sendCode = async () => {
     if (!emailValue) return;
@@ -34,7 +36,7 @@ export default function Login() {
       email: emailValue,
       options: {
         shouldCreateUser: false,
-        emailRedirectTo: `${getRuntimeConfig().publicSiteUrl}/auth/callback`,
+        emailRedirectTo: authRedirectUrl,
       },
     });
 
@@ -61,7 +63,7 @@ export default function Login() {
       email: emailValue,
       options: {
         shouldCreateUser: false,
-        emailRedirectTo: `${getRuntimeConfig().publicSiteUrl}/auth/callback`,
+        emailRedirectTo: authRedirectUrl,
       },
     });
     setResending(false);

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -4,6 +4,7 @@ import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/contexts/AuthContext";
 import { cn } from "@/lib/utils";
 import { getRuntimeConfig } from "@/lib/runtime-config";
+import { buildPublicAuthRedirectUrl } from "@/lib/github-pages-routing";
 
 type Step = "form" | "check-email";
 
@@ -28,6 +29,7 @@ export default function Signup() {
     firstName.trim().length > 0 &&
     lastName.trim().length > 0 &&
     email.trim().length > 0;
+  const authRedirectUrl = buildPublicAuthRedirectUrl(getRuntimeConfig().publicSiteUrl, "/auth/callback");
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -51,7 +53,7 @@ export default function Signup() {
     const { data, error: authError } = await supabase.auth.signInWithOtp({
       email: email.trim().toLowerCase(),
       options: {
-        emailRedirectTo: `${getRuntimeConfig().publicSiteUrl}/auth/callback`,
+        emailRedirectTo: authRedirectUrl,
         shouldCreateUser: true,
         data: {
           full_name: ownerName,

--- a/src/test/lib/github-pages-routing.test.ts
+++ b/src/test/lib/github-pages-routing.test.ts
@@ -1,4 +1,4 @@
-import { buildGitHubPagesRoute } from "@/lib/github-pages-routing";
+import { buildGitHubPagesRoute, buildPublicAuthRedirectUrl, restoreGitHubPagesRoute } from "@/lib/github-pages-routing";
 
 describe("github-pages-routing", () => {
   it("returns null when the fallback query param is missing", () => {
@@ -19,5 +19,23 @@ describe("github-pages-routing", () => {
 
   it("does not add a duplicate slash for root base paths", () => {
     expect(buildGitHubPagesRoute("?p=admin", "/")).toBe("/admin");
+  });
+
+  it("preserves the current hash when restoring a GitHub Pages fallback route", () => {
+    expect(restoreGitHubPagesRoute("?p=%2Fauth%2Fcallback", "/olia-your-daily-operations/", "#access_token=abc")).toBe(
+      "/olia-your-daily-operations/auth/callback#access_token=abc",
+    );
+  });
+
+  it("builds a GitHub Pages-safe auth redirect URL", () => {
+    expect(buildPublicAuthRedirectUrl("https://dorabuilds.github.io/olia-your-daily-operations", "/auth/callback")).toBe(
+      "https://dorabuilds.github.io/olia-your-daily-operations?p=%2Fauth%2Fcallback",
+    );
+  });
+
+  it("builds a direct auth redirect URL for non-GitHub Pages hosts", () => {
+    expect(buildPublicAuthRedirectUrl("https://app.olia.com", "/auth/callback")).toBe(
+      "https://app.olia.com/auth/callback",
+    );
   });
 });

--- a/src/test/pages/Login.test.tsx
+++ b/src/test/pages/Login.test.tsx
@@ -62,6 +62,7 @@ describe("Login page", () => {
   });
 
   it("sends a magic link to the email address", async () => {
+    import.meta.env.VITE_PUBLIC_SITE_URL = "https://dora.github.io/olia";
     renderPage();
     fireEvent.change(screen.getByPlaceholderText("you@yourbusiness.com"), {
       target: { value: "owner@olia.app" },
@@ -73,7 +74,7 @@ describe("Login page", () => {
         email: "owner@olia.app",
         options: expect.objectContaining({
           shouldCreateUser: false,
-          emailRedirectTo: expect.stringContaining("/auth/callback"),
+          emailRedirectTo: "https://dora.github.io/olia?p=%2Fauth%2Fcallback",
         }),
       }));
     });

--- a/src/test/pages/Signup.test.tsx
+++ b/src/test/pages/Signup.test.tsx
@@ -186,7 +186,7 @@ describe("Signup page", () => {
     await waitFor(() => expect(mockSignInWithOtp).toHaveBeenCalledWith(
       expect.objectContaining({
         options: expect.objectContaining({
-          emailRedirectTo: "https://dora.github.io/olia/auth/callback",
+          emailRedirectTo: "https://dora.github.io/olia?p=%2Fauth%2Fcallback",
         }),
       })
     ));


### PR DESCRIPTION
## Summary\n- send hosted Supabase auth redirects through the GitHub Pages fallback route\n- preserve Supabase auth hash fragments when restoring GitHub Pages routes\n- add regression coverage for hosted auth redirect URLs\n\n## Testing\n- bun run test src/test/lib/github-pages-routing.test.ts src/test/pages/Signup.test.tsx src/test/pages/Login.test.tsx\n- bun run build\n\nRefs #81