### PR TITLE
Fix kiosk checklist refresh and dialog sizing

### DIFF
--- a/src/pages/Kiosk.tsx
+++ b/src/pages/Kiosk.tsx
@@ -120,6 +120,12 @@ function dbToKioskChecklist(raw: any): KioskChecklist {
   };
 }
 
+async function fetchKioskChecklists(locationId: string) {
+  const { data, error } = await supabase.rpc("get_kiosk_checklists", { p_location_id: locationId });
+  if (error) throw error;
+  return (data ?? []).map(dbToKioskChecklist);
+}
+
 function parseTimeToMinutes(time: string | null | undefined): number | null {
   if (!time) return null;
   const [h, m] = time.split(":").map(Number);
@@ -1761,6 +1767,39 @@ export default function Kiosk() {
   const [checklistsLoading, setChecklistsLoading] = useState(false);
   const [checklistsError, setChecklistsError] = useState<string | null>(null);
 
+  useEffect(() => {
+    if (!locationId) return;
+    let cancelled = false;
+
+    supabase
+      .from("locations")
+      .select("id, name")
+      .eq("id", locationId)
+      .maybeSingle()
+      .then(({ data }) => {
+        if (cancelled) return;
+        if (data?.id) {
+          if (data.name && data.name !== locationName) {
+            _kioskLocationName = data.name;
+            localStorage.setItem("kiosk_location_name", data.name);
+            setLocationName(data.name);
+          }
+          return;
+        }
+        _kioskLocationId = null;
+        _kioskLocationName = null;
+        localStorage.removeItem("kiosk_location_id");
+        localStorage.removeItem("kiosk_location_name");
+        setLocationId(null);
+        setLocationName("");
+        setKioskChecklists([]);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [locationId, locationName]);
+
   // Drain any queued submissions from previous offline sessions.
   // Legacy queue entries may contain location_id values that reference mock/test
   // location UUIDs which fail the FK constraint — strip it so those entries can
@@ -1777,22 +1816,50 @@ export default function Kiosk() {
     });
   }, [locationId]);
 
-  // Fetch checklists for the selected location whenever it changes
+  // Fetch checklists for the selected location whenever it changes and keep the
+  // grid fresh when the kiosk regains focus after checklist/admin edits.
   useEffect(() => {
     if (!locationId) return;
-    setChecklistsLoading(true);
-    setChecklistsError(null);
-    supabase
-      .rpc("get_kiosk_checklists", { p_location_id: locationId })
-      .then(({ data, error }) => {
-        if (error) {
-          console.error("get_kiosk_checklists failed:", error.message);
-          setChecklistsError("Could not load checklists. Check your connection and try again.");
-        } else {
-          setKioskChecklists((data ?? []).map(dbToKioskChecklist));
+    let cancelled = false;
+
+    const load = async (showSpinner = false) => {
+      if (showSpinner) setChecklistsLoading(true);
+      setChecklistsError(null);
+      try {
+        const next = await fetchKioskChecklists(locationId);
+        if (!cancelled) {
+          setKioskChecklists(next);
         }
-        setChecklistsLoading(false);
-      });
+      } catch (error: any) {
+        if (!cancelled) {
+          console.error("get_kiosk_checklists failed:", error?.message ?? error);
+          setChecklistsError("Could not load checklists. Check your connection and try again.");
+        }
+      } finally {
+        if (!cancelled && showSpinner) setChecklistsLoading(false);
+      }
+    };
+
+    const handleFocusRefresh = () => {
+      void load(false);
+    };
+    const handleVisibility = () => {
+      if (document.visibilityState === "visible") {
+        void load(false);
+      }
+    };
+
+    void load(true);
+    const intervalId = window.setInterval(() => void load(false), 30000);
+    window.addEventListener("focus", handleFocusRefresh);
+    document.addEventListener("visibilitychange", handleVisibility);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+      window.removeEventListener("focus", handleFocusRefresh);
+      document.removeEventListener("visibilitychange", handleVisibility);
+    };
   }, [locationId]);
 
   const handleSetup = (id: string, name: string) => {
@@ -2050,13 +2117,12 @@ export default function Kiosk() {
               onClick={() => {
                 setChecklistsError(null);
                 setChecklistsLoading(true);
-                supabase
-                  .rpc("get_kiosk_checklists", { p_location_id: locationId! })
-                  .then(({ data, error }) => {
-                    if (error) setChecklistsError("Retry failed. Check your connection.");
-                    else setKioskChecklists((data ?? []).map(dbToKioskChecklist));
-                    setChecklistsLoading(false);
-                  });
+                fetchKioskChecklists(locationId!)
+                  .then((data) => {
+                    setKioskChecklists(data);
+                  })
+                  .catch(() => setChecklistsError("Retry failed. Check your connection."))
+                  .finally(() => setChecklistsLoading(false));
               }}
               className="px-4 py-2 text-xs font-semibold rounded-xl border border-border hover:bg-muted transition-colors"
             >

--- a/src/pages/checklists/ConvertFileModal.tsx
+++ b/src/pages/checklists/ConvertFileModal.tsx
@@ -84,10 +84,14 @@ export function ConvertFileModal({ onClose, onConvert }: { onClose: () => void; 
   };
 
   return (
-    // No pb-16 on outer wrapper — that created a dead zone covered by the bottom nav.
-    // The card itself has pb-safe to clear nav on mobile.
-    <div className="fixed inset-0 z-[60] flex items-end justify-center bg-foreground/20 backdrop-blur-sm animate-fade-in" onClick={onClose}>
-      <div className="bg-card w-full rounded-t-2xl p-5 pb-safe space-y-5 animate-fade-in" onClick={e => e.stopPropagation()}>
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-foreground/20 p-4 backdrop-blur-sm animate-fade-in sm:p-6"
+      onClick={onClose}
+    >
+      <div
+        className="bg-card w-full max-w-3xl rounded-2xl p-5 pb-safe shadow-2xl space-y-5 animate-fade-in sm:rounded-3xl sm:p-6"
+        onClick={e => e.stopPropagation()}
+      >
         <div className="flex items-center justify-between">
           <h2 className="font-display text-lg text-foreground">Convert file to checklist</h2>
           <button

--- a/src/test/pages/Kiosk.test.tsx
+++ b/src/test/pages/Kiosk.test.tsx
@@ -29,53 +29,74 @@ vi.mock("@/lib/supabase", () => ({
       onAuthStateChange: vi.fn().mockReturnValue({ data: { subscription: { unsubscribe: vi.fn() } } }),
     },
     from: vi.fn((table: string) => {
+      let eqValue: string | null = null;
       if (table === "alerts") {
-        return {
+        const chain: any = {
           select: vi.fn().mockReturnThis(),
           order: vi.fn().mockReturnThis(),
-          eq: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockImplementation((_: string, value: string) => {
+            eqValue = value;
+            return chain;
+          }),
           single: vi.fn().mockResolvedValue({ data: null, error: null }),
+          maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
           insert: alertsInsert,
           update: vi.fn().mockReturnThis(),
           upsert: vi.fn().mockResolvedValue({ error: null }),
           delete: vi.fn().mockReturnThis(),
           then: vi.fn().mockImplementation((cb) => Promise.resolve(cb({ data: [], error: null }))),
         };
+        return chain;
       }
 
       if (table === "checklist_logs") {
-        return {
+        const chain: any = {
           select: vi.fn().mockReturnThis(),
           order: vi.fn().mockReturnThis(),
-          eq: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockImplementation((_: string, value: string) => {
+            eqValue = value;
+            return chain;
+          }),
           single: vi.fn().mockResolvedValue({ data: null, error: null }),
+          maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
           insert: checklistLogsInsert,
           update: vi.fn().mockReturnThis(),
           upsert: vi.fn().mockResolvedValue({ error: null }),
           delete: vi.fn().mockReturnThis(),
           then: vi.fn().mockImplementation((cb) => Promise.resolve(cb({ data: [], error: null }))),
         };
+        return chain;
       }
 
-      return {
+      const locations = [
+        { id: "00000000-0000-0000-0000-000000000011", name: "Terrace" },
+        { id: "00000000-0000-0000-0000-000000000010", name: "Grand Ballroom" },
+      ];
+
+      const chain: any = {
         select: vi.fn().mockReturnThis(),
         order: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockImplementation((_: string, value: string) => {
+          eqValue = value;
+          return chain;
+        }),
         single: vi.fn().mockResolvedValue({ data: null, error: null }),
+        maybeSingle: vi.fn().mockImplementation(() => Promise.resolve({
+          data: table === "locations" ? locations.find((location) => location.id === eqValue) ?? null : null,
+          error: null,
+        })),
         insert: vi.fn().mockResolvedValue({ error: null }),
         update: vi.fn().mockReturnThis(),
         upsert: vi.fn().mockResolvedValue({ error: null }),
         delete: vi.fn().mockReturnThis(),
         then: vi.fn().mockImplementation((cb) =>
           Promise.resolve(cb({
-            data: [
-              { id: "00000000-0000-0000-0000-000000000011", name: "Terrace" },
-              { id: "00000000-0000-0000-0000-000000000010", name: "Grand Ballroom" },
-            ],
+            data: locations,
             error: null,
           }))
         ),
       };
+      return chain;
     }),
     rpc: vi.fn().mockImplementation((fn: string) => {
       if (fn === "get_kiosk_checklists") {

--- a/src/test/pages/checklists/ConvertFileModal.test.tsx
+++ b/src/test/pages/checklists/ConvertFileModal.test.tsx
@@ -43,8 +43,9 @@ describe("ConvertFileModal", () => {
   });
 
   it("renders without crashing", () => {
-    render(<ConvertFileModal onClose={onClose} onConvert={onConvert} />);
+    const { container } = render(<ConvertFileModal onClose={onClose} onConvert={onConvert} />);
     expect(screen.getByText("Convert file to checklist")).toBeInTheDocument();
+    expect(container.querySelector(".max-w-3xl")).toBeInTheDocument();
   });
 
   it("shows file upload instruction", () => {


### PR DESCRIPTION
Closes #164
Closes #165

## Summary
- tighten the convert-file modal to a standard centered desktop width
- refresh kiosk checklist data on focus, visibility changes, and a short poll interval
- clear stale stored kiosk location assignments that no longer resolve for the current session

## Verification
- bun run test src/test/pages/Kiosk.test.tsx src/test/pages/checklists/ConvertFileModal.test.tsx
- bun run build