### PR TITLE
Fix GitHub Pages recursive route fallback

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -9,14 +9,20 @@
         var pathname = window.location.pathname;
         var firstRouteSlash = pathname.indexOf("/", 1);
         var route = firstRouteSlash === -1 ? "/" : pathname.slice(firstRouteSlash);
+        var search = window.location.search || "";
+        var hash = window.location.hash || "";
+        var searchParams = new URLSearchParams(search);
 
         if (route === "/") {
           window.location.replace("./");
           return;
         }
 
-        var search = window.location.search || "";
-        var hash = window.location.hash || "";
+        if (searchParams.get("p")) {
+          window.location.replace("./" + search + hash);
+          return;
+        }
+
         window.location.replace("./?p=" + encodeURIComponent(route + search + hash));
       })();
     </script>

--- a/src/lib/github-pages-routing.ts
+++ b/src/lib/github-pages-routing.ts
@@ -7,6 +7,23 @@ function normalizeFallbackRoute(fallbackRoute: string): string {
   return fallbackRoute.startsWith("/") ? fallbackRoute : `/${fallbackRoute}`;
 }
 
+function unwrapNestedFallbackRoute(fallbackRoute: string): string {
+  let currentRoute = normalizeFallbackRoute(fallbackRoute);
+
+  for (let i = 0; i < 10; i += 1) {
+    const url = new URL(currentRoute, "https://olia.app");
+    const nestedRoute = url.searchParams.get("p");
+
+    if (!nestedRoute) {
+      return `${url.pathname}${url.search}${url.hash}`;
+    }
+
+    currentRoute = normalizeFallbackRoute(nestedRoute);
+  }
+
+  return currentRoute;
+}
+
 function isGitHubPagesUrl(publicSiteUrl: string) {
   return new URL(publicSiteUrl).hostname.endsWith("github.io");
 }
@@ -17,7 +34,7 @@ export function buildGitHubPagesRoute(search: string, basePath: string): string 
   if (!fallbackRoute) return null;
 
   const normalizedBasePath = normalizeBasePath(basePath);
-  const normalizedRoute = normalizeFallbackRoute(fallbackRoute);
+  const normalizedRoute = unwrapNestedFallbackRoute(fallbackRoute);
   return `${normalizedBasePath}${normalizedRoute}`;
 }
 

--- a/src/test/lib/github-pages-routing.test.ts
+++ b/src/test/lib/github-pages-routing.test.ts
@@ -27,6 +27,15 @@ describe("github-pages-routing", () => {
     );
   });
 
+  it("unwraps nested fallback params instead of recursively growing the route", () => {
+    expect(
+      buildGitHubPagesRoute(
+        "?p=%2Fadmin%2F%3Fp%3D%252Fadmin%252Flocation",
+        "/olia-your-daily-operations/",
+      ),
+    ).toBe("/olia-your-daily-operations/admin/location");
+  });
+
   it("builds a GitHub Pages-safe auth redirect URL", () => {
     expect(buildPublicAuthRedirectUrl("https://dorabuilds.github.io/olia-your-daily-operations", "/auth/callback")).toBe(
       "https://dorabuilds.github.io/olia-your-daily-operations?p=%2Fauth%2Fcallback",


### PR DESCRIPTION
## Summary\n- stop GitHub Pages fallback URLs from recursively nesting the  parameter\n- make the runtime route restoration unwrap nested fallback routes safely\n- make  idempotent when a fallback parameter already exists\n\n## Testing\n- bun run test src/test/lib/github-pages-routing.test.ts\n- bun run build\n\nCloses #133