### PR TITLE
Restore email code auth flow

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -6,13 +6,14 @@ import { cn } from "@/lib/utils";
 import { getRuntimeConfig } from "@/lib/runtime-config";
 import { buildPublicAuthRedirectUrl } from "@/lib/github-pages-routing";
 
-type Step = "email" | "check-email";
+type Step = "email" | "code";
 
 export default function Login() {
   const navigate = useNavigate();
   const { user } = useAuth();
   const [step, setStep] = useState<Step>("email");
   const [email, setEmail] = useState("");
+  const [code, setCode] = useState("");
   const [loading, setLoading] = useState(false);
   const [resending, setResending] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -47,13 +48,40 @@ export default function Login() {
       return;
     }
 
-    setStep("check-email");
-    setInfo(`We sent a magic link to ${emailValue}.`);
+    setStep("code");
+    setInfo(`We sent an 8-digit code to ${emailValue}.`);
+  };
+
+  const verifyCode = async () => {
+    if (!emailValue || code.trim().length < 6) return;
+
+    setLoading(true);
+    setError(null);
+
+    const { error: authError } = await supabase.auth.verifyOtp({
+      email: emailValue,
+      token: code.trim(),
+      type: "email",
+    });
+
+    setLoading(false);
+
+    if (authError) {
+      setError(authError.message);
+      return;
+    }
+
+    navigate("/admin", { replace: true });
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    await sendCode();
+    if (step === "email") {
+      await sendCode();
+      return;
+    }
+
+    await verifyCode();
   };
 
   const handleResend = async () => {
@@ -73,7 +101,7 @@ export default function Login() {
       return;
     }
 
-    setInfo(`We sent a fresh magic link to ${emailValue}.`);
+    setInfo(`We sent a fresh 8-digit code to ${emailValue}.`);
   };
 
   return (
@@ -84,7 +112,7 @@ export default function Login() {
             <span className="text-white font-display text-2xl font-bold">O</span>
           </div>
           <h1 className="font-display text-2xl text-foreground">Sign in</h1>
-          <p className="text-sm text-muted-foreground mt-1">Use a magic link from your inbox.</p>
+          <p className="text-sm text-muted-foreground mt-1">Use the one-time code from your inbox.</p>
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-4">
@@ -101,6 +129,22 @@ export default function Login() {
             />
           </div>
 
+          {step === "code" && (
+            <div>
+              <label className="text-xs text-muted-foreground mb-1 block">One-time code</label>
+              <input
+                autoFocus
+                type="text"
+                inputMode="numeric"
+                autoComplete="one-time-code"
+                value={code}
+                onChange={e => setCode(e.target.value.replace(/\D/g, "").slice(0, 8))}
+                placeholder="Enter the code from your email"
+                className="w-full border border-border rounded-xl px-4 py-3 text-sm bg-card focus:outline-none focus:ring-1 focus:ring-ring"
+              />
+            </div>
+          )}
+
           {info && (
             <p className="text-xs text-sage-deep bg-sage/10 border border-sage/20 rounded-xl px-3 py-2">
               {info}
@@ -113,19 +157,19 @@ export default function Login() {
 
           <button
             type="submit"
-            disabled={loading || !emailValue}
+            disabled={loading || !emailValue || (step === "code" && code.trim().length < 6)}
             className={cn(
               "w-full py-3 rounded-xl text-sm font-semibold transition-colors",
-              !loading && emailValue
+              !loading && emailValue && (step === "email" || code.trim().length >= 6)
                 ? "bg-sage text-primary-foreground hover:bg-sage-deep"
                 : "bg-muted text-muted-foreground cursor-not-allowed",
             )}
           >
-            {loading ? "Sending magic link…" : "Send magic link"}
+            {loading ? (step === "email" ? "Sending code…" : "Verifying…") : (step === "email" ? "Send code" : "Verify code")}
           </button>
         </form>
 
-        {step === "check-email" && (
+        {step === "code" && (
           <div className="flex items-center justify-between gap-3">
             <button
               type="button"
@@ -133,12 +177,13 @@ export default function Login() {
               disabled={resending || loading || !emailValue}
               className="text-xs font-medium text-sage hover:underline disabled:opacity-50"
             >
-              {resending ? "Resending…" : "Resend link"}
+              {resending ? "Resending…" : "Resend code"}
             </button>
             <button
               type="button"
               onClick={() => {
                 setStep("email");
+                setCode("");
                 setError(null);
                 setInfo(null);
               }}

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
 import { getRuntimeConfig } from "@/lib/runtime-config";
 import { buildPublicAuthRedirectUrl } from "@/lib/github-pages-routing";
 
-type Step = "form" | "check-email";
+type Step = "form" | "code";
 
 export default function Signup() {
   const navigate = useNavigate();
@@ -16,7 +16,9 @@ export default function Signup() {
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
   const [email, setEmail] = useState("");
+  const [code, setCode] = useState("");
   const [loading, setLoading] = useState(false);
+  const [resending, setResending] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   // Already authenticated → go to admin (new users add their first location there)
@@ -73,26 +75,133 @@ export default function Signup() {
     if (data.session) {
       // Some environments may sign the user in immediately.
     } else {
-      setStep("check-email");
+      setStep("code");
     }
   };
 
-  if (step === "check-email") {
+  const handleVerifyCode = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (code.trim().length < 6) return;
+
+    setLoading(true);
+    setError(null);
+
+    const { error: authError } = await supabase.auth.verifyOtp({
+      email: email.trim().toLowerCase(),
+      token: code.trim(),
+      type: "signup",
+    });
+
+    setLoading(false);
+
+    if (authError) {
+      setError(authError.message);
+      return;
+    }
+
+    navigate("/admin", { replace: true });
+  };
+
+  const handleResendCode = async () => {
+    if (!isFormValid) return;
+
+    setResending(true);
+    setError(null);
+
+    const ownerName = `${firstName.trim()} ${lastName.trim()}`;
+    const { error: authError } = await supabase.auth.signInWithOtp({
+      email: email.trim().toLowerCase(),
+      options: {
+        emailRedirectTo: authRedirectUrl,
+        shouldCreateUser: true,
+        data: {
+          full_name: ownerName,
+          business_name: businessName.trim(),
+        },
+      },
+    });
+
+    setResending(false);
+
+    if (authError) {
+      setError(authError.message);
+    }
+  };
+
+  if (step === "code") {
     return (
       <div className="min-h-screen bg-background flex flex-col items-center justify-center px-6">
-        <div className="w-full max-w-sm space-y-6 text-center">
-          <div className="w-16 h-16 rounded-2xl bg-sage/10 flex items-center justify-center mx-auto text-3xl">
-            ✉
+        <div className="w-full max-w-sm space-y-6">
+          <div className="text-center space-y-3">
+            <div className="w-16 h-16 rounded-2xl bg-sage/10 flex items-center justify-center mx-auto text-3xl">
+              #
+            </div>
+            <div>
+              <h1 className="font-display text-2xl text-foreground">Enter your code</h1>
+              <p className="text-sm text-muted-foreground mt-2 leading-relaxed">
+                We sent an 8-digit code to{" "}
+                <span className="text-foreground font-medium">{email}</span>.
+                Enter it here to finish creating your account.
+              </p>
+            </div>
           </div>
-          <div>
-            <h1 className="font-display text-2xl text-foreground">Check your email</h1>
-            <p className="text-sm text-muted-foreground mt-2 leading-relaxed">
-              We sent a magic link to{" "}
-              <span className="text-foreground font-medium">{email}</span>.
-              Open it on this device and you'll land straight in your workspace.
-            </p>
+
+          <form onSubmit={handleVerifyCode} className="space-y-4">
+            <div>
+              <label className="text-xs text-muted-foreground mb-1 block">One-time code</label>
+              <input
+                autoFocus
+                type="text"
+                inputMode="numeric"
+                autoComplete="one-time-code"
+                value={code}
+                onChange={e => setCode(e.target.value.replace(/\D/g, "").slice(0, 8))}
+                placeholder="Enter the code from your email"
+                className="w-full border border-border rounded-xl px-4 py-3 text-sm bg-card focus:outline-none focus:ring-1 focus:ring-ring"
+              />
+            </div>
+
+            {error && (
+              <p id="signup-error" className="text-xs text-status-error">{error}</p>
+            )}
+
+            <button
+              type="submit"
+              disabled={loading || code.trim().length < 6}
+              className={cn(
+                "w-full py-3 rounded-xl text-sm font-semibold transition-colors",
+                !loading && code.trim().length >= 6
+                  ? "bg-sage text-primary-foreground hover:bg-sage-deep"
+                  : "bg-muted text-muted-foreground cursor-not-allowed",
+              )}
+            >
+              {loading ? "Verifying…" : "Verify code"}
+            </button>
+          </form>
+
+          <div className="flex items-center justify-between gap-3">
+            <button
+              type="button"
+              onClick={handleResendCode}
+              disabled={resending || loading}
+              className="text-xs font-medium text-sage hover:underline disabled:opacity-50"
+            >
+              {resending ? "Resending…" : "Resend code"}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setStep("form");
+                setCode("");
+                setError(null);
+              }}
+              className="text-xs font-medium text-muted-foreground hover:text-foreground"
+            >
+              Change email
+            </button>
           </div>
-          <p className="text-xs text-muted-foreground">
+
+          <p className="text-center text-xs text-muted-foreground">
             Already confirmed?{" "}
             <Link to="/login" className="text-sage font-medium hover:underline">
               Sign in
@@ -112,7 +221,7 @@ export default function Signup() {
             <span className="text-white font-display text-2xl font-bold">O</span>
           </div>
           <h1 className="font-display text-2xl text-foreground">Create your account</h1>
-          <p className="text-sm text-muted-foreground mt-1">Set up Olia for your business with a magic link</p>
+          <p className="text-sm text-muted-foreground mt-1">Set up Olia for your business with a one-time code</p>
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-4">
@@ -190,7 +299,7 @@ export default function Signup() {
                 : "bg-muted text-muted-foreground cursor-not-allowed"
             )}
           >
-            {loading ? "Sending magic link…" : "Create account"}
+            {loading ? "Sending code…" : "Create account"}
           </button>
         </form>
 

--- a/src/test/pages/Login.test.tsx
+++ b/src/test/pages/Login.test.tsx
@@ -2,14 +2,16 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import Login from "@/pages/Login";
 
-const { mockSignInWithOtp } = vi.hoisted(() => ({
+const { mockSignInWithOtp, mockVerifyOtp } = vi.hoisted(() => ({
   mockSignInWithOtp: vi.fn(),
+  mockVerifyOtp: vi.fn(),
 }));
 
 vi.mock("@/lib/supabase", () => ({
   supabase: {
     auth: {
       signInWithOtp: mockSignInWithOtp,
+      verifyOtp: mockVerifyOtp,
       getSession: vi.fn().mockResolvedValue({ data: { session: null } }),
       onAuthStateChange: vi.fn().mockReturnValue({
         data: { subscription: { unsubscribe: vi.fn() } },
@@ -52,22 +54,23 @@ describe("Login page", () => {
     vi.clearAllMocks();
     mockUseAuth.mockReturnValue({ user: null, loading: false });
     mockSignInWithOtp.mockResolvedValue({ data: {}, error: null });
+    mockVerifyOtp.mockResolvedValue({ data: { session: { user: { id: "u1" } } }, error: null });
   });
 
-  it("renders an email-only sign-in form", () => {
+  it("renders an email-first sign-in form", () => {
     renderPage();
     expect(screen.getByText("Sign in")).toBeInTheDocument();
     expect(screen.getByPlaceholderText("you@yourbusiness.com")).toBeInTheDocument();
     expect(screen.queryByPlaceholderText(/Enter the code from your email/i)).not.toBeInTheDocument();
   });
 
-  it("sends a magic link to the email address", async () => {
+  it("sends a code to the email address", async () => {
     import.meta.env.VITE_PUBLIC_SITE_URL = "https://dora.github.io/olia";
     renderPage();
     fireEvent.change(screen.getByPlaceholderText("you@yourbusiness.com"), {
       target: { value: "owner@olia.app" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Send magic link" }));
+    fireEvent.click(screen.getByRole("button", { name: "Send code" }));
 
     await waitFor(() => {
       expect(mockSignInWithOtp).toHaveBeenCalledWith(expect.objectContaining({
@@ -79,8 +82,34 @@ describe("Login page", () => {
       }));
     });
 
-    expect(screen.getByText(/magic link to owner@olia.app/i)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /resend link/i })).toBeInTheDocument();
+    expect(screen.getByText(/8-digit code to owner@olia.app/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /resend code/i })).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/Enter the code from your email/i)).toBeInTheDocument();
+  });
+
+  it("verifies the emailed code and navigates to admin", async () => {
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText("you@yourbusiness.com"), {
+      target: { value: "owner@olia.app" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send code" }));
+
+    await waitFor(() => expect(screen.getByPlaceholderText(/Enter the code from your email/i)).toBeInTheDocument());
+
+    fireEvent.change(screen.getByPlaceholderText(/Enter the code from your email/i), {
+      target: { value: "12345678" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Verify code" }));
+
+    await waitFor(() => {
+      expect(mockVerifyOtp).toHaveBeenCalledWith({
+        email: "owner@olia.app",
+        token: "12345678",
+        type: "email",
+      });
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith("/admin", { replace: true });
   });
 
   it("shows a create-account link", () => {

--- a/src/test/pages/Signup.test.tsx
+++ b/src/test/pages/Signup.test.tsx
@@ -4,12 +4,16 @@ import Signup from "@/pages/Signup";
 import { routerFutureFlags } from "@/lib/router-future-flags";
 
 // ─── Supabase mock ────────────────────────────────────────────────────────────
-const { mockSignInWithOtp } = vi.hoisted(() => ({ mockSignInWithOtp: vi.fn() }));
+const { mockSignInWithOtp, mockVerifyOtp } = vi.hoisted(() => ({
+  mockSignInWithOtp: vi.fn(),
+  mockVerifyOtp: vi.fn(),
+}));
 
 vi.mock("@/lib/supabase", () => ({
   supabase: {
     auth: {
       signInWithOtp: mockSignInWithOtp,
+      verifyOtp: mockVerifyOtp,
       getSession: vi.fn().mockResolvedValue({ data: { session: null } }),
       onAuthStateChange: vi.fn().mockReturnValue({
         data: { subscription: { unsubscribe: vi.fn() } },
@@ -50,6 +54,13 @@ describe("Signup page", () => {
     localStorage.clear();
     delete import.meta.env.VITE_PUBLIC_SITE_URL;
     mockSignInWithOtp.mockResolvedValue({
+      data: {
+        user: { id: "new-user-1" },
+        session: { access_token: "tok", refresh_token: "ref" },
+      },
+      error: null,
+    });
+    mockVerifyOtp.mockResolvedValue({
       data: {
         user: { id: "new-user-1" },
         session: { access_token: "tok", refresh_token: "ref" },
@@ -106,9 +117,9 @@ describe("Signup page", () => {
     expect(screen.getByText("Create account")).toBeInTheDocument();
   });
 
-  it("shows the magic-link signup subtitle", () => {
+  it("shows the one-time-code signup subtitle", () => {
     render(<Signup />, { wrapper });
-    expect(screen.getByText("Set up Olia for your business with a magic link")).toBeInTheDocument();
+    expect(screen.getByText("Set up Olia for your business with a one-time code")).toBeInTheDocument();
   });
 
   // ── Validation ──────────────────────────────────────────────────────────────
@@ -207,17 +218,17 @@ describe("Signup page", () => {
     }
   });
 
-  // ── Check-email screen ──────────────────────────────────────────────────────
+  // ── Code screen ─────────────────────────────────────────────────────────────
 
-  it("shows check-email screen when signUp returns no session", async () => {
+  it("shows code-entry screen when signUp returns no session", async () => {
     mockSignInWithOtp.mockResolvedValue({ data: { user: { id: "u1" }, session: null }, error: null });
     render(<Signup />, { wrapper });
     fillValidForm();
     fireEvent.click(screen.getByText("Create account"));
-    await waitFor(() => expect(screen.getByText("Check your email")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText("Enter your code")).toBeInTheDocument());
   });
 
-  it("shows the user's email on the check-email screen", async () => {
+  it("shows the user's email on the code-entry screen", async () => {
     mockSignInWithOtp.mockResolvedValue({ data: { user: { id: "u1" }, session: null }, error: null });
     render(<Signup />, { wrapper });
     fillValidForm();
@@ -225,17 +236,37 @@ describe("Signup page", () => {
     await waitFor(() => expect(screen.getByText("sarah@acme.com")).toBeInTheDocument());
   });
 
-  it("check-email screen explains that a magic link was sent", async () => {
+  it("code-entry screen explains that a one-time code was sent", async () => {
     mockSignInWithOtp.mockResolvedValue({ data: { user: { id: "u1" }, session: null }, error: null });
     render(<Signup />, { wrapper });
     fillValidForm();
     fireEvent.click(screen.getByText("Create account"));
-    await waitFor(() => expect(screen.getByText(/magic link/i)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/8-digit code/i)).toBeInTheDocument());
+  });
+
+  it("verifies the emailed code with signup verification", async () => {
+    mockSignInWithOtp.mockResolvedValue({ data: { user: { id: "u1" }, session: null }, error: null });
+    render(<Signup />, { wrapper });
+    fillValidForm();
+    fireEvent.click(screen.getByText("Create account"));
+
+    await waitFor(() => expect(screen.getByPlaceholderText(/Enter the code from your email/i)).toBeInTheDocument());
+
+    fireEvent.change(screen.getByPlaceholderText(/Enter the code from your email/i), {
+      target: { value: "12345678" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Verify code" }));
+
+    await waitFor(() => expect(mockVerifyOtp).toHaveBeenCalledWith({
+      email: "sarah@acme.com",
+      token: "12345678",
+      type: "signup",
+    }));
   });
 
   // ── Error handling ──────────────────────────────────────────────────────────
 
-  it("shows auth error message on signup magic-link failure", async () => {
+  it("shows auth error message on signup code-send failure", async () => {
     mockSignInWithOtp.mockResolvedValue({
       data: { user: null, session: null },
       error: { message: "Email already registered" },


### PR DESCRIPTION
## Summary\n- switch login back to request-and-verify email codes instead of a magic-link-only UI\n- switch signup to a code verification step after requesting account creation\n- keep the hosted redirect URL path aligned for GitHub Pages while using Supabase OTP verification\n\n## Testing\n- bun run test src/test/pages/Login.test.tsx src/test/pages/Signup.test.tsx\n- bun run build\n\nRefs #81