### PR TITLE
Fix desktop UI consistency and kiosk regressions

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -17,8 +17,8 @@ interface LayoutProps {
 export function Layout({ children, title, subtitle, headerRight, headerLeft }: LayoutProps) {
   const { user, signOut } = useAuth();
   const navigate = useNavigate();
-  const shellWidthClass = "mx-auto w-full max-w-[1380px]";
-  const contentWidthClass = "w-full max-w-[1040px] xl:max-w-[980px]";
+  const shellWidthClass = "mx-auto w-full max-w-[1320px]";
+  const contentWidthClass = "w-full max-w-[960px] xl:max-w-[920px]";
 
   const handleLogout = async () => {
     await signOut();

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1120,6 +1120,7 @@ interface AccountTabProps {
   departments: StaffDepartment[];
   setDepartments: React.Dispatch<React.SetStateAction<StaffDepartment[]>>;
   auditLog: AuditLogEntry[];
+  authAccount: TeamMember | null;
   authMemberId: string | undefined;
   authUserEmail: string | undefined;
   authUserName: string | undefined;
@@ -1142,7 +1143,7 @@ interface AccountTabProps {
 
 function AccountTab({
   locations, activeLocationIds, inactiveLocationIds, staffProfiles, teamMembers, checklists, onSavePerms,
-  onSaveAccount, departments, setDepartments, auditLog, authMemberId, authUserEmail, authUserName,
+  onSaveAccount, departments, setDepartments, auditLog, authAccount, authMemberId, authUserEmail, authUserName,
   billingUnavailable, locationLimit, isLocationOverLimit, locationGraceEndsAt, isGraceActive, isGraceExpired,
   onAddLocation, onLocationLimitReached, onEditLocation, onDeleteLocation, onSaveActiveLocations, savingActiveLocations,
   onInviteMember, onEditMember, onDeleteMember,
@@ -1153,7 +1154,7 @@ function AccountTab({
   const [expandedMemberId, setExpandedMemberId] = useState<string | null>(null);
   const [pendingPerms, setPendingPerms] = useState<Record<string, ManagerPermissions>>({});
   const currentTeamMember = teamMembers.find(member => member.id === authMemberId);
-  const currentAccount = currentTeamMember ?? (authMemberId ? {
+  const currentAccount = currentTeamMember ?? authAccount ?? (authMemberId ? {
     id: authMemberId,
     name: authUserName ?? "",
     email: authUserEmail ?? "",
@@ -2211,6 +2212,15 @@ export default function Admin() {
               departments={departments}
               setDepartments={setDepartments}
               auditLog={auditLog}
+              authAccount={authMember ? {
+                id: authMember.id,
+                name: authMember.name,
+                email: user?.email ?? authMember.email,
+                role: authMember.role,
+                initials: getInitials(authMember.name),
+                location_ids: authMember.location_ids,
+                permissions: authMember.permissions,
+              } : null}
               authMemberId={authMember?.id}
               authUserEmail={user?.email}
               authUserName={authMember?.name}

--- a/src/pages/Infohub.tsx
+++ b/src/pages/Infohub.tsx
@@ -42,6 +42,33 @@ type AccessTarget = {
   access: InfohubAccessControl;
 };
 
+function CenteredModalShell({
+  children,
+  onClose,
+  maxWidthClass = "max-w-lg",
+}: {
+  children: React.ReactNode;
+  onClose: () => void;
+  maxWidthClass?: string;
+}) {
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-end justify-center bg-foreground/30 px-4 pb-8 backdrop-blur-sm sm:items-center sm:px-6 sm:py-10"
+      onClick={onClose}
+    >
+      <div
+        className={cn(
+          "relative w-full rounded-3xl border border-border bg-card p-5 pb-6 shadow-2xl animate-fade-in max-h-[85vh] overflow-y-auto",
+          maxWidthClass,
+        )}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function sortFolders<T extends { name: string; sortOrder: number | null }>(folders: T[]): T[] {
@@ -122,9 +149,8 @@ function MoveToFolderSheet({ folders, currentParentId, onClose, onMove }: {
     folders.filter(f => f.parentId === parentId && f.id !== currentParentId);
 
   return (
-    <div className="fixed inset-0 z-50 flex items-end justify-center" onClick={onClose}>
-      <div className="absolute inset-0 bg-foreground/30 backdrop-blur-sm" />
-      <div className="relative w-full max-w-lg bg-card rounded-t-2xl border-t border-border p-5 pb-8 space-y-3 animate-fade-in max-h-[85vh] overflow-y-auto" onClick={e => e.stopPropagation()}>
+    <CenteredModalShell onClose={onClose}>
+      <div className="space-y-3">
         <div className="flex items-center justify-between mb-1">
           <h3 className="font-display text-base text-foreground">Move to folder</h3>
           <button onClick={onClose} className="p-1.5 rounded-full hover:bg-muted transition-colors">
@@ -177,7 +203,7 @@ function MoveToFolderSheet({ folders, currentParentId, onClose, onMove }: {
           <p className="text-sm text-muted-foreground text-center py-4">No folders found.</p>
         )}
       </div>
-    </div>
+    </CenteredModalShell>
   );
 }
 
@@ -190,9 +216,8 @@ function CreateFolderModal({ parentId, onClose, onSave }: {
 }) {
   const [name, setName] = useState("");
   return (
-    <div className="fixed inset-0 z-50 flex items-end justify-center" onClick={onClose}>
-      <div className="absolute inset-0 bg-foreground/30 backdrop-blur-sm" />
-      <div className="relative w-full max-w-lg bg-card rounded-t-2xl border-t border-border p-5 pb-8 space-y-4 animate-fade-in max-h-[85vh] overflow-y-auto" onClick={e => e.stopPropagation()}>
+    <CenteredModalShell onClose={onClose}>
+      <div className="space-y-4">
         <div className="flex items-center justify-between">
           <h3 className="font-display text-base text-foreground">New folder</h3>
           <button onClick={onClose} className="p-1.5 rounded-full hover:bg-muted transition-colors">
@@ -214,7 +239,7 @@ function CreateFolderModal({ parentId, onClose, onSave }: {
           Create folder
         </button>
       </div>
-    </div>
+    </CenteredModalShell>
   );
 }
 
@@ -227,9 +252,8 @@ function RenameFolderModal({ currentName, onClose, onSave }: {
 }) {
   const [name, setName] = useState(currentName);
   return (
-    <div className="fixed inset-0 z-50 flex items-end justify-center" onClick={onClose}>
-      <div className="absolute inset-0 bg-foreground/30 backdrop-blur-sm" />
-      <div className="relative w-full max-w-lg bg-card rounded-t-2xl border-t border-border p-5 pb-8 space-y-4 animate-fade-in max-h-[85vh] overflow-y-auto" onClick={e => e.stopPropagation()}>
+    <CenteredModalShell onClose={onClose}>
+      <div className="space-y-4">
         <div className="flex items-center justify-between">
           <h3 className="font-display text-base text-foreground">Rename folder</h3>
           <button onClick={onClose} className="p-1.5 rounded-full hover:bg-muted transition-colors">
@@ -251,7 +275,7 @@ function RenameFolderModal({ currentName, onClose, onSave }: {
           Rename
         </button>
       </div>
-    </div>
+    </CenteredModalShell>
   );
 }
 
@@ -267,9 +291,8 @@ function CreateDocModal({ folderId, folders, onClose, onSave }: {
   const [selectedFolder, setSelectedFolder] = useState(folderId || folders[0]?.id || "");
   const [tagsInput, setTagsInput] = useState("");
   return (
-    <div className="fixed inset-0 z-50 flex items-end justify-center" onClick={onClose}>
-      <div className="absolute inset-0 bg-foreground/30 backdrop-blur-sm" />
-      <div className="relative w-full max-w-lg bg-card rounded-t-2xl border-t border-border p-5 pb-8 space-y-4 animate-fade-in max-h-[85vh] overflow-y-auto" onClick={e => e.stopPropagation()}>
+    <CenteredModalShell onClose={onClose}>
+      <div className="space-y-4">
         <div className="flex items-center justify-between">
           <h3 className="font-display text-base text-foreground">New document</h3>
           <button onClick={onClose} className="p-1.5 rounded-full hover:bg-muted transition-colors">
@@ -310,7 +333,7 @@ function CreateDocModal({ folderId, folders, onClose, onSave }: {
           Create document
         </button>
       </div>
-    </div>
+    </CenteredModalShell>
   );
 }
 
@@ -321,20 +344,12 @@ function PlusMenu({ onClose, onAction }: {
   onAction: (action: "document" | "upload" | "folder") => void;
 }) {
   return (
-    <div className="fixed inset-0 z-[60] flex items-end justify-center" onClick={onClose}>
-      <div className="absolute inset-0 bg-foreground/30 backdrop-blur-sm" />
-      <div
-        className="relative w-full bg-card rounded-t-2xl border-t border-border p-5 pb-6 space-y-1 animate-fade-in max-h-[85vh] overflow-y-auto"
-        onClick={e => e.stopPropagation()}
-      >
+    <CenteredModalShell onClose={onClose} maxWidthClass="max-w-md">
+      <div className="space-y-1">
         <div className="flex items-center justify-between mb-3">
           <h3 className="font-display text-base text-foreground">Create new</h3>
-          <button
-            onClick={onClose}
-            className="flex items-center gap-1 px-3 py-1.5 rounded-full bg-muted hover:bg-muted/80 transition-colors text-xs font-medium text-muted-foreground"
-          >
-            <X size={14} />
-            Close
+          <button onClick={onClose} className="p-1.5 rounded-full hover:bg-muted transition-colors">
+            <X size={18} className="text-muted-foreground" />
           </button>
         </div>
         <button onClick={() => onAction("document")} className="w-full flex items-center gap-3 px-4 py-3.5 rounded-xl hover:bg-muted/50 transition-colors text-left">
@@ -365,7 +380,7 @@ function PlusMenu({ onClose, onAction }: {
           </div>
         </button>
       </div>
-    </div>
+    </CenteredModalShell>
   );
 }
 
@@ -406,12 +421,8 @@ function ManageAccessModal({
   };
 
   return (
-    <div className="fixed inset-0 z-[70] flex items-end justify-center" onClick={onClose}>
-      <div className="absolute inset-0 bg-foreground/30 backdrop-blur-sm" />
-      <div
-        className="relative w-full max-w-2xl bg-card rounded-t-2xl border-t border-border p-5 pb-8 space-y-4 animate-fade-in max-h-[85vh] overflow-y-auto"
-        onClick={(e) => e.stopPropagation()}
-      >
+    <CenteredModalShell onClose={onClose} maxWidthClass="max-w-2xl">
+      <div className="space-y-4">
         <div className="flex items-center justify-between">
           <div>
             <h3 className="font-display text-base text-foreground">Manage access</h3>
@@ -517,7 +528,7 @@ function ManageAccessModal({
           Save access
         </button>
       </div>
-    </div>
+    </CenteredModalShell>
   );
 }
 
@@ -570,12 +581,8 @@ function AIActionsSheet({
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-end justify-center" onClick={onClose}>
-      <div className="absolute inset-0 bg-foreground/30 backdrop-blur-sm" />
-      <div
-        className="relative w-full max-w-lg bg-card rounded-t-2xl border-t border-border p-5 pb-8 space-y-4 animate-fade-in max-h-[85vh] overflow-y-auto"
-        onClick={e => e.stopPropagation()}
-      >
+    <CenteredModalShell onClose={onClose}>
+      <div className="space-y-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <Sparkles size={16} className="text-lavender-deep" />
@@ -711,7 +718,7 @@ function AIActionsSheet({
           </div>
         )}
       </div>
-    </div>
+    </CenteredModalShell>
   );
 }
 
@@ -1113,6 +1120,7 @@ export default function Infohub() {
   const routeSubTab: SubTab = location.pathname.startsWith("/infohub/training") ? "training" : "library";
   const [subTab, setSubTab] = useState<SubTab>(routeSubTab);
   const [showSearch, setShowSearch] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
   const [showPlusMenu, setShowPlusMenu] = useState(false);
   const [showCreateFolder, setShowCreateFolder] = useState(false);
   const [showCreateDoc, setShowCreateDoc] = useState(false);
@@ -1164,41 +1172,54 @@ export default function Infohub() {
     })),
     [infohubData.trainingDocs, trainCompletionMap],
   );
+  const normalizedSearch = searchQuery.trim().toLowerCase();
 
   // Sorted folder lists
   const visibleLibFolders = useMemo(() =>
-    sortFolders(libFolders.filter(f => f.parentId === currentLibFolder)),
-    [libFolders, currentLibFolder]
+    sortFolders(libFolders.filter((folder) => {
+      if (normalizedSearch) return folder.name.toLowerCase().includes(normalizedSearch);
+      return folder.parentId === currentLibFolder;
+    })),
+    [libFolders, currentLibFolder, normalizedSearch]
   );
   const accessibleLibFolders = useMemo(() =>
     visibleLibFolders.filter(folder => canAccessInfohubContent(folder.access, currentPrincipal)),
     [visibleLibFolders, currentPrincipal]
   );
   const docsInCurrentFolder = useMemo(() =>
-    currentLibFolder
-      ? libDocs
-        .filter(d => d.folderId === currentLibFolder)
-        .sort((a, b) => a.title.localeCompare(b.title))
-      : [],
-    [libDocs, currentLibFolder]
+    (normalizedSearch
+      ? libDocs.filter((doc) =>
+          doc.title.toLowerCase().includes(normalizedSearch)
+          || doc.summary.toLowerCase().includes(normalizedSearch)
+        )
+      : currentLibFolder
+        ? libDocs.filter(d => d.folderId === currentLibFolder)
+        : []
+    ).sort((a, b) => a.title.localeCompare(b.title)),
+    [libDocs, currentLibFolder, normalizedSearch]
   );
   const accessibleDocsInCurrentFolder = useMemo(() =>
     docsInCurrentFolder.filter(doc => canAccessInfohubContent(doc.access, currentPrincipal)),
     [docsInCurrentFolder, currentPrincipal]
   );
   const visibleTrainFolders = useMemo(() =>
-    sortFolders(trainFolders.filter(f => f.parentId === currentTrainFolder)),
-    [trainFolders, currentTrainFolder]
+    sortFolders(trainFolders.filter((folder) => {
+      if (normalizedSearch) return folder.name.toLowerCase().includes(normalizedSearch);
+      return folder.parentId === currentTrainFolder;
+    })),
+    [trainFolders, currentTrainFolder, normalizedSearch]
   );
   const accessibleTrainFolders = useMemo(() =>
     visibleTrainFolders.filter(folder => canAccessInfohubContent(folder.access, currentPrincipal)),
     [visibleTrainFolders, currentPrincipal]
   );
   const docsInCurrentTrainFolder = useMemo(() =>
-    currentTrainFolder
-      ? trainDocs.filter(d => d.folderId === currentTrainFolder)
-      : [],
-    [trainDocs, currentTrainFolder]
+    normalizedSearch
+      ? trainDocs.filter(d => d.title.toLowerCase().includes(normalizedSearch))
+      : currentTrainFolder
+        ? trainDocs.filter(d => d.folderId === currentTrainFolder)
+        : [],
+    [trainDocs, currentTrainFolder, normalizedSearch]
   );
   const accessibleDocsInCurrentTrainFolder = useMemo(() =>
     docsInCurrentTrainFolder.filter(doc => canAccessInfohubContent(doc.access, currentPrincipal)),
@@ -1369,15 +1390,36 @@ export default function Infohub() {
     <Layout title="Infohub" subtitle={subtitle}
       headerRight={
         <div className="flex items-center gap-1">
-          <button onClick={() => setShowSearch(true)} aria-label="Search documents" className="p-2 rounded-full hover:bg-muted transition-colors">
-            <Search size={18} className="text-muted-foreground" />
-          </button>
-          <button onClick={() => setShowPlusMenu(true)} aria-label="Add content" className="p-2 rounded-full hover:bg-sage-light transition-colors">
-            <Plus size={18} className="text-sage-deep" />
+          <button
+            onClick={() => setShowPlusMenu(true)}
+            aria-label="Add content"
+            className="hidden h-10 w-10 items-center justify-center rounded-xl bg-sage text-primary-foreground transition-colors hover:bg-sage-deep md:flex"
+          >
+            <Plus size={18} />
           </button>
         </div>
       }
     >
+      <div className="flex items-center gap-2">
+        <div className="relative flex-1">
+          <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
+          <input
+            type="text"
+            placeholder={subTab === "library" ? "Search documents and folders…" : "Search training and folders…"}
+            value={searchQuery}
+            onChange={e => setSearchQuery(e.target.value)}
+            className="w-full rounded-xl border border-border bg-card py-2.5 pl-9 pr-4 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+          />
+        </div>
+        <button
+          onClick={() => setShowPlusMenu(true)}
+          aria-label="Add content"
+          className="flex h-10 w-10 items-center justify-center rounded-xl bg-sage text-primary-foreground transition-colors hover:bg-sage-deep md:hidden"
+        >
+          <Plus size={18} />
+        </button>
+      </div>
+
       {/* Sub-tab toggle */}
       <div className="flex gap-1 bg-muted rounded-xl p-1 md:hidden">
         {([
@@ -1464,7 +1506,7 @@ export default function Infohub() {
           )}
 
           {/* Documents in current folder */}
-          {currentLibFolder && accessibleDocsInCurrentFolder.length > 0 && (
+          {(currentLibFolder || normalizedSearch) && accessibleDocsInCurrentFolder.length > 0 && (
             <>
               <p className="section-label">Documents</p>
               <div className="card-surface divide-y divide-border">
@@ -1522,7 +1564,11 @@ export default function Infohub() {
               <div className="w-10 h-10 rounded-full bg-sage-light flex items-center justify-center mx-auto mb-2">
                 <Plus size={18} className="text-sage-deep" />
               </div>
-              <p className="text-sm text-muted-foreground">{currentLibFolder ? "This folder is empty." : "No folders yet."}</p>
+              <p className="text-sm text-muted-foreground">
+                {normalizedSearch
+                  ? "No matching library items."
+                  : currentLibFolder ? "This folder is empty." : "No folders yet."}
+              </p>
               <p className="text-xs text-muted-foreground mt-1">Tap to create a folder or document.</p>
             </button>
           )}
@@ -1617,7 +1663,7 @@ export default function Infohub() {
             </>
           )}
 
-          {currentTrainFolder && accessibleDocsInCurrentTrainFolder.length > 0 && (
+          {(currentTrainFolder || normalizedSearch) && accessibleDocsInCurrentTrainFolder.length > 0 && (
             <>
               <p className="section-label">Modules</p>
               <div className="card-surface divide-y divide-border">
@@ -1671,13 +1717,15 @@ export default function Infohub() {
             </>
           )}
 
-          {accessibleTrainFolders.length === 0 && accessibleDocsInCurrentTrainFolder.length === 0 && currentTrainFolder && (
+          {accessibleTrainFolders.length === 0 && accessibleDocsInCurrentTrainFolder.length === 0 && (currentTrainFolder || normalizedSearch) && (
             <button onClick={() => setShowPlusMenu(true)}
               className="card-surface p-8 text-center w-full hover:bg-muted/30 transition-colors cursor-pointer">
               <div className="w-10 h-10 rounded-full bg-lavender-light flex items-center justify-center mx-auto mb-2">
                 <Plus size={18} className="text-lavender-deep" />
               </div>
-              <p className="text-sm text-muted-foreground">This folder is empty.</p>
+              <p className="text-sm text-muted-foreground">
+                {normalizedSearch ? "No matching training items." : "This folder is empty."}
+              </p>
               <p className="text-xs text-muted-foreground mt-1">Tap to create a folder or document.</p>
             </button>
           )}

--- a/src/pages/Kiosk.tsx
+++ b/src/pages/Kiosk.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { X, Check, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { supabase } from "@/lib/supabase";
-import { runtimeConfig } from "@/lib/runtime-config";
+import { useAuth } from "@/contexts/AuthContext";
 import { enqueueLog, drainQueue } from "@/lib/submission-queue";
 import { getLinkableInfohubResource } from "@/lib/infohub-catalog";
 
@@ -121,39 +121,15 @@ function dbToKioskChecklist(raw: any): KioskChecklist {
   };
 }
 
+function clearKioskLocationSelection() {
+  _kioskLocationId = null;
+  _kioskLocationName = null;
+  localStorage.removeItem("kiosk_location_id");
+  localStorage.removeItem("kiosk_location_name");
+}
+
 async function fetchKioskChecklists(locationId: string) {
   const { data, error } = await supabase.rpc("get_kiosk_checklists", { p_location_id: locationId });
-  if (!error && (data?.length ?? 0) > 0) {
-    return (data ?? []).map(dbToKioskChecklist);
-  }
-
-  // Kiosk is a public operational surface. When an authenticated browser
-  // session has stale org context, the authenticated RPC path can return an
-  // empty set even though the anon kiosk RPC still has the correct result for
-  // the selected location. Retry anonymously so kiosk visibility does not
-  // depend on whichever admin session was previously open in the tab.
-  if (!import.meta.env.TEST) {
-    try {
-      const response = await fetch(`${runtimeConfig.supabaseUrl}/rest/v1/rpc/get_kiosk_checklists`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          apikey: runtimeConfig.supabaseAnonKey,
-          Authorization: `Bearer ${runtimeConfig.supabaseAnonKey}`,
-        },
-        body: JSON.stringify({ p_location_id: locationId }),
-      });
-      if (response.ok) {
-        const anonData = await response.json();
-        if (Array.isArray(anonData)) {
-          return anonData.map(dbToKioskChecklist);
-        }
-      }
-    } catch {
-      // Fall back to the original RPC error below.
-    }
-  }
-
   if (error) throw error;
   return (data ?? []).map(dbToKioskChecklist);
 }
@@ -1706,6 +1682,7 @@ function ChecklistCard({ cl, idx, onSelect, dim = false }: {
 // ─── Kiosk Page ───────────────────────────────────────────────────────────────
 export default function Kiosk() {
   const [searchParams] = useSearchParams();
+  const { user } = useAuth();
 
   const [locationId, setLocationId] = useState<string | null>(() => {
     const url = searchParams.get("locationId");
@@ -1727,6 +1704,31 @@ export default function Kiosk() {
   const [insertError, setInsertError] = useState<string | null>(null);
   // Four-tab kiosk view: due | overdue | upcoming | done
   const [kioskTab, setKioskTab] = useState<"due" | "overdue" | "upcoming" | "done">("due");
+
+  useEffect(() => {
+    const ownerKey = "kiosk_owner_user_id";
+    const storedOwnerId = localStorage.getItem(ownerKey);
+
+    if (!user?.id) {
+      if (storedOwnerId) {
+        clearKioskLocationSelection();
+        localStorage.removeItem(ownerKey);
+        setLocationId(null);
+        setLocationName("");
+        setKioskChecklists([]);
+      }
+      return;
+    }
+
+    if (storedOwnerId && storedOwnerId !== user.id) {
+      clearKioskLocationSelection();
+      setLocationId(null);
+      setLocationName("");
+      setKioskChecklists([]);
+    }
+
+    localStorage.setItem(ownerKey, user.id);
+  }, [user?.id]);
 
   // Load persisted completions for today whenever locationId is resolved
   useEffect(() => {
@@ -1824,10 +1826,7 @@ export default function Kiosk() {
           }
           return;
         }
-        _kioskLocationId = null;
-        _kioskLocationName = null;
-        localStorage.removeItem("kiosk_location_id");
-        localStorage.removeItem("kiosk_location_name");
+        clearKioskLocationSelection();
         setLocationId(null);
         setLocationName("");
         setKioskChecklists([]);
@@ -2076,7 +2075,7 @@ export default function Kiosk() {
 
       {/* Agenda heading */}
       <div className="px-5 pt-6 pb-2">
-        <h1 className="font-display text-3xl italic text-foreground leading-tight">
+        <h1 className="font-display text-3xl italic text-foreground leading-tight text-center">
           What's on the agenda<br />for today?
         </h1>
 

--- a/src/pages/checklists/ChecklistsTab.tsx
+++ b/src/pages/checklists/ChecklistsTab.tsx
@@ -109,13 +109,13 @@ export function ChecklistsTab() {
   const [editingChecklistId, setEditingChecklistId] = useState<string | null>(null);
   const [previewChecklist, setPreviewChecklist] = useState<ChecklistItem | null>(null);
   const editingChecklist = editingChecklistId ? dbChecklists.find(c => c.id === editingChecklistId) : null;
+  const normalizedSearch = search.trim().toLowerCase();
   const visibleFolders = [...folders]
-    .filter(f => f.parentId === currentFolder)
-    .filter(f => !search || f.name.toLowerCase().includes(search.toLowerCase()))
+    .filter(f => normalizedSearch ? f.name.toLowerCase().includes(normalizedSearch) : f.parentId === currentFolder)
     .sort((a, b) => folderOrder.indexOf(a.id) - folderOrder.indexOf(b.id));
   const selectedLocationObj = dbLocations.find(l => l.name === selectedLocation);
-  const visibleChecklists = checklists.filter(c => c.folderId === currentFolder)
-    .filter(c => !search || c.title.toLowerCase().includes(search.toLowerCase()))
+  const visibleChecklists = checklists
+    .filter(c => normalizedSearch ? c.title.toLowerCase().includes(normalizedSearch) : c.folderId === currentFolder)
     .filter(c => {
       if (selectedLocation === "All locations") return true;
       if (!selectedLocationObj) return true;
@@ -125,7 +125,7 @@ export function ChecklistsTab() {
       );
     });
 
-  const isEmpty = visibleFolders.length === 0 && visibleChecklists.length === 0 && !search;
+  const isEmpty = visibleFolders.length === 0 && visibleChecklists.length === 0 && !normalizedSearch;
 
   const handleCreateFolder = () => {
     if (!newFolderName.trim()) return;

--- a/src/pages/checklists/CreateMenuSheet.tsx
+++ b/src/pages/checklists/CreateMenuSheet.tsx
@@ -15,8 +15,8 @@ export function CreateMenuSheet({ onClose, onBuildOwn, onConvertFile, onBuildAI,
   ];
 
   return (
-    <div className="fixed inset-0 z-[60] flex items-end justify-center pb-16 bg-foreground/20 backdrop-blur-sm animate-fade-in">
-      <div className="bg-card w-full max-w-lg rounded-t-2xl p-5 pb-20 space-y-1 animate-fade-in">
+    <div className="fixed inset-0 z-[60] flex items-end justify-center bg-foreground/20 px-4 pb-8 backdrop-blur-sm animate-fade-in sm:items-center sm:px-6 sm:py-10">
+      <div className="bg-card w-full max-w-md rounded-3xl border border-border p-5 pb-6 space-y-1 shadow-2xl animate-fade-in">
         <div className="flex items-center justify-between mb-3">
           <h2 className="font-display text-lg text-foreground">Create new</h2>
           <button onClick={onClose} className="p-1.5 rounded-full hover:bg-muted transition-colors">

--- a/src/test/pages/Infohub.extended.test.tsx
+++ b/src/test/pages/Infohub.extended.test.tsx
@@ -2,6 +2,16 @@ import { fireEvent, screen, within } from "@testing-library/react";
 import Infohub from "@/pages/Infohub";
 import { renderWithProviders } from "../test-utils";
 
+const mockNavigate = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
 vi.mock("@/lib/supabase", () => ({
   supabase: {
     rpc: vi.fn().mockResolvedValue({ data: [], error: null }),
@@ -112,7 +122,6 @@ function openFirstDocMenu() {
 }
 
 function openLatteModule() {
-  fireEvent.click(screen.getByRole("button", { name: /training/i }));
   const onboardingFolder = screen.getByText("Onboarding");
   const folderRow = onboardingFolder.closest("div[class*='flex']") as HTMLElement | null;
   if (!folderRow) return false;
@@ -220,11 +229,8 @@ describe("Infohub extended behavior", () => {
   });
 
   it("creates a document with tags", () => {
-    renderWithProviders(<Infohub />);
-    const headerButtons = screen.getAllByRole("button").filter((btn) =>
-      btn.className.includes("rounded-full") && btn.querySelector("svg")
-    );
-    fireEvent.click(headerButtons[1]);
+    renderWithProviders(<Infohub />, { initialEntries: ["/infohub/library"] });
+    fireEvent.click(screen.getAllByLabelText("Add content")[0]);
     fireEvent.click(screen.getByText("New document"));
     fireEvent.change(screen.getByTestId("doc-title-input"), { target: { value: "Weekly briefing" } });
     fireEvent.change(screen.getByTestId("doc-tags-input"), { target: { value: "Weekly, Team" } });
@@ -235,7 +241,7 @@ describe("Infohub extended behavior", () => {
   });
 
   it("allows completed training to be marked incomplete", () => {
-    renderWithProviders(<Infohub />);
+    renderWithProviders(<Infohub />, { initialEntries: ["/infohub/training"] });
     const opened = openLatteModule();
     if (!opened) return;
 

--- a/src/test/pages/Infohub.test.tsx
+++ b/src/test/pages/Infohub.test.tsx
@@ -2,6 +2,16 @@ import { screen, fireEvent, within } from "@testing-library/react";
 import Infohub from "@/pages/Infohub";
 import { renderWithProviders } from "../test-utils";
 
+const mockNavigate = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
 vi.mock("@/lib/supabase", () => ({
   supabase: {
     auth: {
@@ -144,91 +154,40 @@ describe("Infohub page", () => {
     }
   });
 
-  it("search button is visible in header", () => {
+  it("search field is visible in header", () => {
     renderWithProviders(<Infohub />, { initialEntries: ["/infohub/library"] });
-    // The search icon button should be in the page
-    const buttons = screen.getAllByRole("button");
-    const hasSearchIcon = buttons.some(btn => btn.querySelector("svg") !== null);
-    expect(hasSearchIcon).toBe(true);
+    expect(screen.getByPlaceholderText("Search documents and folders…")).toBeInTheDocument();
   });
 
-  it("clicking the search button opens search overlay with input", () => {
+  it("inline search field accepts input", () => {
     renderWithProviders(<Infohub />, { initialEntries: ["/infohub/library"] });
-    // Find the search button (it has a Search icon)
-    // The header has search + plus buttons; search is first
-    const buttons = screen.getAllByRole("button");
-    // Search button is in the headerRight area
-    // Find by looking at buttons with aria-label or by position
-    // The search overlay shows "Search all documents..." placeholder
-    const searchButtons = buttons.filter(btn => {
-      const svgPath = btn.querySelector("svg");
-      return svgPath && btn.className.includes("rounded-full");
+    const input = screen.getByPlaceholderText("Search documents and folders…");
+    fireEvent.change(input, { target: { value: "allergen" } });
+    expect(input).toHaveValue("allergen");
+  });
+
+  it("inline search shows empty state for unmatched query", () => {
+    renderWithProviders(<Infohub />, { initialEntries: ["/infohub/library"] });
+    fireEvent.change(screen.getByPlaceholderText("Search documents and folders…"), {
+      target: { value: "xyznonexistentterm" },
     });
-    if (searchButtons.length > 0) {
-      fireEvent.click(searchButtons[0]);
-      const input = screen.queryByPlaceholderText("Search all documents...");
-      if (input) {
-        expect(input).toBeInTheDocument();
-      }
-    }
-    // At least the buttons exist
-    expect(buttons.length).toBeGreaterThan(0);
+    expect(screen.getByText("No matching library items.")).toBeInTheDocument();
   });
 
-  it("search overlay shows 'No results found' for unmatched query", () => {
+  it("inline search filters library docs by title", () => {
     renderWithProviders(<Infohub />, { initialEntries: ["/infohub/library"] });
-    const buttons = screen.getAllByRole("button");
-    const searchButtons = buttons.filter(btn =>
-      btn.className.includes("rounded-full") && btn.querySelector("svg")
-    );
-    if (searchButtons.length > 0) {
-      fireEvent.click(searchButtons[0]);
-    }
-    const input = screen.queryByPlaceholderText("Search all documents...");
-    if (input) {
-      fireEvent.change(input, { target: { value: "xyznonexistentterm" } });
-      expect(screen.getByText("No results found.")).toBeInTheDocument();
-    }
+    fireEvent.change(screen.getByPlaceholderText("Search documents and folders…"), {
+      target: { value: "allergen" },
+    });
+    expect(screen.queryAllByText(/allergen/i).length).toBeGreaterThan(0);
   });
 
-  it("search overlay filters library docs by title", () => {
+  it("clearing inline search returns to main view", () => {
     renderWithProviders(<Infohub />, { initialEntries: ["/infohub/library"] });
-    const buttons = screen.getAllByRole("button");
-    const searchButtons = buttons.filter(btn =>
-      btn.className.includes("rounded-full") && btn.querySelector("svg")
-    );
-    if (searchButtons.length > 0) {
-      fireEvent.click(searchButtons[0]);
-    }
-    const input = screen.queryByPlaceholderText("Search all documents...");
-    if (input) {
-      fireEvent.change(input, { target: { value: "allergen" } });
-      // Should find allergen handling documents from library
-      expect(screen.queryAllByText(/allergen/i).length).toBeGreaterThan(0);
-    }
-  });
-
-  it("closing search overlay (X button) returns to main view", () => {
-    renderWithProviders(<Infohub />, { initialEntries: ["/infohub/library"] });
-    const buttons = screen.getAllByRole("button");
-    const searchButtons = buttons.filter(btn =>
-      btn.className.includes("rounded-full") && btn.querySelector("svg")
-    );
-    if (searchButtons.length > 0) {
-      fireEvent.click(searchButtons[0]);
-    }
-    const input = screen.queryByPlaceholderText("Search all documents...");
-    if (input) {
-      // Find and click the X close button
-      const closeBtn = screen.getAllByRole("button").find(btn =>
-        btn.className.includes("rounded-full") && btn !== searchButtons[0]
-      );
-      if (closeBtn) {
-        fireEvent.click(closeBtn);
-        // Should be back to main page
-        expect(screen.getByText("Folders")).toBeInTheDocument();
-      }
-    }
+    const input = screen.getByPlaceholderText("Search documents and folders…");
+    fireEvent.change(input, { target: { value: "allergen" } });
+    fireEvent.change(input, { target: { value: "" } });
+    expect(screen.getByText("Folders")).toBeInTheDocument();
   });
 
   it("generates an AI summary for a library document", async () => {
@@ -236,26 +195,25 @@ describe("Infohub page", () => {
     vi.mocked(supabase.functions.invoke).mockResolvedValue({
       data: {
         type: "summary",
-        title: "How to serve a customer",
-        bullets: ["Greet within 30 seconds", "Repeat the order back clearly"],
-        takeaway: "Keep service warm, calm, and accurate.",
+        title: "Allergen handling procedure",
+        bullets: ["Treat all allergy queries seriously", "Notify the kitchen verbally"],
+        takeaway: "Never guess when allergens are involved.",
       },
       error: null,
     } as any);
 
     renderWithProviders(<Infohub />);
 
-    fireEvent.click(screen.getByRole("button", { name: /search documents/i }));
-    fireEvent.change(screen.getByPlaceholderText("Search all documents..."), {
-      target: { value: "serve a customer" },
+    fireEvent.change(screen.getByPlaceholderText("Search documents and folders…"), {
+      target: { value: "allergen" },
     });
-    fireEvent.click(screen.getByRole("button", { name: /how to serve a customer/i }));
+    fireEvent.click(screen.getByText(/allergen handling procedure/i).closest("div[class*='cursor-pointer']") as HTMLElement);
 
     fireEvent.click(screen.getByRole("button", { name: /open ai tools/i }));
     fireEvent.click(screen.getByRole("button", { name: /generate summary/i }));
 
-    expect(await screen.findByText("Keep service warm, calm, and accurate.")).toBeInTheDocument();
-    expect(screen.getByText("Greet within 30 seconds")).toBeInTheDocument();
+    expect(await screen.findByText("Never guess when allergens are involved.")).toBeInTheDocument();
+    expect(screen.getByText("Treat all allergy queries seriously")).toBeInTheDocument();
   });
 
   it("switching to Training tab shows training folders", () => {
@@ -415,87 +373,47 @@ describe("Infohub page", () => {
 
   it("plus (+) button opens the Plus menu", () => {
     renderWithProviders(<Infohub />);
-    const buttons = screen.getAllByRole("button");
-    // Plus button is next to search in the header
-    const plusBtn = buttons.find(btn =>
-      btn.className.includes("rounded-full") && btn.className.includes("sage")
-    );
-    if (plusBtn) {
-      fireEvent.click(plusBtn);
-      expect(screen.getByText("Create new")).toBeInTheDocument();
-    }
+    fireEvent.click(screen.getAllByLabelText("Add content")[0]);
+    expect(screen.getByText("Create new")).toBeInTheDocument();
   });
 
   it("Plus menu shows 'New document', 'Upload file', and 'New folder' options", () => {
     renderWithProviders(<Infohub />);
-    const buttons = screen.getAllByRole("button");
-    const plusBtn = buttons.find(btn =>
-      btn.className.includes("rounded-full") && btn.className.includes("sage")
-    );
-    if (plusBtn) {
-      fireEvent.click(plusBtn);
-      expect(screen.getByText("New document")).toBeInTheDocument();
-      expect(screen.getByText("Upload file")).toBeInTheDocument();
-      expect(screen.getByText("New folder")).toBeInTheDocument();
-    }
+    fireEvent.click(screen.getAllByLabelText("Add content")[0]);
+    expect(screen.getByText("New document")).toBeInTheDocument();
+    expect(screen.getByText("Upload file")).toBeInTheDocument();
+    expect(screen.getByText("New folder")).toBeInTheDocument();
   });
 
   it("clicking 'New folder' from Plus menu opens CreateFolder modal", () => {
     renderWithProviders(<Infohub />);
-    const buttons = screen.getAllByRole("button");
-    const plusBtn = buttons.find(btn =>
-      btn.className.includes("rounded-full") && btn.className.includes("sage")
-    );
-    if (plusBtn) {
-      fireEvent.click(plusBtn);
-      const newFolderBtn = screen.queryByText("New folder");
-      if (newFolderBtn) {
-        fireEvent.click(newFolderBtn);
-        expect(screen.getByText("New folder")).toBeInTheDocument();
-        // Create folder modal also shows "Folder name" label
-        expect(screen.queryByText("Folder name")).toBeTruthy();
-      }
-    }
+    fireEvent.click(screen.getAllByLabelText("Add content")[0]);
+    fireEvent.click(screen.getByText("New folder"));
+    expect(screen.getByText("New folder")).toBeInTheDocument();
+    expect(screen.queryByText("Folder name")).toBeTruthy();
   });
 
   it("CreateFolder modal: typing a name and clicking 'Create folder' adds a new folder", () => {
     renderWithProviders(<Infohub />);
-    const buttons = screen.getAllByRole("button");
-    const plusBtn = buttons.find(btn =>
-      btn.className.includes("rounded-full") && btn.className.includes("sage")
-    );
-    if (plusBtn) {
-      fireEvent.click(plusBtn);
-      const newFolderBtn = screen.queryByText("New folder");
-      if (newFolderBtn) {
-        fireEvent.click(newFolderBtn);
-        const input = screen.queryByPlaceholderText("e.g. Health & Safety");
-        if (input) {
-          fireEvent.change(input, { target: { value: "Test New Folder" } });
-          const createBtn = screen.getByText("Create folder");
-          fireEvent.click(createBtn);
-          // Modal closes, new folder should appear in the list
-          expect(screen.queryByText("Test New Folder")).toBeTruthy();
-        }
-      }
+    fireEvent.click(screen.getAllByLabelText("Add content")[0]);
+    fireEvent.click(screen.getByText("New folder"));
+    const input = screen.queryByPlaceholderText("e.g. Health & Safety");
+    if (input) {
+      fireEvent.change(input, { target: { value: "Test New Folder" } });
+      const createBtn = screen.getByText("Create folder");
+      fireEvent.click(createBtn);
+      expect(screen.queryByText("Test New Folder")).toBeTruthy();
     }
   });
 
   it("clicking 'New document' from Plus menu opens CreateDoc modal", () => {
     renderWithProviders(<Infohub />);
-    const buttons = screen.getAllByRole("button");
-    const plusBtn = buttons.find(btn =>
-      btn.className.includes("rounded-full") && btn.className.includes("sage")
-    );
-    if (plusBtn) {
-      fireEvent.click(plusBtn);
-      const newDocBtn = screen.queryByText("New document");
-      if (newDocBtn) {
-        fireEvent.click(newDocBtn);
-        expect(screen.getByText("New document")).toBeInTheDocument();
-        // Modal has a folder selector
-        expect(screen.queryByText("Title")).toBeTruthy();
-      }
+    fireEvent.click(screen.getAllByLabelText("Add content")[0]);
+    const newDocBtn = screen.queryByText("New document");
+    if (newDocBtn) {
+      fireEvent.click(newDocBtn);
+      expect(screen.getByText("New document")).toBeInTheDocument();
+      expect(screen.queryByText("Title")).toBeTruthy();
     }
   });
 
@@ -742,21 +660,12 @@ describe("Infohub page", () => {
 
   it("Plus menu closes when backdrop is clicked (via X button)", () => {
     renderWithProviders(<Infohub />);
-    const buttons = screen.getAllByRole("button");
-    const plusBtn = buttons.find(btn =>
-      btn.className.includes("rounded-full") && btn.className.includes("sage")
-    );
-    if (plusBtn) {
-      fireEvent.click(plusBtn);
-      // Menu is open, find close button
-      const closeBtn = screen.queryAllByRole("button").find(btn =>
-        btn.querySelector("svg") && btn.className.includes("rounded-full")
-      );
-      if (closeBtn) {
-        fireEvent.click(closeBtn);
-        // Menu should be closed
-        expect(screen.queryByText("Create new")).toBeNull();
-      }
+    fireEvent.click(screen.getAllByLabelText("Add content")[0]);
+    const menuHeading = screen.getByText("Create new");
+    const closeBtn = menuHeading.parentElement?.querySelector("button");
+    if (closeBtn) {
+      fireEvent.click(closeBtn);
+      expect(screen.queryByText("Create new")).toBeNull();
     }
   });
 
@@ -779,18 +688,8 @@ describe("Infohub page", () => {
     }
   });
 
-  it("search overlay shows 'Start typing' hint when query is empty", () => {
+  it("inline search is empty by default", () => {
     renderWithProviders(<Infohub />);
-    const buttons = screen.getAllByRole("button");
-    const searchButtons = buttons.filter(btn =>
-      btn.className.includes("rounded-full") && btn.querySelector("svg")
-    );
-    if (searchButtons.length > 0) {
-      fireEvent.click(searchButtons[0]);
-    }
-    const searchHint = screen.queryByText(/Start typing to search/i);
-    if (searchHint) {
-      expect(searchHint).toBeInTheDocument();
-    }
+    expect(screen.getByPlaceholderText("Search documents and folders…")).toHaveValue("");
   });
 });


### PR DESCRIPTION
## Summary
- tighten desktop shell width and convert create menus/modals to centered popups for more standard desktop presentation
- make checklist and infohub search behave consistently, with inline fields and searchable document/module results at the root level
- harden kiosk account isolation by clearing stale kiosk location ownership on auth changes, removing the unsafe checklist fallback, and restoring centered kiosk header alignment
- make admin account edits use the authenticated owner context so PIN updates persist reliably into kiosk validation

## Testing
- bun run test src/test/pages/checklists/ChecklistsTab.test.tsx src/test/pages/Infohub.test.tsx src/test/pages/Infohub.extended.test.tsx src/test/pages/Kiosk.test.tsx src/test/pages/Admin.test.tsx src/test/components/Layout.test.tsx
- bun run build
- bun run lint

Closes #171
Closes #172
Closes #173