### PR TITLE
Auth: show a friendly sign-in error when the email has no account yet

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -13,6 +13,25 @@ function isEmailRateLimited(message: string | null | undefined) {
   return normalized.includes("rate limit") || normalized.includes("over_email_send_rate_limit");
 }
 
+function isMissingAccount(message: string | null | undefined) {
+  const normalized = (message ?? "").toLowerCase();
+  return (
+    normalized.includes("signups not allowed for otp") ||
+    normalized.includes("signup not allowed") ||
+    normalized.includes("user not found") ||
+    normalized.includes("email not found") ||
+    normalized.includes("no account")
+  );
+}
+
+function getFriendlyAuthError(message: string | null | undefined) {
+  if (isMissingAccount(message)) {
+    return "No Olia account was found for that email yet. Please create one first.";
+  }
+
+  return message ?? "Something went wrong. Please try again.";
+}
+
 export default function Login() {
   const navigate = useNavigate();
   const { user } = useAuth();
@@ -53,7 +72,7 @@ export default function Login() {
         setStep("code");
         setInfo("Too many email attempts. If you already received a recent code, enter it below. Otherwise wait a minute before requesting another one.");
       }
-      setError(authError.message);
+      setError(getFriendlyAuthError(authError.message));
       return;
     }
 
@@ -80,7 +99,7 @@ export default function Login() {
         setStep("code");
         setInfo("Too many email attempts. If you already received a recent code, enter it below. Otherwise wait a minute before requesting another one.");
       }
-      setError(authError.message);
+      setError(getFriendlyAuthError(authError.message));
       return;
     }
 

--- a/src/test/pages/Login.test.tsx
+++ b/src/test/pages/Login.test.tsx
@@ -149,6 +149,25 @@ describe("Login page", () => {
     });
   });
 
+  it("shows a friendly create-account message when the email has no sign-in account yet", async () => {
+    mockSignInWithOtp.mockResolvedValue({
+      data: {},
+      error: { message: "Signups not allowed for otp" },
+    });
+
+    renderPage();
+    fireEvent.change(screen.getByPlaceholderText("you@yourbusiness.com"), {
+      target: { value: "owner@olia.app" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send code" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/No Olia account was found/i)).toBeInTheDocument();
+      expect(screen.getByText(/create one first/i)).toBeInTheDocument();
+      expect(screen.queryByText(/signups not allowed for otp/i)).not.toBeInTheDocument();
+    });
+  });
+
   it("redirects authenticated users to admin", () => {
     mockUseAuth.mockReturnValue({ user: { id: "u1" }, loading: false });
     renderPage();


### PR DESCRIPTION
Closes #202\n\nThis keeps the login flow friendly when a user enters an email that has not signed up yet. It translates the raw Supabase OTP error into a user-friendly message telling them to create an account first.\n\nIncludes a focused test update for the missing-account case.