### PR TITLE
Add Infohub and Admin sidebar subpages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,10 +56,14 @@ const App = () => (
                 <Route path="/notifications" element={<ProtectedRoute><Notifications /></ProtectedRoute>} />
                 <Route path="/checklists/*" element={<ProtectedRoute><Checklists /></ProtectedRoute>} />
                 <Route path="/reporting" element={<ProtectedRoute><Reporting /></ProtectedRoute>} />
-                <Route path="/infohub/*" element={<ProtectedRoute><Infohub /></ProtectedRoute>} />
-                <Route path="/training/*" element={<Navigate to="/infohub" replace />} />
+                <Route path="/infohub" element={<Navigate to="/infohub/library" replace />} />
+                <Route path="/infohub/library/*" element={<ProtectedRoute><Infohub /></ProtectedRoute>} />
+                <Route path="/infohub/training/*" element={<ProtectedRoute><Infohub /></ProtectedRoute>} />
+                <Route path="/training/*" element={<Navigate to="/infohub/training" replace />} />
                 <Route path="/maintenance" element={<Navigate to="/dashboard" replace />} />
-                <Route path="/admin" element={<ProtectedRoute><Admin /></ProtectedRoute>} />
+                <Route path="/admin" element={<Navigate to="/admin/location" replace />} />
+                <Route path="/admin/location" element={<ProtectedRoute><Admin /></ProtectedRoute>} />
+                <Route path="/admin/account" element={<ProtectedRoute><Admin /></ProtectedRoute>} />
                 <Route path="/billing" element={<ProtectedRoute><Billing /></ProtectedRoute>} />
                 <Route path="*" element={<NotFound />} />
               </Routes>

--- a/src/components/SidebarNav.tsx
+++ b/src/components/SidebarNav.tsx
@@ -1,9 +1,12 @@
 import { NavLink, useLocation } from "react-router-dom";
 import { appNavItems } from "./app-nav";
 import { cn } from "@/lib/utils";
+import { useAuth } from "@/contexts/AuthContext";
 
 export function SidebarNav() {
   const location = useLocation();
+  const { teamMember } = useAuth();
+  const isOwner = teamMember?.role === "Owner";
 
   return (
     <aside className="hidden md:flex md:w-[224px] md:shrink-0">
@@ -12,30 +15,58 @@ export function SidebarNav() {
           Navigate
         </p>
         <nav aria-label="Primary" className="space-y-1">
-          {appNavItems.map(({ to, label, icon: Icon }) => {
+          {appNavItems.map(({ to, label, icon: Icon, children }) => {
             const active = location.pathname.startsWith(to);
+            const visibleChildren = children?.filter((child) => {
+              if (to === "/admin" && child.to === "/admin/account" && !isOwner) {
+                return false;
+              }
+              return true;
+            }) ?? [];
 
             return (
-              <NavLink
-                key={to}
-                to={to}
-                className={cn(
-                  "group flex items-center gap-3 rounded-2xl px-3 py-3 text-sm font-medium transition-all",
-                  active
-                    ? "bg-sage text-white shadow-sm"
-                    : "text-muted-foreground hover:bg-muted hover:text-foreground",
-                )}
-              >
-                <span
+              <div key={to} className="space-y-1">
+                <NavLink
+                  to={to}
                   className={cn(
-                    "flex h-10 w-10 items-center justify-center rounded-2xl transition-colors",
-                    active ? "bg-white/16" : "bg-muted text-muted-foreground group-hover:bg-card",
+                    "group flex items-center gap-3 rounded-2xl px-3 py-3 text-sm font-medium transition-all",
+                    active
+                      ? "bg-sage text-white shadow-sm"
+                      : "text-muted-foreground hover:bg-muted hover:text-foreground",
                   )}
                 >
-                  <Icon size={18} strokeWidth={active ? 2.2 : 1.8} />
-                </span>
-                <span className="tracking-[0.02em]">{label}</span>
-              </NavLink>
+                  <span
+                    className={cn(
+                      "flex h-10 w-10 items-center justify-center rounded-2xl transition-colors",
+                      active ? "bg-white/16" : "bg-muted text-muted-foreground group-hover:bg-card",
+                    )}
+                  >
+                    <Icon size={18} strokeWidth={active ? 2.2 : 1.8} />
+                  </span>
+                  <span className="tracking-[0.02em]">{label}</span>
+                </NavLink>
+                {active && visibleChildren.length > 0 ? (
+                  <div className="ml-5 border-l border-border/70 pl-4 space-y-1">
+                    {visibleChildren.map((child) => {
+                      const childActive = location.pathname.startsWith(child.to);
+                      return (
+                        <NavLink
+                          key={child.to}
+                          to={child.to}
+                          className={cn(
+                            "block rounded-xl px-3 py-2 text-xs font-semibold tracking-[0.08em] uppercase transition-colors",
+                            childActive
+                              ? "bg-muted text-foreground"
+                              : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
+                          )}
+                        >
+                          {child.label}
+                        </NavLink>
+                      );
+                    })}
+                  </div>
+                ) : null}
+              </div>
             );
           })}
         </nav>

--- a/src/components/app-nav.ts
+++ b/src/components/app-nav.ts
@@ -11,12 +11,32 @@ export interface AppNavItem {
   to: string;
   label: string;
   icon: LucideIcon;
+  children?: Array<{
+    to: string;
+    label: string;
+  }>;
 }
 
 export const appNavItems: AppNavItem[] = [
   { to: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
   { to: "/checklists", label: "Checklists", icon: ClipboardList },
   { to: "/reporting", label: "Reporting", icon: BarChart3 },
-  { to: "/infohub", label: "Infohub", icon: BookOpen },
-  { to: "/admin", label: "Admin", icon: ShieldCheck },
+  {
+    to: "/infohub",
+    label: "Infohub",
+    icon: BookOpen,
+    children: [
+      { to: "/infohub/library", label: "Library" },
+      { to: "/infohub/training", label: "Training" },
+    ],
+  },
+  {
+    to: "/admin",
+    label: "Admin",
+    icon: ShieldCheck,
+    children: [
+      { to: "/admin/location", label: "My Location" },
+      { to: "/admin/account", label: "Account" },
+    ],
+  },
 ];

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { Layout } from "@/components/Layout";
 import {
   MapPin, Clock, Mail, Phone, Plus, Pencil, Trash2, Archive, RotateCcw,
@@ -2073,6 +2073,7 @@ type ConfirmState = {
 } | null;
 
 export default function Admin() {
+  const location = useLocation();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const fromKiosk = searchParams.get("from") === "kiosk";
@@ -2111,7 +2112,8 @@ export default function Admin() {
   const auditLog: AuditLogEntry[] = [];
 
   // UI state
-  const [activeTab, setActiveTab] = useState<"location" | "account">("location");
+  const routeTab: "location" | "account" = location.pathname.startsWith("/admin/account") ? "account" : "location";
+  const [activeTab, setActiveTab] = useState<"location" | "account">(routeTab);
   const [currentLocationId, setCurrentLocationId] = useState("");
 
   // Set default location once data loads
@@ -2133,6 +2135,14 @@ export default function Admin() {
   // Determine active user from URL param
   const activeUser = userId ? (teamMembers.find(m => m.id === userId) ?? null) : null;
   const isOwner = !activeUser || activeUser.role === "Owner";
+
+  useEffect(() => {
+    if (!isOwner && routeTab === "account") {
+      navigate("/admin/location", { replace: true });
+      return;
+    }
+    setActiveTab(routeTab);
+  }, [isOwner, navigate, routeTab]);
   const permissions: ManagerPermissions | null = isOwner ? null : (activeUser?.permissions ?? null);
 
   // Inactivity timer — when from kiosk, redirect back after 90s idle
@@ -2346,11 +2356,11 @@ export default function Admin() {
       >
         <div className="mx-auto w-full max-w-[1040px] space-y-4 xl:max-w-[980px]">
           {/* Sub-tab pill toggle */}
-          <div className="flex gap-1 bg-muted rounded-2xl p-1">
+          <div className="flex gap-1 bg-muted rounded-2xl p-1 md:hidden">
             {TABS.map(({ key, label }) => (
               <button
                 key={key}
-                onClick={() => setActiveTab(key)}
+                onClick={() => navigate(key === "location" ? "/admin/location" : "/admin/account")}
                 className={cn(
                   "flex-1 py-2.5 text-xs font-semibold rounded-xl transition-colors tracking-wide",
                   activeTab === key ? "bg-card text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground",

--- a/src/pages/Infohub.tsx
+++ b/src/pages/Infohub.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useRef, useEffect } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import { Layout } from "@/components/Layout";
 import { useAuth } from "@/contexts/AuthContext";
 import { supabase } from "@/lib/supabase";
@@ -1092,6 +1093,8 @@ function useDragReorder<T extends { id: string }>(items: T[], onReorder: (reorde
 // ─── Infohub Page ─────────────────────────────────────────────────────────────
 
 export default function Infohub() {
+  const location = useLocation();
+  const navigate = useNavigate();
   const { teamMember } = useAuth();
   const { data: teamMembers = [] } = useTeamMembers();
   const { data: locations = [] } = useLocations();
@@ -1107,7 +1110,8 @@ export default function Infohub() {
     reorderFolders,
   } = useInfohubContent();
   const { data: trainingProgress = [], saveProgress } = useTrainingProgress();
-  const [subTab, setSubTab] = useState<SubTab>("library");
+  const routeSubTab: SubTab = location.pathname.startsWith("/infohub/training") ? "training" : "library";
+  const [subTab, setSubTab] = useState<SubTab>(routeSubTab);
   const [showSearch, setShowSearch] = useState(false);
   const [showPlusMenu, setShowPlusMenu] = useState(false);
   const [showCreateFolder, setShowCreateFolder] = useState(false);
@@ -1132,6 +1136,10 @@ export default function Infohub() {
   const [moveTarget, setMoveTarget] = useState<{ type: "folder" | "doc"; id: string; section: "library" | "training" } | null>(null);
   const [renameTarget, setRenameTarget] = useState<{ id: string; name: string; section: "library" | "training" } | null>(null);
   const [accessTarget, setAccessTarget] = useState<AccessTarget | null>(null);
+
+  useEffect(() => {
+    setSubTab(routeSubTab);
+  }, [routeSubTab]);
 
   const currentPrincipal: InfohubPrincipal = {
     teamMemberId: teamMember?.id ?? null,
@@ -1371,13 +1379,17 @@ export default function Infohub() {
       }
     >
       {/* Sub-tab toggle */}
-      <div className="flex gap-1 bg-muted rounded-xl p-1">
+      <div className="flex gap-1 bg-muted rounded-xl p-1 md:hidden">
         {([
           { key: "library" as const, label: "Library", icon: BookOpen },
           { key: "training" as const, label: "Training", icon: GraduationCap },
         ]).map(({ key, label, icon: Icon }) => (
           <button key={key}
-            onClick={() => { setSubTab(key); setCurrentLibFolder(null); setCurrentTrainFolder(null); }}
+            onClick={() => {
+              setCurrentLibFolder(null);
+              setCurrentTrainFolder(null);
+              navigate(key === "library" ? "/infohub/library" : "/infohub/training");
+            }}
             className={cn(
               "flex-1 flex items-center justify-center gap-1.5 py-2 text-xs font-medium rounded-lg transition-colors",
               subTab === key ? "bg-card text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground"

--- a/src/test/components/SidebarNav.test.tsx
+++ b/src/test/components/SidebarNav.test.tsx
@@ -1,0 +1,50 @@
+import { screen } from "@testing-library/react";
+import { SidebarNav } from "@/components/SidebarNav";
+import { renderWithProviders } from "../test-utils";
+
+const { mockUseAuth } = vi.hoisted(() => ({
+  mockUseAuth: vi.fn(),
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: mockUseAuth,
+}));
+
+describe("SidebarNav", () => {
+  beforeEach(() => {
+    mockUseAuth.mockReturnValue({
+      teamMember: {
+        id: "tm-1",
+        role: "Owner",
+      },
+    });
+  });
+
+  it("shows Infohub child links when Infohub is active", () => {
+    renderWithProviders(<SidebarNav />, { initialEntries: ["/infohub/library"] });
+
+    expect(screen.getByRole("link", { name: "Library" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Training" })).toBeInTheDocument();
+  });
+
+  it("shows Admin child links for owners when Admin is active", () => {
+    renderWithProviders(<SidebarNav />, { initialEntries: ["/admin/account"] });
+
+    expect(screen.getByRole("link", { name: "My Location" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Account" })).toBeInTheDocument();
+  });
+
+  it("hides the Account child link for non-owners", () => {
+    mockUseAuth.mockReturnValue({
+      teamMember: {
+        id: "tm-2",
+        role: "Manager",
+      },
+    });
+
+    renderWithProviders(<SidebarNav />, { initialEntries: ["/admin/location"] });
+
+    expect(screen.getByRole("link", { name: "My Location" })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Account" })).toBeNull();
+  });
+});

--- a/src/test/pages/Admin.test.tsx
+++ b/src/test/pages/Admin.test.tsx
@@ -156,35 +156,33 @@ vi.mock("@/hooks/useChecklists", () => ({
 describe("Admin page", () => {
   // 1. Renders without crashing
   it("renders the Admin page without crashing", () => {
-    renderWithProviders(<Admin />);
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/location"] });
     expect(document.body).toBeDefined();
   });
 
   // 2. Shows both tabs
   it("shows 'My Location' and 'Account' tabs", () => {
-    renderWithProviders(<Admin />);
-    expect(screen.getByText("My Location")).toBeInTheDocument();
-    expect(screen.getByText("Account")).toBeInTheDocument();
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/location"] });
+    expect(screen.getAllByText("My Location").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Account").length).toBeGreaterThanOrEqual(1);
   });
 
   // 3. My Location is active by default
   it("'My Location' tab is active by default", () => {
-    renderWithProviders(<Admin />);
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/location"] });
     // The location picker / section-label should be visible
     expect(screen.getByText("Location details")).toBeInTheDocument();
   });
 
-  // 4. Clicking Account tab shows account content
-  it("clicking 'Account' tab shows account content", () => {
-    renderWithProviders(<Admin />);
-    const accountTab = screen.getByText("Account");
-    fireEvent.click(accountTab);
+  // 4. Account route shows account content
+  it("account route shows account content", () => {
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
     expect(screen.getByText("My account")).toBeInTheDocument();
   });
 
   // 5. Location section shows location names
   it("location select shows location names (Main Branch, City Centre)", async () => {
-    renderWithProviders(<Admin />);
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/location"] });
     await waitFor(() => {
       // Either in a dropdown or displayed text somewhere
       const mainBranch = screen.queryByText("Main Branch") || screen.queryAllByText(/Main Branch/i)[0];
@@ -194,7 +192,7 @@ describe("Admin page", () => {
 
   // 6. Location details card appears when a location exists
   it("location details card is rendered when location is selected", async () => {
-    renderWithProviders(<Admin />);
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/location"] });
     await waitFor(() => {
       expect(screen.getByText("Location details")).toBeInTheDocument();
     });
@@ -202,7 +200,7 @@ describe("Admin page", () => {
 
   // 7. Staff Profiles section shows active staff (Alice Smith)
   it("staff profiles section shows Alice Smith", async () => {
-    renderWithProviders(<Admin />);
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/location"] });
     await waitFor(() => {
       expect(screen.getByText("Alice Smith")).toBeInTheDocument();
     });
@@ -210,7 +208,7 @@ describe("Admin page", () => {
 
   // 8. Staff role badge shows department-based label
   it("shows Alice Smith's role as Front of House / Server", async () => {
-    renderWithProviders(<Admin />);
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/location"] });
     await waitFor(() => {
       const roleBadges = screen.getAllByText("Front of House / Server");
       expect(roleBadges.length).toBeGreaterThanOrEqual(1);
@@ -219,7 +217,7 @@ describe("Admin page", () => {
 
   // 9. Active staff shows Edit button (Pencil)
   it("active staff has edit (pencil) button", async () => {
-    renderWithProviders(<Admin />);
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/location"] });
     await waitFor(() => {
       const editBtns = screen.getAllByRole("button", { name: /edit/i });
       expect(editBtns.length).toBeGreaterThanOrEqual(1);
@@ -228,7 +226,7 @@ describe("Admin page", () => {
 
   // 10. Active staff has Archive button
   it("active staff has archive button", async () => {
-    renderWithProviders(<Admin />);
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/location"] });
     await waitFor(() => {
       const archiveBtns = screen.getAllByRole("button", { name: /archive/i });
       expect(archiveBtns.length).toBeGreaterThanOrEqual(1);
@@ -237,7 +235,7 @@ describe("Admin page", () => {
 
   // 11. Clicking "Add" staff button opens staff profile form
   it("clicking 'Add' staff opens the staff profile form sheet", async () => {
-    renderWithProviders(<Admin />);
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/location"] });
     await waitFor(() => {
       expect(screen.getByText("Staff profiles")).toBeInTheDocument();
     });
@@ -251,7 +249,7 @@ describe("Admin page", () => {
 
   // 12. Staff form has First Name field
   it("staff profile form has First name field", async () => {
-    renderWithProviders(<Admin />);
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/location"] });
     await waitFor(() => expect(screen.getByText("Staff profiles")).toBeInTheDocument());
     const addBtns = screen.getAllByText("Add");
     fireEvent.click(addBtns[0]);
@@ -354,8 +352,7 @@ describe("Admin page", () => {
 
   // 21. Account tab shows "All locations" section with locations
   it("Account tab shows all locations", async () => {
-    renderWithProviders(<Admin />);
-    fireEvent.click(screen.getByText("Account"));
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
     await waitFor(() => {
       expect(screen.getAllByText("Main Branch").length).toBeGreaterThanOrEqual(1);
     });
@@ -363,8 +360,7 @@ describe("Admin page", () => {
 
   // 22. Account tab shows "City Centre" location
   it("Account tab shows City Centre location", async () => {
-    renderWithProviders(<Admin />);
-    fireEvent.click(screen.getByText("Account"));
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
     await waitFor(() => {
       expect(screen.getAllByText("City Centre").length).toBeGreaterThanOrEqual(1);
     });
@@ -372,18 +368,16 @@ describe("Admin page", () => {
 
   // 23. Team Members section shows Sarah Owner and Mike Manager
   it("Account tab shows team members Sarah Owner and Mike Manager", async () => {
-    renderWithProviders(<Admin />);
-    fireEvent.click(screen.getByText("Account"));
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
     await waitFor(() => {
-      expect(screen.getByText("Sarah Owner")).toBeInTheDocument();
-      expect(screen.getByText("Mike Manager")).toBeInTheDocument();
+      expect(screen.getAllByText("Sarah Owner").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText("Mike Manager").length).toBeGreaterThanOrEqual(1);
     });
   });
 
   // 23b. Account tab shows self-service account settings
   it("Account tab shows my account settings", async () => {
-    renderWithProviders(<Admin />);
-    fireEvent.click(screen.getByText("Account"));
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
 
     await waitFor(() => {
       expect(screen.getByText("My account")).toBeInTheDocument();
@@ -405,8 +399,7 @@ describe("Admin page", () => {
     mockSaveTeamMember.mutateAsync.mockClear();
     updateUser.mockClear();
 
-    renderWithProviders(<Admin />);
-    fireEvent.click(screen.getByText("Account"));
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
 
     await waitFor(() => expect(screen.getByText("Save profile")).toBeInTheDocument());
     fireEvent.click(screen.getByRole("button", { name: "Save profile" }));
@@ -423,8 +416,7 @@ describe("Admin page", () => {
 
   // 24. "Add location" button visible in Account tab
   it("'Add location' button is visible in Account tab", async () => {
-    renderWithProviders(<Admin />);
-    fireEvent.click(screen.getByText("Account"));
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
     await waitFor(() => {
       expect(screen.getByText("Add location")).toBeInTheDocument();
     });
@@ -432,8 +424,7 @@ describe("Admin page", () => {
 
   // 25. Clicking "Add location" opens a location form
   it("clicking 'Add location' opens location form sheet", async () => {
-    renderWithProviders(<Admin />);
-    fireEvent.click(screen.getByText("Account"));
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
     await waitFor(() => {
       expect(screen.getByText("Add location")).toBeInTheDocument();
     });
@@ -445,8 +436,7 @@ describe("Admin page", () => {
 
   // 26. Location form has Name field
   it("location form has 'Location name (required)' field", async () => {
-    renderWithProviders(<Admin />);
-    fireEvent.click(screen.getByText("Account"));
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
     await waitFor(() => expect(screen.getByText("Add location")).toBeInTheDocument());
     fireEvent.click(screen.getByText("Add location"));
     await waitFor(() => {
@@ -456,8 +446,7 @@ describe("Admin page", () => {
 
   // 27. Location form has Address field
   it("location form has Address field", async () => {
-    renderWithProviders(<Admin />);
-    fireEvent.click(screen.getByText("Account"));
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
     await waitFor(() => expect(screen.getByText("Add location")).toBeInTheDocument());
     fireEvent.click(screen.getByText("Add location"));
     await waitFor(() => {
@@ -484,8 +473,7 @@ describe("Admin page", () => {
 
   // 28. Location form does not show email for new locations
   it("location form hides email field for new locations", async () => {
-    renderWithProviders(<Admin />);
-    fireEvent.click(screen.getByText("Account"));
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
     await waitFor(() => expect(screen.getByText("Add location")).toBeInTheDocument());
     fireEvent.click(screen.getByText("Add location"));
     await waitFor(() => {
@@ -495,8 +483,7 @@ describe("Admin page", () => {
 
   // 29. Location form has Location phone field
   it("location form has Location phone field", async () => {
-    renderWithProviders(<Admin />);
-    fireEvent.click(screen.getByText("Account"));
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
     await waitFor(() => expect(screen.getByText("Add location")).toBeInTheDocument());
     fireEvent.click(screen.getByText("Add location"));
     await waitFor(() => {
@@ -506,8 +493,7 @@ describe("Admin page", () => {
 
   // 30. Clicking Edit on a location opens edit form with "Edit location" heading
   it("clicking Edit on a location opens edit form", async () => {
-    renderWithProviders(<Admin />);
-    fireEvent.click(screen.getByText("Account"));
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
     await waitFor(() => {
       // There are pencil (Edit) buttons next to each location
       const editBtns = screen.getAllByRole("button");
@@ -532,8 +518,7 @@ describe("Admin page", () => {
 
   // 31. Delete location button opens confirm modal
   it("clicking delete on a location shows confirm modal", async () => {
-    renderWithProviders(<Admin />);
-    fireEvent.click(screen.getByText("Account"));
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
     await waitFor(() => {
       expect(screen.getAllByText("Main Branch").length).toBeGreaterThanOrEqual(1);
     });
@@ -566,8 +551,7 @@ describe("Admin page", () => {
 
   // 32. Confirm modal has "Cancel" button
   it("confirm modal has Cancel button", async () => {
-    renderWithProviders(<Admin />);
-    fireEvent.click(screen.getByText("Account"));
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
     await waitFor(() => expect(screen.getAllByText("Main Branch").length).toBeGreaterThanOrEqual(1));
     const allLocationsHeading = screen.getAllByText("All locations").find(el => el.classList.contains("section-label"));
     const section = allLocationsHeading?.closest("section");
@@ -588,8 +572,7 @@ describe("Admin page", () => {
 
   // 33. Clicking "Invite" opens team member form
   it("clicking 'Invite' opens team member form", async () => {
-    renderWithProviders(<Admin />);
-    fireEvent.click(screen.getByText("Account"));
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
     await waitFor(() => {
       expect(screen.getByText("Add")).toBeInTheDocument();
     });
@@ -601,8 +584,7 @@ describe("Admin page", () => {
 
   // 34. Team member form has Full name field
   it("team member form has Full name field", async () => {
-    renderWithProviders(<Admin />);
-    fireEvent.click(screen.getByText("Account"));
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
     await waitFor(() => expect(screen.getByText("Add")).toBeInTheDocument());
     fireEvent.click(screen.getByText("Add"));
     await waitFor(() => {
@@ -612,8 +594,7 @@ describe("Admin page", () => {
 
   // 35. Team member form has Email field
   it("team member form has Email field", async () => {
-    renderWithProviders(<Admin />);
-    fireEvent.click(screen.getByText("Account"));
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
     await waitFor(() => expect(screen.getByText("Add")).toBeInTheDocument());
     fireEvent.click(screen.getByText("Add"));
     await waitFor(() => {
@@ -623,8 +604,7 @@ describe("Admin page", () => {
 
   // 35b. Team member form has PIN field for kiosk/admin access
   it("team member form has Kiosk PIN field", async () => {
-    renderWithProviders(<Admin />);
-    fireEvent.click(screen.getByText("Account"));
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
     await waitFor(() => expect(screen.getByText("Add")).toBeInTheDocument());
     fireEvent.click(screen.getByText("Add"));
     await waitFor(() => {
@@ -634,9 +614,8 @@ describe("Admin page", () => {
 
   // 35c. Owner edit form shows Admin PIN field
   it("owner team member edit form has Admin PIN field", async () => {
-    renderWithProviders(<Admin />);
-    fireEvent.click(screen.getByText("Account"));
-    await waitFor(() => expect(screen.getByText("Sarah Owner")).toBeInTheDocument());
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
+    await waitFor(() => expect(screen.getAllByText("Sarah Owner").length).toBeGreaterThanOrEqual(1));
     fireEvent.click(screen.getByLabelText("Edit Sarah Owner"));
     await waitFor(() => expect(screen.getByRole("heading", { name: "Edit team member" })).toBeInTheDocument());
     await waitFor(() => expect(screen.getByText("Generate")).toBeInTheDocument());
@@ -644,8 +623,7 @@ describe("Admin page", () => {
 
   // 36. Billing card is visible in Account tab
   it("billing card is visible in Account tab", async () => {
-    renderWithProviders(<Admin />);
-    fireEvent.click(screen.getByText("Account"));
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
     await waitFor(() => {
       expect(screen.getByText("Current Plan")).toBeInTheDocument();
     });
@@ -653,8 +631,7 @@ describe("Admin page", () => {
 
   // 37. Billing card shows "Olia Growth" plan name
   it("billing card shows plan name", async () => {
-    renderWithProviders(<Admin />);
-    fireEvent.click(screen.getByText("Account"));
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
     await waitFor(() => {
       expect(screen.getByText("Olia Growth")).toBeInTheDocument();
     });
@@ -662,8 +639,7 @@ describe("Admin page", () => {
 
   // 38. Manage Billing button is visible
   it("'Manage Billing' button is visible in Account tab", async () => {
-    renderWithProviders(<Admin />);
-    fireEvent.click(screen.getByText("Account"));
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
     await waitFor(() => {
       expect(screen.getByText("Manage Billing")).toBeInTheDocument();
     });
@@ -671,10 +647,9 @@ describe("Admin page", () => {
 
   // 39. At least one permission label appears in team member expand
   it("permission labels appear when team member is expanded", async () => {
-    renderWithProviders(<Admin />);
-    fireEvent.click(screen.getByText("Account"));
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
     await waitFor(() => {
-      expect(screen.getByText("Mike Manager")).toBeInTheDocument();
+      expect(screen.getAllByText("Mike Manager").length).toBeGreaterThanOrEqual(1);
     });
     // Click the expand (ChevronDown) button for Mike Manager
     const mikeRow = screen.getByText("Mike Manager").closest("[class*='flex items-center']");
@@ -692,8 +667,7 @@ describe("Admin page", () => {
 
   // 40. Department management section shows default departments
   it("Account tab shows Department management section with default departments", async () => {
-    renderWithProviders(<Admin />);
-    fireEvent.click(screen.getByText("Account"));
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
     await waitFor(() => {
       expect(screen.getByText("Department management")).toBeInTheDocument();
     });
@@ -701,8 +675,7 @@ describe("Admin page", () => {
 
   // 41. Default departments listed
   it("Department management section shows default department names", async () => {
-    renderWithProviders(<Admin />);
-    fireEvent.click(screen.getByText("Account"));
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
     await waitFor(() => {
       expect(screen.getByText("Front of House")).toBeInTheDocument();
       expect(screen.getByText("Back of House")).toBeInTheDocument();
@@ -713,8 +686,7 @@ describe("Admin page", () => {
 
   // 42. Add department input exists
   it("Account tab has 'Add department' input", async () => {
-    renderWithProviders(<Admin />);
-    fireEvent.click(screen.getByText("Account"));
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
     await waitFor(() => {
       expect(screen.getByPlaceholderText("Add department…")).toBeInTheDocument();
     });
@@ -722,8 +694,7 @@ describe("Admin page", () => {
 
   // 43. Audit log section exists
   it("Account tab has Audit log section", async () => {
-    renderWithProviders(<Admin />);
-    fireEvent.click(screen.getByText("Account"));
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
     await waitFor(() => {
       expect(screen.getByText("Audit log")).toBeInTheDocument();
     });
@@ -776,8 +747,7 @@ describe("Admin page", () => {
 
   // 49. Team members section label in Account tab
   it("Account tab shows 'Team members' section label", async () => {
-    renderWithProviders(<Admin />);
-    fireEvent.click(screen.getByText("Account"));
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
     await waitFor(() => {
       expect(screen.getByText("Team members")).toBeInTheDocument();
     });
@@ -785,8 +755,7 @@ describe("Admin page", () => {
 
   // 50. Checklist coverage summary in Account tab
   it("Account tab shows Checklist coverage summary", async () => {
-    renderWithProviders(<Admin />);
-    fireEvent.click(screen.getByText("Account"));
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
     await waitFor(() => {
       expect(screen.getByText("Checklist coverage")).toBeInTheDocument();
     });
@@ -839,8 +808,7 @@ describe("Admin page", () => {
   });
 
   it("location form shows Opening hours with time inputs for open days and 'Closed' for closed days", async () => {
-    renderWithProviders(<Admin />);
-    fireEvent.click(screen.getByText("Account"));
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
     await waitFor(() => expect(screen.getAllByText("Main Branch").length).toBeGreaterThanOrEqual(1));
     // click the pencil/edit button on the first location
     const allLocationsSection = screen.getAllByText("All locations").find(el => el.classList.contains("section-label"))?.closest("section");
@@ -858,8 +826,7 @@ describe("Admin page", () => {
   });
 
   it("location form supports split-day hours and copying them to later days", async () => {
-    renderWithProviders(<Admin />);
-    fireEvent.click(screen.getByText("Account"));
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
     await waitFor(() => expect(screen.getByText("Add location")).toBeInTheDocument());
     fireEvent.click(screen.getByText("Add location"));
 
@@ -925,8 +892,7 @@ describe("Admin page", () => {
   });
 
   it("Account tab shows checklist coverage with checklist titles", async () => {
-    renderWithProviders(<Admin />);
-    fireEvent.click(screen.getByText("Account"));
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
     await waitFor(() => {
       expect(screen.getByText("Checklist coverage")).toBeInTheDocument();
       expect(screen.getAllByText("Opening Checklist").length).toBeGreaterThanOrEqual(1);

--- a/src/test/pages/Infohub.test.tsx
+++ b/src/test/pages/Infohub.test.tsx
@@ -76,44 +76,48 @@ describe("Infohub page", () => {
   });
 
   it("renders without crashing", () => {
-    renderWithProviders(<Infohub />);
+    renderWithProviders(<Infohub />, { initialEntries: ["/infohub/library"] });
     expect(document.body).toBeDefined();
   });
 
   it("shows 'Library' and 'Training' subtab buttons", () => {
-    renderWithProviders(<Infohub />);
+    renderWithProviders(<Infohub />, { initialEntries: ["/infohub/library"] });
     expect(screen.getByRole("button", { name: /library/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /training/i })).toBeInTheDocument();
   });
 
-  it("Library tab is active by default (shows Folders section)", () => {
-    renderWithProviders(<Infohub />);
-    // The Library tab is active, so the Folders section should be visible
+  it("library route is active by default (shows Folders section)", () => {
+    renderWithProviders(<Infohub />, { initialEntries: ["/infohub/library"] });
     expect(screen.getByText("Folders")).toBeInTheDocument();
   });
 
+  it("training route shows training modules", () => {
+    renderWithProviders(<Infohub />, { initialEntries: ["/infohub/training"] });
+    expect(screen.getByText("Staff training modules")).toBeInTheDocument();
+  });
+
   it("shows folder list on Library tab including 'Cleaning & Maintenance'", () => {
-    renderWithProviders(<Infohub />);
+    renderWithProviders(<Infohub />, { initialEntries: ["/infohub/library"] });
     expect(screen.getByText("Cleaning & Maintenance")).toBeInTheDocument();
   });
 
   it("shows folder list including 'Food Safety'", () => {
-    renderWithProviders(<Infohub />);
+    renderWithProviders(<Infohub />, { initialEntries: ["/infohub/library"] });
     expect(screen.getByText("Food Safety")).toBeInTheDocument();
   });
 
   it("shows folder list including 'Opening & Closing'", () => {
-    renderWithProviders(<Infohub />);
+    renderWithProviders(<Infohub />, { initialEntries: ["/infohub/library"] });
     expect(screen.getByText("Opening & Closing")).toBeInTheDocument();
   });
 
   it("shows folder list including 'Service Standards'", () => {
-    renderWithProviders(<Infohub />);
+    renderWithProviders(<Infohub />, { initialEntries: ["/infohub/library"] });
     expect(screen.getByText("Service Standards")).toBeInTheDocument();
   });
 
   it("clicking a folder navigates into it and shows Documents section", () => {
-    renderWithProviders(<Infohub />);
+    renderWithProviders(<Infohub />, { initialEntries: ["/infohub/library"] });
     const foodSafetyFolder = screen.getByText("Food Safety");
     const folderRow = foodSafetyFolder.closest("div[class*='flex']") as HTMLElement;
     if (folderRow) {
@@ -124,7 +128,7 @@ describe("Infohub page", () => {
   });
 
   it("clicking 'All folders' breadcrumb navigates back to root", () => {
-    renderWithProviders(<Infohub />);
+    renderWithProviders(<Infohub />, { initialEntries: ["/infohub/library"] });
     // Click into a folder first
     const foodSafetyFolder = screen.getByText("Food Safety");
     const folderRow = foodSafetyFolder.closest("div[class*='flex']") as HTMLElement;
@@ -141,7 +145,7 @@ describe("Infohub page", () => {
   });
 
   it("search button is visible in header", () => {
-    renderWithProviders(<Infohub />);
+    renderWithProviders(<Infohub />, { initialEntries: ["/infohub/library"] });
     // The search icon button should be in the page
     const buttons = screen.getAllByRole("button");
     const hasSearchIcon = buttons.some(btn => btn.querySelector("svg") !== null);
@@ -149,7 +153,7 @@ describe("Infohub page", () => {
   });
 
   it("clicking the search button opens search overlay with input", () => {
-    renderWithProviders(<Infohub />);
+    renderWithProviders(<Infohub />, { initialEntries: ["/infohub/library"] });
     // Find the search button (it has a Search icon)
     // The header has search + plus buttons; search is first
     const buttons = screen.getAllByRole("button");
@@ -172,7 +176,7 @@ describe("Infohub page", () => {
   });
 
   it("search overlay shows 'No results found' for unmatched query", () => {
-    renderWithProviders(<Infohub />);
+    renderWithProviders(<Infohub />, { initialEntries: ["/infohub/library"] });
     const buttons = screen.getAllByRole("button");
     const searchButtons = buttons.filter(btn =>
       btn.className.includes("rounded-full") && btn.querySelector("svg")
@@ -188,7 +192,7 @@ describe("Infohub page", () => {
   });
 
   it("search overlay filters library docs by title", () => {
-    renderWithProviders(<Infohub />);
+    renderWithProviders(<Infohub />, { initialEntries: ["/infohub/library"] });
     const buttons = screen.getAllByRole("button");
     const searchButtons = buttons.filter(btn =>
       btn.className.includes("rounded-full") && btn.querySelector("svg")
@@ -205,7 +209,7 @@ describe("Infohub page", () => {
   });
 
   it("closing search overlay (X button) returns to main view", () => {
-    renderWithProviders(<Infohub />);
+    renderWithProviders(<Infohub />, { initialEntries: ["/infohub/library"] });
     const buttons = screen.getAllByRole("button");
     const searchButtons = buttons.filter(btn =>
       btn.className.includes("rounded-full") && btn.querySelector("svg")
@@ -222,7 +226,7 @@ describe("Infohub page", () => {
       if (closeBtn) {
         fireEvent.click(closeBtn);
         // Should be back to main page
-        expect(screen.queryByText("Library")).toBeInTheDocument();
+        expect(screen.getByText("Folders")).toBeInTheDocument();
       }
     }
   });
@@ -255,31 +259,22 @@ describe("Infohub page", () => {
   });
 
   it("switching to Training tab shows training folders", () => {
-    renderWithProviders(<Infohub />);
-    const trainingTab = screen.getByRole("button", { name: /training/i });
-    fireEvent.click(trainingTab);
-    // Training tab shows Onboarding and Troubleshooting folders
-    expect(screen.queryByText("Onboarding") || screen.queryByText("Folders")).toBeTruthy();
+    renderWithProviders(<Infohub />, { initialEntries: ["/infohub/training"] });
+    expect(screen.queryByText("Onboarding") || screen.queryByText("Troubleshooting")).toBeTruthy();
   });
 
   it("Training tab shows training module folders like Onboarding", () => {
-    renderWithProviders(<Infohub />);
-    const trainingTab = screen.getByRole("button", { name: /training/i });
-    fireEvent.click(trainingTab);
+    renderWithProviders(<Infohub />, { initialEntries: ["/infohub/training"] });
     expect(screen.getByText("Onboarding")).toBeInTheDocument();
   });
 
   it("Training tab shows Troubleshooting folder", () => {
-    renderWithProviders(<Infohub />);
-    const trainingTab = screen.getByRole("button", { name: /training/i });
-    fireEvent.click(trainingTab);
+    renderWithProviders(<Infohub />, { initialEntries: ["/infohub/training"] });
     expect(screen.getByText("Troubleshooting")).toBeInTheDocument();
   });
 
   it("clicking a training folder navigates into it", () => {
-    renderWithProviders(<Infohub />);
-    const trainingTab = screen.getByRole("button", { name: /training/i });
-    fireEvent.click(trainingTab);
+    renderWithProviders(<Infohub />, { initialEntries: ["/infohub/training"] });
     const onboardingFolder = screen.getByText("Onboarding");
     const folderRow = onboardingFolder.closest("div[class*='flex']") as HTMLElement;
     if (folderRow) {
@@ -290,9 +285,7 @@ describe("Infohub page", () => {
   });
 
   it("clicking a training module opens the training detail view", () => {
-    renderWithProviders(<Infohub />);
-    const trainingTab = screen.getByRole("button", { name: /training/i });
-    fireEvent.click(trainingTab);
+    renderWithProviders(<Infohub />, { initialEntries: ["/infohub/training"] });
     // Navigate into Onboarding folder
     const onboardingFolder = screen.getByText("Onboarding");
     const folderRow = onboardingFolder.closest("div[class*='flex']") as HTMLElement;
@@ -312,9 +305,7 @@ describe("Infohub page", () => {
   });
 
   it("training doc detail shows step 1 text", () => {
-    renderWithProviders(<Infohub />);
-    const trainingTab = screen.getByRole("button", { name: /training/i });
-    fireEvent.click(trainingTab);
+    renderWithProviders(<Infohub />, { initialEntries: ["/infohub/training"] });
     const onboardingFolder = screen.getByText("Onboarding");
     const folderRow = onboardingFolder.closest("div[class*='flex']") as HTMLElement;
     if (folderRow) {
@@ -331,9 +322,7 @@ describe("Infohub page", () => {
   });
 
   it("training doc step can be toggled (clicking marks it done)", () => {
-    renderWithProviders(<Infohub />);
-    const trainingTab = screen.getByRole("button", { name: /training/i });
-    fireEvent.click(trainingTab);
+    renderWithProviders(<Infohub />, { initialEntries: ["/infohub/training"] });
     const onboardingFolder = screen.getByText("Onboarding");
     const folderRow = onboardingFolder.closest("div[class*='flex']") as HTMLElement;
     if (folderRow) {
@@ -359,9 +348,7 @@ describe("Infohub page", () => {
   });
 
   it("back button in training doc detail returns to folder view", () => {
-    renderWithProviders(<Infohub />);
-    const trainingTab = screen.getByRole("button", { name: /training/i });
-    fireEvent.click(trainingTab);
+    renderWithProviders(<Infohub />, { initialEntries: ["/infohub/training"] });
     const onboardingFolder = screen.getByText("Onboarding");
     const folderRow = onboardingFolder.closest("div[class*='flex']") as HTMLElement;
     if (folderRow) {
@@ -378,7 +365,7 @@ describe("Infohub page", () => {
           if (backBtn) {
             fireEvent.click(backBtn);
             // Should return to folder view
-            expect(screen.queryByText("Training") || screen.queryByText("Onboarding")).toBeTruthy();
+            expect(screen.getByText("Onboarding")).toBeInTheDocument();
           }
         }
       }
@@ -386,8 +373,7 @@ describe("Infohub page", () => {
   });
 
   it("completed training modules stay completed after going back and reopening", () => {
-    renderWithProviders(<Infohub />);
-    fireEvent.click(screen.getByRole("button", { name: /training/i }));
+    renderWithProviders(<Infohub />, { initialEntries: ["/infohub/training"] });
 
     const onboardingFolder = screen.getByText("Onboarding");
     const folderRow = onboardingFolder.closest("div[class*='flex']") as HTMLElement;
@@ -715,19 +701,13 @@ describe("Infohub page", () => {
   });
 
   it("training tab: Onboarding folder shows module count", () => {
-    renderWithProviders(<Infohub />);
-    const trainingTab = screen.getByRole("button", { name: /training/i });
-    fireEvent.click(trainingTab);
-    // Should show something like "3 modules"
+    renderWithProviders(<Infohub />, { initialEntries: ["/infohub/training"] });
     expect(screen.queryAllByText(/modules/i).length).toBeGreaterThan(0);
   });
 
   it("training tab: Troubleshooting folder shows module count", () => {
-    renderWithProviders(<Infohub />);
-    const trainingTab = screen.getByRole("button", { name: /training/i });
-    fireEvent.click(trainingTab);
+    renderWithProviders(<Infohub />, { initialEntries: ["/infohub/training"] });
     expect(screen.getByText("Troubleshooting")).toBeInTheDocument();
-    // Both folders should show module count text
     const modulesText = screen.queryAllByText(/modules/i);
     expect(modulesText.length).toBeGreaterThan(0);
   });
@@ -750,9 +730,7 @@ describe("Infohub page", () => {
   });
 
   it("Training tab subtitle changes when tab switched", () => {
-    renderWithProviders(<Infohub />);
-    const trainingTab = screen.getByRole("button", { name: /training/i });
-    fireEvent.click(trainingTab);
+    renderWithProviders(<Infohub />, { initialEntries: ["/infohub/training"] });
     expect(screen.getByText("Staff training modules")).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary\n- move Infohub library and training into route-backed sidebar subpages\n- move Admin my location and account into route-backed sidebar subpages\n- keep the mobile tab toggles as a lightweight fallback while desktop/tablet use the sidebar hierarchy\n\n## Testing\n- bun run test src/test/components/SidebarNav.test.tsx src/test/components/Layout.test.tsx src/test/components/BottomNav.test.tsx src/test/pages/Infohub.test.tsx src/test/pages/Admin.test.tsx\n- bun run build\n\nCloses #130