### PR TITLE
Fix kiosk checklist visibility and admin PIN recovery

### DIFF
--- a/src/hooks/useChecklists.ts
+++ b/src/hooks/useChecklists.ts
@@ -15,6 +15,7 @@ export interface ChecklistItem {
   folder_id: string | null;
   location_id: string | null;
   location_ids?: string[] | null;
+  start_date: string | null;
   schedule: any;
   sections: any[];
   time_of_day: "morning" | "afternoon" | "evening" | "anytime";
@@ -77,7 +78,7 @@ export function useChecklists() {
     queryFn: async () => {
       const { data, error } = await supabase
         .from("checklists")
-        .select("id, title, folder_id, location_id, location_ids, schedule, sections, time_of_day, due_time, visibility_from, visibility_until, created_at, updated_at")
+        .select("id, title, folder_id, location_id, location_ids, start_date, schedule, sections, time_of_day, due_time, visibility_from, visibility_until, created_at, updated_at")
         .order("title");
       if (error) throw error;
       return (data ?? []) as ChecklistItem[];
@@ -97,6 +98,7 @@ export function useSaveChecklist() {
         folder_id: checklist.folder_id ?? null,
         location_id: checklist.location_id ?? null,
         location_ids: checklist.location_ids ?? null,
+        start_date: checklist.start_date ?? null,
         schedule: checklist.schedule ?? null,
         sections: checklist.sections ?? [],
         time_of_day: "anytime",              // always anytime — kiosk uses visibility fields instead

--- a/src/hooks/useTeamMembers.ts
+++ b/src/hooks/useTeamMembers.ts
@@ -29,16 +29,47 @@ export function useSaveTeamMember() {
   const { teamMember } = useAuth();
   return useMutation({
     mutationFn: async (tm: Partial<TeamMember> & { id?: string; rawPin?: string }) => {
-      const { error } = await supabase.from("team_members").upsert({
-        id: tm.id || undefined,
-        organization_id: teamMember!.organization_id,
+      if (!teamMember) {
+        throw new Error("Your account setup is not complete. Please refresh the page and try again.");
+      }
+
+      if (tm.id) {
+        const updatePayload: Record<string, unknown> = {
+          name: tm.name,
+          email: tm.email,
+          role: tm.role ?? "Manager",
+          location_ids: tm.location_ids ?? [],
+          permissions: tm.permissions ?? DEFAULT_PERMISSIONS,
+        };
+        if (tm.rawPin) {
+          updatePayload.pin = await hashPin(tm.rawPin);
+        }
+
+        const { data: updated, error } = await supabase
+          .from("team_members")
+          .update(updatePayload)
+          .eq("id", tm.id)
+          .select("id");
+        if (error) throw error;
+        if (!updated || updated.length === 0) {
+          throw new Error("Account update failed. Please refresh the page and try again.");
+        }
+        return;
+      }
+
+      const insertPayload: Record<string, unknown> = {
+        organization_id: teamMember.organization_id,
         name: tm.name,
         email: tm.email,
         role: tm.role ?? "Manager",
         location_ids: tm.location_ids ?? [],
         permissions: tm.permissions ?? DEFAULT_PERMISSIONS,
-        ...(tm.rawPin ? { pin: await hashPin(tm.rawPin) } : {}),
-      });
+      };
+      if (tm.rawPin) {
+        insertPayload.pin = await hashPin(tm.rawPin);
+      }
+
+      const { error } = await supabase.from("team_members").insert(insertPayload);
       if (error) throw error;
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ["team_members"] }),

--- a/src/pages/Kiosk.tsx
+++ b/src/pages/Kiosk.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { X, Check, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { supabase } from "@/lib/supabase";
+import { runtimeConfig } from "@/lib/runtime-config";
 import { enqueueLog, drainQueue } from "@/lib/submission-queue";
 import { getLinkableInfohubResource } from "@/lib/infohub-catalog";
 
@@ -122,6 +123,37 @@ function dbToKioskChecklist(raw: any): KioskChecklist {
 
 async function fetchKioskChecklists(locationId: string) {
   const { data, error } = await supabase.rpc("get_kiosk_checklists", { p_location_id: locationId });
+  if (!error && (data?.length ?? 0) > 0) {
+    return (data ?? []).map(dbToKioskChecklist);
+  }
+
+  // Kiosk is a public operational surface. When an authenticated browser
+  // session has stale org context, the authenticated RPC path can return an
+  // empty set even though the anon kiosk RPC still has the correct result for
+  // the selected location. Retry anonymously so kiosk visibility does not
+  // depend on whichever admin session was previously open in the tab.
+  if (!import.meta.env.TEST) {
+    try {
+      const response = await fetch(`${runtimeConfig.supabaseUrl}/rest/v1/rpc/get_kiosk_checklists`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          apikey: runtimeConfig.supabaseAnonKey,
+          Authorization: `Bearer ${runtimeConfig.supabaseAnonKey}`,
+        },
+        body: JSON.stringify({ p_location_id: locationId }),
+      });
+      if (response.ok) {
+        const anonData = await response.json();
+        if (Array.isArray(anonData)) {
+          return anonData.map(dbToKioskChecklist);
+        }
+      }
+    } catch {
+      // Fall back to the original RPC error below.
+    }
+  }
+
   if (error) throw error;
   return (data ?? []).map(dbToKioskChecklist);
 }
@@ -384,6 +416,12 @@ function AdminLoginModal({ onClose }: { onClose: () => void }) {
     navigate(`/admin?from=kiosk&userId=${data[0].id}`);
   };
 
+  const handlePinRecovery = async () => {
+    await supabase.auth.signOut();
+    onClose();
+    navigate("/login?reason=reset-pin");
+  };
+
   return (
     <div
       className="fixed inset-0 z-[60] flex items-center justify-center bg-foreground/20 backdrop-blur-sm"
@@ -430,12 +468,12 @@ function AdminLoginModal({ onClose }: { onClose: () => void }) {
           </button>
         </form>
         <p className="text-center text-xs text-muted-foreground pt-1">
-          New to Olia?{" "}
+          Forgot your PIN?{" "}
           <button
-            onClick={() => { onClose(); navigate("/signup"); }}
+            onClick={() => { void handlePinRecovery(); }}
             className="text-sage font-medium hover:underline"
           >
-            Create an account
+            Log out and sign in again
           </button>
         </p>
       </div>

--- a/src/pages/checklists/ChecklistBuilderModal.tsx
+++ b/src/pages/checklists/ChecklistBuilderModal.tsx
@@ -40,6 +40,7 @@ interface ChecklistBuilderModalProps {
   initialTitle?: string;
   initialSections?: SectionDef[];
   initialLocationIds?: string[] | null;
+  initialStartDate?: string | null;
   initialVisibilityFrom?: string | null;
   initialVisibilityUntil?: string | null;
   editId?: string;
@@ -50,7 +51,7 @@ interface ChecklistBuilderModalProps {
 
 export function ChecklistBuilderModal({
   onClose, onAdd, onUpdate, initialTitle, initialSections, initialLocationIds,
-  initialVisibilityFrom, initialVisibilityUntil, editId, asPage = false,
+  initialStartDate, initialVisibilityFrom, initialVisibilityUntil, editId, asPage = false,
 }: ChecklistBuilderModalProps) {
   const createAlert = useCreateAlert();
   const { data: dbLocations = [] } = useLocations();
@@ -60,7 +61,9 @@ export function ChecklistBuilderModal({
 
   const [title, setTitle] = useState(initialTitle || "");
   const [description, setDescription] = useState("");
-  const [startDate, setStartDate] = useState<Date | undefined>(undefined);
+  const [startDate, setStartDate] = useState<Date | undefined>(
+    initialStartDate ? new Date(`${initialStartDate}T00:00:00`) : undefined,
+  );
   const [visibilityWindowEnabled, setVisibilityWindowEnabled] = useState(Boolean(initialVisibilityFrom || initialVisibilityUntil));
   const [visibilityFrom, setVisibilityFrom] = useState(initialVisibilityFrom || "09:00");
   const [visibilityUntil, setVisibilityUntil] = useState(initialVisibilityUntil || "10:00");
@@ -198,6 +201,7 @@ export function ChecklistBuilderModal({
       description: description.trim() || undefined,
       questionsCount: totalQuestions,
       schedule: schedLabel,
+      start_date: startDate ? format(startDate, "yyyy-MM-dd") : null,
       sections: sectionsWithPersonChoices,
       time_of_day: "anytime",         // visibility is handled with the explicit window below
       due_time: null,

--- a/src/pages/checklists/ChecklistsTab.tsx
+++ b/src/pages/checklists/ChecklistsTab.tsx
@@ -60,6 +60,7 @@ export function ChecklistsTab() {
     folderId: c.folder_id,
     location_id: c.location_id,
     location_ids: c.location_ids ?? (c.location_id ? [c.location_id] : null),
+    start_date: c.start_date ?? null,
     createdAt: c.created_at,
     sections: c.sections as SectionDef[],
     due_time: c.due_time ?? null,
@@ -197,6 +198,7 @@ export function ChecklistsTab() {
             folder_id: currentFolder,
             location_id: item.location_id ?? null,
             location_ids: locationIds,
+            start_date: item.start_date ?? null,
             sections: item.sections ?? [],
             schedule: item.schedule ?? null,
             time_of_day: "anytime",
@@ -214,6 +216,7 @@ export function ChecklistsTab() {
             schedule: updates.schedule ?? orig.schedule,
             location_id: updates.location_id !== undefined ? updates.location_id : orig.location_id,
             location_ids: updates.location_ids !== undefined ? updates.location_ids : orig.location_ids,
+            start_date: updates.start_date !== undefined ? updates.start_date : orig.start_date,
             time_of_day: "anytime",
             due_time: updates.due_time !== undefined ? updates.due_time : orig.due_time,
             visibility_from: updates.visibility_from !== undefined ? updates.visibility_from : (orig.visibility_from ?? null),
@@ -223,6 +226,7 @@ export function ChecklistsTab() {
         initialTitle={prefillTitle}
         initialSections={prefillSections}
         initialLocationIds={prefillLocationIds}
+        initialStartDate={editingChecklist?.start_date ?? null}
         initialVisibilityFrom={editingChecklist?.visibility_from ?? null}
         initialVisibilityUntil={editingChecklist?.visibility_until ?? null}
         editId={editingChecklistId || undefined}

--- a/src/pages/checklists/types.ts
+++ b/src/pages/checklists/types.ts
@@ -24,6 +24,7 @@ export interface ChecklistItem {
   folderId: string | null;
   location_id?: string | null;
   location_ids?: string[] | null;
+  start_date?: string | null;
   createdAt: string;
   sections?: SectionDef[];
   time_of_day?: "morning" | "afternoon" | "evening" | "anytime";

--- a/src/test/hooks/useChecklists.test.tsx
+++ b/src/test/hooks/useChecklists.test.tsx
@@ -163,6 +163,7 @@ describe("useChecklists", () => {
         title: "Opening Checklist",
         folder_id: null,
         location_id: null,
+        start_date: "2026-04-08",
         schedule: "daily",
         sections: [],
         created_at: "2026-01-01",
@@ -200,6 +201,37 @@ describe("useSaveChecklist", () => {
   it("returns a mutateAsync function", () => {
     const { result } = renderHook(() => useSaveChecklist(), { wrapper: makeWrapper() });
     expect(typeof result.current.mutateAsync).toBe("function");
+  });
+
+  it("persists a checklist start date when saving", async () => {
+    const upsert = vi.fn().mockResolvedValue({ data: [{ id: "cl-1" }], error: null });
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue({ data: [], error: null }),
+      eq: vi.fn().mockReturnThis(),
+      lte: vi.fn().mockReturnThis(),
+      gte: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null, error: null }),
+      insert: vi.fn().mockResolvedValue({ data: [{ id: "new1" }], error: null }),
+      update: vi.fn().mockReturnThis(),
+      upsert,
+      delete: vi.fn().mockReturnThis(),
+      then: vi.fn().mockImplementation((cb) =>
+        Promise.resolve(cb({ data: [], error: null }))
+      ),
+    });
+
+    const { result } = renderHook(() => useSaveChecklist(), { wrapper: makeWrapper() });
+    await result.current.mutateAsync({
+      id: "cl-1",
+      title: "Opening Checklist",
+      start_date: "2026-04-08",
+      sections: [],
+    } as any);
+
+    expect(upsert).toHaveBeenCalledWith(expect.objectContaining({
+      start_date: "2026-04-08",
+    }));
   });
 });
 

--- a/src/test/hooks/useTeamMembers.test.tsx
+++ b/src/test/hooks/useTeamMembers.test.tsx
@@ -45,7 +45,8 @@ beforeEach(() => {
     select: vi.fn().mockReturnThis(),
     eq: vi.fn().mockReturnThis(),
     order: vi.fn().mockResolvedValue({ data: [], error: null }),
-    upsert: vi.fn().mockResolvedValue({ error: null }),
+    update: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockResolvedValue({ error: null }),
     delete: vi.fn().mockReturnThis(),
   });
 });
@@ -105,12 +106,15 @@ describe("useSaveTeamMember", () => {
   });
 
   it("hashes a raw PIN before saving team members", async () => {
-    const upsert = vi.fn().mockResolvedValue({ error: null });
+    const select = vi.fn().mockResolvedValue({ data: [{ id: "tm-2" }], error: null });
+    const eq = vi.fn().mockReturnValue({ select });
+    const update = vi.fn().mockReturnValue({ eq });
     mockFrom.mockReturnValue({
       select: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
       order: vi.fn().mockResolvedValue({ data: [], error: null }),
-      upsert,
+      update,
+      insert: vi.fn().mockResolvedValue({ error: null }),
       delete: vi.fn().mockReturnThis(),
     });
 
@@ -127,13 +131,38 @@ describe("useSaveTeamMember", () => {
       } as any);
     });
 
-    expect(upsert).toHaveBeenCalledWith(
+    expect(update).toHaveBeenCalledWith(
       expect.objectContaining({
         pin: expect.any(String),
       }),
     );
-    const payload = upsert.mock.calls[0][0];
+    const payload = update.mock.calls[0][0];
     expect(payload.pin).toHaveLength(64);
+  });
+
+  it("fails loudly when an existing team member update affects no rows", async () => {
+    const select = vi.fn().mockResolvedValue({ data: [], error: null });
+    const eq = vi.fn().mockReturnValue({ select });
+    const update = vi.fn().mockReturnValue({ eq });
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue({ data: [], error: null }),
+      update,
+      insert: vi.fn().mockResolvedValue({ error: null }),
+      delete: vi.fn().mockReturnThis(),
+    });
+
+    const { result } = renderHook(() => useSaveTeamMember(), { wrapper: makeWrapper() });
+
+    await expect(result.current.mutateAsync({
+      id: "tm-2",
+      name: "Test User",
+      email: "test@example.com",
+      role: "Owner",
+      location_ids: [],
+      permissions: {},
+    } as any)).rejects.toThrow(/Account update failed/i);
   });
 });
 

--- a/src/test/pages/Kiosk.test.tsx
+++ b/src/test/pages/Kiosk.test.tsx
@@ -460,6 +460,25 @@ describe("Kiosk — Grid Screen", () => {
     });
   });
 
+  it("offers a logout-and-login recovery path instead of a signup bypass", async () => {
+    const { supabase } = await import("@/lib/supabase");
+    await renderGridScreen();
+    const adminBtn = document.getElementById("admin-btn") as HTMLButtonElement;
+    fireEvent.click(adminBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Forgot your PIN/i)).toBeInTheDocument();
+      expect(screen.queryByText(/Create an account/i)).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Log out and sign in again/i }));
+
+    await waitFor(() => {
+      expect(supabase.auth.signOut).toHaveBeenCalled();
+      expect(mockNavigate).toHaveBeenCalledWith("/login?reason=reset-pin");
+    });
+  });
+
   it("clicking backdrop of Admin Login Modal closes it", async () => {
     await renderGridScreen();
     const adminBtn = document.getElementById("admin-btn") as HTMLButtonElement;

--- a/src/test/pages/checklists/ChecklistBuilderModal.test.tsx
+++ b/src/test/pages/checklists/ChecklistBuilderModal.test.tsx
@@ -431,6 +431,26 @@ describe("ChecklistBuilderModal - new checklist", () => {
       due_time: null,
     }));
   });
+
+  it("stores the selected start date on save", async () => {
+    renderWithClient(<ChecklistBuilderModal onClose={onClose} onAdd={onAdd} />);
+
+    fireEvent.click(screen.getByText("Select start date"));
+    await waitFor(() => {
+      expect(screen.getByText("15")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("15"));
+    fireEvent.change(screen.getByPlaceholderText(/Morning Opening Checklist/), {
+      target: { value: "Date Checklist" },
+    });
+
+    fireEvent.click(screen.getByText("Create checklist"));
+
+    expect(onAdd).toHaveBeenCalledWith(expect.objectContaining({
+      title: "Date Checklist",
+      start_date: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+    }));
+  });
 });
 
 describe("ChecklistBuilderModal - edit mode", () => {
@@ -528,5 +548,19 @@ describe("ChecklistBuilderModal - edit mode", () => {
     fireEvent.click(screen.getByText("Save checklist"));
     expect(onUpdate).toHaveBeenCalledWith("cl-1", expect.objectContaining({ title: "Existing Checklist" }));
     expect(onAdd).not.toHaveBeenCalled();
+  });
+
+  it("pre-fills the saved start date in edit mode", () => {
+    renderWithClient(
+      <ChecklistBuilderModal
+        onClose={onClose}
+        onAdd={onAdd}
+        onUpdate={onUpdate}
+        editId="cl-1"
+        initialTitle="Existing Checklist"
+        initialStartDate="2026-04-08"
+      />
+    );
+    expect(screen.getByText(/Apr/i)).toBeInTheDocument();
   });
 });

--- a/supabase/migrations/20260408000002_checklists_start_date.sql
+++ b/supabase/migrations/20260408000002_checklists_start_date.sql
@@ -1,0 +1,11 @@
+-- ================================================================
+-- Persist checklist start dates.
+--
+-- The checklist builder already exposes a start-date control, but the
+-- selected value was never stored in the database. That meant editing an
+-- existing checklist always showed a blank start date even when one had
+-- been chosen earlier.
+-- ================================================================
+
+ALTER TABLE public.checklists
+  ADD COLUMN IF NOT EXISTS start_date date NULL;


### PR DESCRIPTION
## Summary
- persist checklist start dates so edit mode round-trips the chosen date
- harden team-member PIN saves and replace the kiosk signup bypass with logout/login recovery
- make kiosk checklist loading retry against the public anon RPC path so kiosk stays in sync even after admin session changes

Closes #167
Closes #168
Closes #169