### PR TITLE
Fix checklist builder response-type picker anchoring

### DIFF
--- a/src/pages/checklists/ChecklistBuilderModal.tsx
+++ b/src/pages/checklists/ChecklistBuilderModal.tsx
@@ -19,7 +19,7 @@ import type {
 } from "./types";
 import { parseScheduleType, SCHEDULE_LABELS } from "./types";
 import { RESPONSE_TYPES, multipleChoiceSets } from "./data";
-import { ResponseTypePicker } from "./ResponseTypePicker";
+import { ResponseTypePicker, type ResponseTypePickerAnchorRect } from "./ResponseTypePicker";
 import { CustomRecurrencePicker } from "./CustomRecurrencePicker";
 import { linkableInfohubResources } from "@/lib/infohub-catalog";
 
@@ -86,8 +86,8 @@ export function ChecklistBuilderModal({
     id: "sec-default", name: "", questions: [{ id: "q-1", text: "", responseType: "checkbox", required: true, config: {} }],
   }]);
   const [showResponsePicker, setShowResponsePicker] = useState<
-    | { scope: "main"; sectionIdx: number; questionIdx: number }
-    | { scope: "followup"; sectionIdx: number; questionIdx: number; ruleIdx: number; triggerIdx: number }
+    | { scope: "main"; sectionIdx: number; questionIdx: number; anchorRect?: ResponseTypePickerAnchorRect }
+    | { scope: "followup"; sectionIdx: number; questionIdx: number; ruleIdx: number; triggerIdx: number; anchorRect?: ResponseTypePickerAnchorRect }
     | null
   >(null);
   const [requiredError, setRequiredError] = useState("");
@@ -565,7 +565,7 @@ export function ChecklistBuilderModal({
                   </div>
 
                   <div className="flex items-center justify-between">
-                    <button onClick={() => setShowResponsePicker({ scope: "main", sectionIdx: si, questionIdx: qi })}
+                    <button onClick={e => setShowResponsePicker({ scope: "main", sectionIdx: si, questionIdx: qi, anchorRect: e.currentTarget.getBoundingClientRect() })}
                       className="text-xs px-3 py-1.5 rounded-full border border-border text-muted-foreground hover:border-sage/40 transition-colors flex items-center gap-1">
                       {responseTypeLabel(q.responseType)}
                       <ChevronDown size={10} />
@@ -1258,6 +1258,7 @@ export function ChecklistBuilderModal({
       )}
       {showResponsePicker && (
         <ResponseTypePicker
+          anchorRect={showResponsePicker.anchorRect}
           onSelect={(type, mcSetId) => {
             const mcSet = mcSetId ? multipleChoiceSets.find(m => m.id === mcSetId) : null;
             if (showResponsePicker.scope === "main") {

--- a/src/pages/checklists/FollowUpQuestionEditor.tsx
+++ b/src/pages/checklists/FollowUpQuestionEditor.tsx
@@ -25,7 +25,7 @@ import type {
   ResponseType,
 } from "./types";
 import { RESPONSE_TYPES, multipleChoiceSets } from "./data";
-import { ResponseTypePicker } from "./ResponseTypePicker";
+import { ResponseTypePicker, type ResponseTypePickerAnchorRect } from "./ResponseTypePicker";
 
 const MC_COLOR_OPTIONS = [
   { label: "Green", value: "bg-status-ok/10 border-status-ok/40 text-status-ok" },
@@ -66,7 +66,7 @@ export function FollowUpQuestionEditor({
   label?: string;
   depth?: number;
 }) {
-  const [showResponsePicker, setShowResponsePicker] = useState(false);
+  const [showResponsePicker, setShowResponsePicker] = useState<ResponseTypePickerAnchorRect | null>(null);
   const imgInputRef = useRef<HTMLInputElement | null>(null);
 
   const cfg = question.config || {};
@@ -398,7 +398,7 @@ export function FollowUpQuestionEditor({
         />
         <button
           type="button"
-          onClick={() => setShowResponsePicker(true)}
+          onClick={e => setShowResponsePicker(e.currentTarget.getBoundingClientRect())}
           className="text-xs px-3 py-1.5 rounded-full border border-border text-muted-foreground hover:border-sage/40 transition-colors flex items-center gap-1"
         >
           {responseTypeLabel(question.responseType)}
@@ -432,11 +432,12 @@ export function FollowUpQuestionEditor({
 
       {showResponsePicker && (
         <ResponseTypePicker
+          anchorRect={showResponsePicker}
           onSelect={(type, mcSetId) => {
             setResponseType(type, mcSetId);
-            setShowResponsePicker(false);
+            setShowResponsePicker(null);
           }}
-          onClose={() => setShowResponsePicker(false)}
+          onClose={() => setShowResponsePicker(null)}
         />
       )}
     </div>

--- a/src/pages/checklists/ResponseTypePicker.tsx
+++ b/src/pages/checklists/ResponseTypePicker.tsx
@@ -1,15 +1,64 @@
+import type { CSSProperties } from "react";
 import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { ResponseType } from "./types";
 import { RESPONSE_TYPES, multipleChoiceSets } from "./data";
 
-export function ResponseTypePicker({ onSelect, onClose }: {
+export type ResponseTypePickerAnchorRect = Pick<DOMRect, "top" | "right" | "bottom" | "left" | "width" | "height">;
+
+function getAnchoredStyle(anchorRect: ResponseTypePickerAnchorRect): CSSProperties {
+  const viewportWidth = typeof window !== "undefined" ? window.innerWidth : 1280;
+  const viewportHeight = typeof window !== "undefined" ? window.innerHeight : 800;
+  const padding = 16;
+  const panelWidth = Math.min(380, viewportWidth - padding * 2);
+  const panelMaxHeight = Math.min(460, viewportHeight - padding * 2);
+  const preferredTop = anchorRect.bottom + 12;
+  const fitsBelow = preferredTop + panelMaxHeight <= viewportHeight - padding;
+  const top = fitsBelow
+    ? preferredTop
+    : Math.max(padding, anchorRect.top - panelMaxHeight - 12);
+  const left = Math.min(
+    Math.max(anchorRect.left, padding),
+    Math.max(padding, viewportWidth - panelWidth - padding),
+  );
+
+  return {
+    top,
+    left,
+    width: panelWidth,
+    maxHeight: panelMaxHeight,
+  };
+}
+
+export function ResponseTypePicker({ onSelect, onClose, anchorRect }: {
   onSelect: (type: ResponseType, mcSetId?: string) => void;
   onClose: () => void;
+  anchorRect?: ResponseTypePickerAnchorRect | null;
 }) {
+  const isAnchored = Boolean(anchorRect);
+  const panelStyle = anchorRect ? getAnchoredStyle(anchorRect) : undefined;
+
   return (
-    <div className="fixed inset-0 z-[60] flex items-end justify-center pb-16 bg-foreground/20 backdrop-blur-sm animate-fade-in sm:items-center sm:pb-0 sm:px-4 sm:py-8">
-      <div className="bg-card w-full max-w-lg rounded-t-2xl flex flex-col max-h-[85vh] animate-fade-in sm:max-w-2xl sm:rounded-2xl sm:max-h-[90vh]">
+    <div
+      className={cn(
+        "fixed inset-0 z-[60] bg-foreground/20 backdrop-blur-sm animate-fade-in",
+        isAnchored ? "" : "flex items-end justify-center pb-16 sm:items-center sm:pb-0 sm:px-4 sm:py-8",
+      )}
+      onClick={onClose}
+      role="presentation"
+    >
+      <div
+        className={cn(
+          "bg-card flex flex-col",
+          isAnchored
+            ? "fixed rounded-2xl shadow-2xl"
+            : "w-full max-w-lg rounded-t-2xl max-h-[85vh] animate-fade-in sm:max-w-2xl sm:rounded-2xl sm:max-h-[90vh]",
+        )}
+        style={panelStyle}
+        onClick={e => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+      >
         <div className="flex items-center justify-between px-5 pt-5 pb-3 border-b border-border shrink-0">
           <h2 className="font-display text-lg text-foreground">Type of response</h2>
           <button onClick={onClose} className="p-1.5 rounded-full hover:bg-muted transition-colors">

--- a/src/test/pages/checklists/ResponseTypePicker.test.tsx
+++ b/src/test/pages/checklists/ResponseTypePicker.test.tsx
@@ -75,6 +75,18 @@ describe("ResponseTypePicker", () => {
     expect(screen.getByText("Good")).toBeInTheDocument();
   });
 
+  it("positions as an anchored popover when an anchor rect is provided", () => {
+    render(
+      <ResponseTypePicker
+        onSelect={onSelect}
+        onClose={onClose}
+        anchorRect={{ top: 220, right: 420, bottom: 260, left: 220, width: 200, height: 40 }}
+      />
+    );
+
+    expect(screen.getByRole("dialog")).toHaveStyle({ top: "272px" });
+  });
+
   it("has a close button that calls onClose", () => {
     render(<ResponseTypePicker onSelect={onSelect} onClose={onClose} />);
     const buttons = screen.getAllByRole("button");


### PR DESCRIPTION
## Summary
- open the checklist builder response-type picker near the button that opened it
- keep the same anchored behavior in follow-up question editors for consistency
- add a targeted regression test for anchored positioning

## Verification
- `bunx vitest run src/test/pages/checklists/ResponseTypePicker.test.tsx src/test/pages/checklists/ChecklistBuilderModal.test.tsx`
- `bun run build`

Closes #209