### PR TITLE
Fix admin location deactivation and flatten department roles

### DIFF
--- a/src/hooks/usePlan.ts
+++ b/src/hooks/usePlan.ts
@@ -109,11 +109,15 @@ export function useSaveActiveLocationsSelection() {
       if (!organizationId) {
         throw new Error("Your billing organization could not be resolved.");
       }
-      const { error } = await supabase
+      const { data, error } = await supabase
         .from("organizations")
         .update({ active_location_ids: locationIds })
-        .eq("id", organizationId);
+        .eq("id", organizationId)
+        .select("id, active_location_ids");
       if (error) throw error;
+      if (!data || data.length === 0) {
+        throw new Error("We could not save the active location selection. Please refresh and try again.");
+      }
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["organization", organizationId] });

--- a/src/lib/admin-repository.ts
+++ b/src/lib/admin-repository.ts
@@ -6,21 +6,17 @@ export type StaffStatus = "active" | "archived";
 
 export interface StaffDepartment {
   name: string;
-  subRoles: string[];
 }
 
 export const DEFAULT_STAFF_DEPARTMENTS: StaffDepartment[] = [
-  { name: "Front of House", subRoles: ["Server", "Bartender", "Host"] },
-  { name: "Back of House", subRoles: ["Chef", "Kitchen Helper", "Prep Cook"] },
-  { name: "Management", subRoles: ["Manager"] },
-  { name: "Cleaning Crew", subRoles: ["Cleaner"] },
+  { name: "Front of House" },
+  { name: "Back of House" },
+  { name: "Management" },
+  { name: "Cleaning Crew" },
 ];
 
 export function flattenStaffDepartments(departments: StaffDepartment[]): string[] {
-  return departments.flatMap((department) => [
-    department.name,
-    ...department.subRoles.map(subRole => `${department.name} / ${subRole}`),
-  ]);
+  return departments.map((department) => department.name);
 }
 
 const LEGACY_ROLE_DEPARTMENT_MAP: Record<string, string> = {
@@ -185,7 +181,7 @@ export const initialStaffProfiles: StaffProfile[] = [
     location_id: "l1",
     first_name: "Maria",
     last_name: "Garcia",
-    role: "Front of House / Server",
+    role: "Front of House",
     status: "active",
     pin: "1234",
     last_used_at: new Date(Date.now() - 86400000 * 2).toISOString(),
@@ -197,7 +193,7 @@ export const initialStaffProfiles: StaffProfile[] = [
     location_id: "l1",
     first_name: "Tariq",
     last_name: "Nasser",
-    role: "Front of House / Bartender",
+    role: "Front of House",
     status: "active",
     pin: "5678",
     last_used_at: new Date(Date.now()).toISOString(),
@@ -209,7 +205,7 @@ export const initialStaffProfiles: StaffProfile[] = [
     location_id: "l1",
     first_name: "Lena",
     last_name: "Schmidt",
-    role: "Back of House / Chef",
+    role: "Back of House",
     status: "active",
     pin: "2468",
     last_used_at: new Date(Date.now() - 86400000 * 1).toISOString(),
@@ -221,7 +217,7 @@ export const initialStaffProfiles: StaffProfile[] = [
     location_id: "l1",
     first_name: "Omar",
     last_name: "Boukhari",
-    role: "Front of House / Host",
+    role: "Front of House",
     status: "active",
     pin: "1357",
     last_used_at: new Date(Date.now() - 86400000 * 5).toISOString(),
@@ -233,7 +229,7 @@ export const initialStaffProfiles: StaffProfile[] = [
     location_id: "l2",
     first_name: "Sofia",
     last_name: "Andersen",
-    role: "Front of House / Server",
+    role: "Front of House",
     status: "active",
     pin: "9012",
     last_used_at: null,
@@ -245,7 +241,7 @@ export const initialStaffProfiles: StaffProfile[] = [
     location_id: "l2",
     first_name: "Jan",
     last_name: "Kowalski",
-    role: "Cleaning Crew / Cleaner",
+    role: "Cleaning Crew",
     status: "archived",
     pin: "3579",
     last_used_at: new Date(Date.now() - 86400000 * 45).toISOString(),

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -198,18 +198,11 @@ function SaveButton({ disabled, label }: { disabled: boolean; label: string }) {
 }
 
 function cloneDepartments(departments: StaffDepartment[]): StaffDepartment[] {
-  return departments.map(department => ({
-    name: department.name,
-    subRoles: [...department.subRoles],
-  }));
+  return departments.map((department) => ({ name: department.name }));
 }
 
 function roleUsesDepartment(role: string, departmentName: string): boolean {
   return getRoleDepartment(role) === departmentName;
-}
-
-function roleLabel(departmentName: string, subRole?: string | null): string {
-  return subRole ? `${departmentName} / ${subRole}` : departmentName;
 }
 
 function DepartmentRolePicker({
@@ -222,49 +215,23 @@ function DepartmentRolePicker({
   onChange: (role: string) => void;
 }) {
   return (
-    <div className="space-y-3">
+    <div className="grid gap-2 sm:grid-cols-2">
       {departments.map(department => {
         const departmentSelected = value === department.name;
         return (
-          <div key={department.name} className="rounded-xl border border-border bg-muted/20 p-3 space-y-2">
-            <button
-              type="button"
-              onClick={() => onChange(department.name)}
-              className={cn(
-                "w-full flex items-center justify-between gap-3 rounded-lg px-3 py-2 text-left text-sm font-medium transition-colors border",
-                departmentSelected
-                  ? "bg-sage text-primary-foreground border-sage"
-                  : "bg-card border-border text-foreground hover:border-sage/40",
-              )}
-            >
-              <span>{department.name}</span>
-              <span className="text-[10px] uppercase tracking-[0.18em] opacity-70">Department</span>
-            </button>
-            {department.subRoles.length > 0 && (
-              <div className="grid gap-2 pl-3 border-l border-border">
-                {department.subRoles.map(subRole => {
-                  const roleValue = roleLabel(department.name, subRole);
-                  const selected = value === roleValue;
-                  return (
-                    <button
-                      key={roleValue}
-                      type="button"
-                      onClick={() => onChange(roleValue)}
-                      className={cn(
-                        "w-full flex items-center justify-between gap-3 rounded-lg px-3 py-2 text-left text-xs font-medium transition-colors border",
-                        selected
-                          ? "bg-sage-light text-sage-deep border-sage"
-                          : "bg-card border-border text-muted-foreground hover:border-sage/40",
-                      )}
-                    >
-                      <span>{subRole}</span>
-                      <span className="text-[10px] uppercase tracking-[0.18em] opacity-70">Sub-role</span>
-                    </button>
-                  );
-                })}
-              </div>
+          <button
+            key={department.name}
+            type="button"
+            onClick={() => onChange(department.name)}
+            className={cn(
+              "w-full rounded-xl border px-3 py-3 text-left text-sm font-medium transition-colors",
+              departmentSelected
+                ? "bg-sage text-primary-foreground border-sage"
+                : "bg-card border-border text-foreground hover:border-sage/40",
             )}
-          </div>
+          >
+            {department.name}
+          </button>
         );
       })}
     </div>
@@ -313,7 +280,7 @@ function StaffProfileModal({
   const [firstName, setFirstName] = useState(profile?.first_name ?? "");
   const [lastName, setLastName] = useState(profile?.last_name ?? "");
   const [locationId, setLocationId] = useState(profile?.location_id ?? locations[0]?.id ?? "");
-  const [role, setRole] = useState(profile?.role ?? departments[0]?.name ?? "");
+  const [role, setRole] = useState(getRoleDepartment(profile?.role ?? departments[0]?.name ?? ""));
   // New staff: generate a PIN upfront; editing: leave empty (only set if manager enters a new one)
   const [pin, setPin] = useState(() => isEdit ? "" : generatePin());
 
@@ -998,7 +965,8 @@ function MyLocationTab({
               </p>
             </div>
           ) : filteredStaff.map(sp => {
-            const roleColor = ROLE_COLOR_MAP[sp.role] ?? "bg-muted text-muted-foreground";
+            const displayRole = getRoleDepartment(sp.role);
+            const roleColor = ROLE_COLOR_MAP[displayRole] ?? "bg-muted text-muted-foreground";
             return (
               <div key={sp.id} className="flex items-center gap-3 px-4 py-3">
                 <div className="w-9 h-9 rounded-full bg-sage-light flex items-center justify-center text-xs font-semibold text-sage-deep shrink-0">
@@ -1010,7 +978,7 @@ function MyLocationTab({
                      title={daysAgoTooltip(sp.last_used_at)}>{daysAgo(sp.last_used_at)}</p>
                 </div>
                 <span className={cn("text-xs px-2 py-0.5 rounded-full font-medium whitespace-nowrap", roleColor)}>
-                  {sp.role}
+                  {displayRole}
                 </span>
                 {sp.status === "active" ? (
                   <>
@@ -1203,6 +1171,7 @@ function AccountTab({
   const [passwordSaving, setPasswordSaving] = useState(false);
   const [pinSaving, setPinSaving] = useState(false);
   const [selectedActiveLocationIds, setSelectedActiveLocationIds] = useState<string[]>(activeLocationIds);
+  const [committedActiveLocationIds, setCommittedActiveLocationIds] = useState<string[]>(activeLocationIds);
 
   useEffect(() => {
     setProfileName(authUserName ?? currentAccount?.name ?? "");
@@ -1211,6 +1180,10 @@ function AccountTab({
 
   useEffect(() => {
     setSelectedActiveLocationIds(activeLocationIds);
+  }, [activeLocationIds]);
+
+  useEffect(() => {
+    setCommittedActiveLocationIds(activeLocationIds);
   }, [activeLocationIds]);
 
   const toggleExpand = (id: string, member: TeamMember) => {
@@ -1300,14 +1273,12 @@ function AccountTab({
 
   // Department management
   const [renamingDepartment, setRenamingDepartment] = useState<{ index: number; value: string } | null>(null);
-  const [renamingSubRole, setRenamingSubRole] = useState<{ departmentIndex: number; subRoleIndex: number; value: string } | null>(null);
   const [newDepartmentName, setNewDepartmentName] = useState("");
-  const [newSubRoleNames, setNewSubRoleNames] = useState<Record<number, string>>({});
 
   const addDepartment = () => {
     const trimmed = newDepartmentName.trim();
     if (!trimmed || departments.some(d => d.name.toLowerCase() === trimmed.toLowerCase())) return;
-    setDepartments(prev => [...prev, { name: trimmed, subRoles: [] }]);
+    setDepartments(prev => [...prev, { name: trimmed }]);
     setNewDepartmentName("");
   };
 
@@ -1325,52 +1296,12 @@ function AccountTab({
     setDepartments(prev => prev.filter((_, i) => i !== index));
   };
 
-  const addSubRole = (departmentIndex: number) => {
-    const trimmed = (newSubRoleNames[departmentIndex] ?? "").trim();
-    if (!trimmed) return;
-    const department = departments[departmentIndex];
-    if (!department || department.subRoles.some(subRole => subRole.toLowerCase() === trimmed.toLowerCase())) return;
-    setDepartments(prev => prev.map((dept, i) => (
-      i === departmentIndex
-        ? { ...dept, subRoles: [...dept.subRoles, trimmed] }
-        : dept
-    )));
-    setNewSubRoleNames(prev => ({ ...prev, [departmentIndex]: "" }));
-  };
-
-  const renameSubRole = (departmentIndex: number, subRoleIndex: number, newName: string) => {
-    const trimmed = newName.trim();
-    const department = departments[departmentIndex];
-    if (!department) return;
-    if (!trimmed || department.subRoles.some((subRole, i) => i !== subRoleIndex && subRole.toLowerCase() === trimmed.toLowerCase())) return;
-    const previousSubRole = department.subRoles[subRoleIndex];
-    if (staffProfiles.some(sp => sp.role === roleLabel(department.name, previousSubRole))) return;
-    setDepartments(prev => prev.map((dept, i) => (
-      i === departmentIndex
-        ? { ...dept, subRoles: dept.subRoles.map((subRole, i2) => (i2 === subRoleIndex ? trimmed : subRole)) }
-        : dept
-    )));
-    setRenamingSubRole(null);
-  };
-
-  const deleteSubRole = (departmentIndex: number, subRoleIndex: number) => {
-    const department = departments[departmentIndex];
-    const subRole = department?.subRoles[subRoleIndex];
-    if (!department || !subRole) return;
-    if (staffProfiles.some(sp => sp.role === roleLabel(department.name, subRole))) return;
-    setDepartments(prev => prev.map((dept, i) => (
-      i === departmentIndex
-        ? { ...dept, subRoles: dept.subRoles.filter((_, i2) => i2 !== subRoleIndex) }
-        : dept
-    )));
-  };
-
   // Plan limit check — checked here so the "Add" button can be disabled-adjacent.
   // The modal itself lives at Admin level (outside Layout) so position:fixed is
   // viewport-relative and not trapped inside the animate-fade-in containing block.
   const maxLocations = locationLimit;
   const atLocationLimit = maxLocations !== -1 && locations.length >= maxLocations;
-  const activeLocationSet = new Set(activeLocationIds);
+  const activeLocationSet = new Set(committedActiveLocationIds);
   const inactiveLocationSet = new Set(inactiveLocationIds);
   const graceDeadlineLabel = locationGraceEndsAt
     ? new Date(locationGraceEndsAt).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" })
@@ -1408,6 +1339,7 @@ function AccountTab({
     }
     try {
       await onSaveActiveLocations(selectedActiveLocationIds);
+      setCommittedActiveLocationIds(selectedActiveLocationIds);
       toast.success("Active locations updated");
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Could not update active locations");
@@ -1663,11 +1595,26 @@ function AccountTab({
         )}
         <div className="card-surface divide-y divide-border">
           {locations.map(loc => (
-            <div key={loc.id} className="flex items-center gap-3 px-4 py-4">
-              <MapPin size={15} className="text-sage shrink-0" />
+            <div
+              key={loc.id}
+              className={cn(
+                "flex items-center gap-3 px-4 py-4 transition-colors",
+                inactiveLocationSet.has(loc.id) && "bg-muted/35 opacity-65",
+              )}
+            >
+              <MapPin
+                size={15}
+                className={cn("shrink-0", inactiveLocationSet.has(loc.id) ? "text-muted-foreground" : "text-sage")}
+              />
               <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium text-foreground">{loc.name}</p>
-                {loc.address && <p className="text-xs text-muted-foreground truncate">{loc.address}</p>}
+                <p className={cn("text-sm font-medium", inactiveLocationSet.has(loc.id) ? "text-muted-foreground" : "text-foreground")}>
+                  {loc.name}
+                </p>
+                {loc.address && (
+                  <p className={cn("text-xs truncate", inactiveLocationSet.has(loc.id) ? "text-muted-foreground/80" : "text-muted-foreground")}>
+                    {loc.address}
+                  </p>
+                )}
                 {isLocationOverLimit && (
                   <div className="flex flex-wrap gap-2 mt-2">
                     {activeLocationSet.has(loc.id) ? (
@@ -1686,7 +1633,10 @@ function AccountTab({
               <button
                 onClick={() => onEditLocation(loc)}
                 disabled={inactiveLocationSet.has(loc.id)}
-                className="p-1.5 rounded-lg hover:bg-muted transition-colors"
+                className={cn(
+                  "p-1.5 rounded-lg transition-colors",
+                  inactiveLocationSet.has(loc.id) ? "cursor-not-allowed" : "hover:bg-muted",
+                )}
               >
                 <Pencil size={14} className={cn("text-muted-foreground", inactiveLocationSet.has(loc.id) && "opacity-40")} />
               </button>
@@ -1849,6 +1799,9 @@ function AccountTab({
       {/* Department Management */}
       <section>
         <p className="section-label mb-3">Department management</p>
+        <p className="text-xs text-muted-foreground mb-3">
+          Staff roles are managed at the department level only.
+        </p>
         <div className="space-y-3">
           {departments.map((department, departmentIndex) => {
             const departmentInUse = staffProfiles.some(sp => roleUsesDepartment(sp.role, department.name));
@@ -1888,9 +1841,7 @@ function AccountTab({
                     <>
                       <div className="flex-1 min-w-0">
                         <p className="text-sm font-medium text-foreground">{department.name}</p>
-                        <p className="text-[11px] text-muted-foreground mt-0.5">
-                          {department.subRoles.length} sub-role{department.subRoles.length === 1 ? "" : "s"}
-                        </p>
+                        <p className="text-[11px] text-muted-foreground mt-0.5">Department role</p>
                       </div>
                       <button
                         onClick={() => setRenamingDepartment({ index: departmentIndex, value: department.name })}
@@ -1911,97 +1862,6 @@ function AccountTab({
                       </button>
                     </>
                   )}
-                </div>
-
-                <div className="space-y-2 pl-1">
-                  {department.subRoles.length === 0 ? (
-                    <p className="text-xs text-muted-foreground">No sub-roles yet.</p>
-                  ) : department.subRoles.map((subRole, subRoleIndex) => {
-                    const role = roleLabel(department.name, subRole);
-                    const isSubRoleInUse = staffProfiles.some(sp => sp.role === role);
-                    const isRenamingSubRole = renamingSubRole?.departmentIndex === departmentIndex && renamingSubRole.subRoleIndex === subRoleIndex;
-                    return (
-                      <div key={role} className="flex items-center gap-2 pl-3 border-l border-border">
-                        {isRenamingSubRole ? (
-                          <>
-                            <input
-                              autoFocus
-                              type="text"
-                              value={renamingSubRole.value}
-                              onChange={e => setRenamingSubRole({
-                                departmentIndex,
-                                subRoleIndex,
-                                value: e.target.value,
-                              })}
-                              onKeyDown={e => {
-                                if (e.key === "Enter") {
-                                  e.preventDefault();
-                                  renameSubRole(departmentIndex, subRoleIndex, renamingSubRole.value);
-                                }
-                              }}
-                              className="flex-1 border border-border rounded-lg px-3 py-1.5 text-sm bg-muted focus:outline-none focus:ring-1 focus:ring-ring"
-                            />
-                            <button
-                              onClick={() => renameSubRole(departmentIndex, subRoleIndex, renamingSubRole.value)}
-                              className="p-1.5 rounded-lg hover:bg-muted transition-colors"
-                            >
-                              <Check size={14} className="text-sage" />
-                            </button>
-                            <button
-                              onClick={() => setRenamingSubRole(null)}
-                              className="p-1.5 rounded-lg hover:bg-muted transition-colors"
-                            >
-                              <X size={14} className="text-muted-foreground" />
-                            </button>
-                          </>
-                        ) : (
-                          <>
-                            <p className="flex-1 text-sm text-foreground">{subRole}</p>
-                            <button
-                              onClick={() => setRenamingSubRole({ departmentIndex, subRoleIndex, value: subRole })}
-                              className="p-1.5 rounded-lg hover:bg-muted transition-colors"
-                            >
-                              <Pencil size={14} className="text-muted-foreground" />
-                            </button>
-                            <button
-                              onClick={() => deleteSubRole(departmentIndex, subRoleIndex)}
-                              disabled={isSubRoleInUse}
-                              title={isSubRoleInUse ? "Sub-role is in use" : "Delete sub-role"}
-                              className={cn(
-                                "p-1.5 rounded-lg transition-colors",
-                                isSubRoleInUse ? "opacity-30 cursor-not-allowed" : "hover:bg-muted",
-                              )}
-                            >
-                              <Trash2 size={14} className="text-status-error" />
-                            </button>
-                          </>
-                        )}
-                      </div>
-                    );
-                  })}
-                </div>
-
-                <div className="flex items-center gap-2">
-                  <input
-                    type="text"
-                    value={newSubRoleNames[departmentIndex] ?? ""}
-                    onChange={e => setNewSubRoleNames(prev => ({ ...prev, [departmentIndex]: e.target.value }))}
-                    placeholder="Add sub-role…"
-                    onKeyDown={e => { if (e.key === "Enter") { e.preventDefault(); addSubRole(departmentIndex); } }}
-                    className="flex-1 border border-border rounded-lg px-3 py-1.5 text-sm bg-muted focus:outline-none focus:ring-1 focus:ring-ring"
-                  />
-                  <button
-                    onClick={() => addSubRole(departmentIndex)}
-                    disabled={!(newSubRoleNames[departmentIndex] ?? "").trim()}
-                    className={cn(
-                      "p-1.5 rounded-lg transition-colors",
-                      (newSubRoleNames[departmentIndex] ?? "").trim()
-                        ? "bg-sage text-primary-foreground hover:bg-sage-deep"
-                        : "bg-muted text-muted-foreground cursor-not-allowed",
-                    )}
-                  >
-                    <Plus size={14} />
-                  </button>
                 </div>
               </div>
             );

--- a/src/test/lib/admin-repository.test.ts
+++ b/src/test/lib/admin-repository.test.ts
@@ -178,16 +178,18 @@ describe("DEFAULT_PERMISSIONS", () => {
 });
 
 describe("DEFAULT_STAFF_ROLES", () => {
-  it("contains the default department hierarchy and sub-roles", () => {
+  it("contains the default department roles", () => {
     expect(DEFAULT_STAFF_DEPARTMENTS.map(d => d.name)).toEqual([
       "Front of House",
       "Back of House",
       "Management",
       "Cleaning Crew",
     ]);
-    expect(DEFAULT_STAFF_ROLES).toContain("Front of House");
-    expect(DEFAULT_STAFF_ROLES).toContain("Front of House / Bartender");
-    expect(DEFAULT_STAFF_ROLES).toContain("Back of House / Chef");
-    expect(DEFAULT_STAFF_ROLES).toContain("Cleaning Crew / Cleaner");
+    expect(DEFAULT_STAFF_ROLES).toEqual([
+      "Front of House",
+      "Back of House",
+      "Management",
+      "Cleaning Crew",
+    ]);
   });
 });

--- a/src/test/pages/Admin.test.tsx
+++ b/src/test/pages/Admin.test.tsx
@@ -88,8 +88,8 @@ const mockLocations = [
 ];
 
 const mockStaff = [
-  { id: "sp1", location_id: "l1", first_name: "Alice", last_name: "Smith", role: "Front of House / Server", status: "active", pin: "1234", last_used_at: null, archived_at: null, created_at: "2024-01-01T00:00:00Z" },
-  { id: "sp2", location_id: "l1", first_name: "Bob", last_name: "Jones", role: "Back of House / Chef", status: "archived", pin: "5678", last_used_at: "2024-02-01T00:00:00Z", archived_at: "2024-02-15T00:00:00Z", created_at: "2024-01-01T00:00:00Z" },
+  { id: "sp1", location_id: "l1", first_name: "Alice", last_name: "Smith", role: "Front of House", status: "active", pin: "1234", last_used_at: null, archived_at: null, created_at: "2024-01-01T00:00:00Z" },
+  { id: "sp2", location_id: "l1", first_name: "Bob", last_name: "Jones", role: "Back of House", status: "archived", pin: "5678", last_used_at: "2024-02-01T00:00:00Z", archived_at: "2024-02-15T00:00:00Z", created_at: "2024-01-01T00:00:00Z" },
 ];
 
 const mockTeam = [
@@ -207,10 +207,10 @@ describe("Admin page", () => {
   });
 
   // 8. Staff role badge shows department-based label
-  it("shows Alice Smith's role as Front of House / Server", async () => {
+  it("shows Alice Smith's role as Front of House", async () => {
     renderWithProviders(<Admin />, { initialEntries: ["/admin/location"] });
     await waitFor(() => {
-      const roleBadges = screen.getAllByText("Front of House / Server");
+      const roleBadges = screen.getAllByText("Front of House");
       expect(roleBadges.length).toBeGreaterThanOrEqual(1);
     });
   });
@@ -684,6 +684,15 @@ describe("Admin page", () => {
     });
   });
 
+  it("Department management no longer shows sub-role controls", async () => {
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
+    await waitFor(() => {
+      expect(screen.getByText("Department management")).toBeInTheDocument();
+    });
+    expect(screen.queryByPlaceholderText("Add sub-role…")).not.toBeInTheDocument();
+    expect(screen.queryByText(/sub-role/i)).not.toBeInTheDocument();
+  });
+
   // 42. Add department input exists
   it("Account tab has 'Add department' input", async () => {
     renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
@@ -705,6 +714,41 @@ describe("Admin page", () => {
     renderWithProviders(<Admin />);
     await waitFor(() => {
       expect(screen.getByText(/Launch Kiosk Mode/i)).toBeInTheDocument();
+    });
+  });
+
+  it("Account tab marks inactive over-limit locations as read-only", async () => {
+    mockUseLocations.mockReturnValue({
+      data: [mockLocations[1]],
+      allLocations: mockLocations,
+      inactiveLocations: [mockLocations[0]],
+      maxLocations: 1,
+      isOverLimit: true,
+      graceEndsAt: new Date(Date.now() - 60_000).toISOString(),
+      isGraceActive: false,
+      isGraceExpired: true,
+      effectiveActiveLocationIds: ["l2"],
+      isLoading: false,
+    });
+
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
+
+    await waitFor(() => {
+      expect(screen.getByText("Read-only")).toBeInTheDocument();
+      expect(screen.getAllByText("Active").length).toBeGreaterThan(0);
+    });
+
+    mockUseLocations.mockReturnValue({
+      data: mockLocations,
+      allLocations: mockLocations,
+      inactiveLocations: [],
+      maxLocations: 10,
+      isOverLimit: false,
+      graceEndsAt: null,
+      isGraceActive: false,
+      isGraceExpired: false,
+      effectiveActiveLocationIds: mockLocations.map((location) => location.id),
+      isLoading: false,
     });
   });
 


### PR DESCRIPTION
## Summary
- make active-location saves fail loudly if the organization update does not actually persist
- immediately reflect saved active/inactive location state in Admin and dim read-only locations after a downgrade
- remove sub-role management so departments are flat roles only
- normalize legacy staff role labels to department-level labels in the admin UI

## Testing
- bun run test src/test/pages/Admin.test.tsx src/test/lib/admin-repository.test.ts src/test/hooks/useLocations.test.tsx
- bun run build
- bun run lint

Closes #137
Closes #138