### PR TITLE
Kiosk/Admin: always require the same PIN for checklist start and admin return

### DIFF
--- a/src/pages/Kiosk.tsx
+++ b/src/pages/Kiosk.tsx
@@ -558,8 +558,6 @@ function PinEntryModal({
   const [validating, setValidating] = useState(false);
 
   const { secondsLeft, cancelCountdown } = useInactivityTimer(true, onCancel);
-  const { teamMember } = useAuth();
-  const { allLocations = [] } = useLocations();
 
   // Lock countdown
   useEffect(() => {
@@ -591,16 +589,6 @@ function PinEntryModal({
     if (!adminRpcError && adminData && adminData.length > 0) {
       const admin = adminData[0];
       onSuccess(null, admin.name, admin.organization_id ?? "");
-      return;
-    }
-
-    const canUseAuthenticatedAdminShortcut = Boolean(
-      teamMember?.organization_id
-      && allLocations.some((location) => location.id === locationId),
-    );
-
-    if (!adminRpcError && canUseAuthenticatedAdminShortcut && teamMember) {
-      onSuccess(null, teamMember.name, teamMember.organization_id);
       return;
     }
 
@@ -1729,7 +1717,6 @@ function ChecklistCard({ cl, idx, onSelect, dim = false }: {
 // ─── Kiosk Page ───────────────────────────────────────────────────────────────
 export default function Kiosk() {
   const [searchParams] = useSearchParams();
-  const navigate = useNavigate();
   const urlLocationId = searchParams.get("locationId");
   const { user, teamMember, loading } = useAuth();
   const { allLocations = [], isFetched: locationsFetched } = useLocations();
@@ -2082,24 +2069,11 @@ export default function Kiosk() {
     setScreen("runner");
   };
 
-  const canUseAuthenticatedAdminShortcut = Boolean(
-    teamMember?.organization_id
-    && locationId
-    && allLocations.some((location) => location.id === locationId),
-  );
-
   const handleChecklistSelect = (checklist: KioskChecklist) => {
     setSelectedChecklist(checklist);
-    if (canUseAuthenticatedAdminShortcut && teamMember) {
-      handleStart(null, teamMember.name, teamMember.organization_id);
-    }
   };
 
   const handleAdminButtonClick = () => {
-    if (canUseAuthenticatedAdminShortcut) {
-      navigate("/admin?from=kiosk");
-      return;
-    }
     setShowAdminLogin(true);
   };
 


### PR DESCRIPTION
Fixes #206

## Summary
- remove the authenticated kiosk shortcuts that bypassed the PIN modal
- require the same admin PIN path for both checklist start and kiosk admin return
- restore explicit PIN prompting in both kiosk flows

## Verification
- bun run build
- bun run lint
- bun run test src/test/pages/Kiosk.test.tsx (still stalls in the existing kiosk harness)