### PR TITLE
Fix checklist trigger logic and multiple-choice color controls

### DIFF
--- a/src/pages/Kiosk.tsx
+++ b/src/pages/Kiosk.tsx
@@ -232,7 +232,7 @@ function useLiveClock() {
     if (import.meta.env.TEST) return;
     const id = setInterval(() => setNow(new Date()), 1000);
     return () => clearInterval(id);
-  }, [DRAFT_KEY]);
+  }, []);
   return now;
 }
 
@@ -1181,11 +1181,12 @@ type KioskDraftSnapshot = {
 };
 
 const INSTRUCTION_ACKNOWLEDGED = "__instruction_acknowledged__";
+const UNANSWERED_SENTINEL = "__unanswered__";
 
 function isBlankAnswer(value: any) {
   return Array.isArray(value)
     ? value.length === 0
-    : value === undefined || value === "" || value === null || value === false;
+    : value === UNANSWERED_SENTINEL || value === undefined || value === "" || value === null || value === false;
 }
 
 function loadKioskDraftSnapshot(draftKey: string, questions: Question[]): KioskDraftSnapshot {
@@ -1250,6 +1251,9 @@ function getQuestionAnswer(question: Question, answers: Record<string, any>) {
 
 function doesRuleMatch(question: Question, rule: LogicRule, answers: Record<string, any>) {
   const rawAnswer = getQuestionAnswer(question, answers);
+  if (rule.comparator === "unanswered") {
+    return rawAnswer === UNANSWERED_SENTINEL;
+  }
   if (isBlankAnswer(rawAnswer)) return false;
 
   const answerText = normalizeAnswerText(rawAnswer).toLowerCase();
@@ -1307,7 +1311,7 @@ function createRuntimeQuestion(
 
 function getTriggeredRuntimeQuestions(question: Question, answers: Record<string, any>) {
   const rawAnswer = getQuestionAnswer(question, answers);
-  if (isBlankAnswer(rawAnswer)) return [];
+  if (isBlankAnswer(rawAnswer) && rawAnswer !== UNANSWERED_SENTINEL) return [];
 
   const rules = question.config?.logicRules ?? [];
   const followUps: Question[] = [];
@@ -1407,6 +1411,8 @@ export function ChecklistRunner({
   }).length;
   const progress = scorable.length > 0 ? Math.round((answeredCount / scorable.length) * 100) : 100;
   const currentQuestionIndex = Math.max(0, questions.findIndex(q => q.id === currentQuestionId));
+  const hasUnansweredTrigger = (question: Question) =>
+    Boolean(question.config?.logicRules?.some(rule => rule.comparator === "unanswered" && (rule.triggers?.length ?? 0) > 0));
 
   const persistDraft = useCallback((nextAnswers: Record<string, any>, nextCurrentQuestionId: string) => {
     draftRef.current = {
@@ -1548,6 +1554,7 @@ export function ChecklistRunner({
           // For next/acknowledge button: show on current question for types that don't auto-advance
           // "datetime" is legacy — if it resolves to "text" it's included via q.type === "text"
           const isLastQ = qi >= questions.length - 1;
+          const hasBlankUnansweredTrigger = hasUnansweredTrigger(q);
           const needsNextBtn = isCurrent && (
             isInstruction ||
             q.type === "text" ||
@@ -1555,9 +1562,10 @@ export function ChecklistRunner({
             q.type === "datetime" ||
             q.type === "media" ||
             (!q.required && q.type === "checkbox") ||
+            hasBlankUnansweredTrigger ||
             (q.type === "multiple_choice" && (q.selectionMode === "multiple" || !q.required))
           );
-          const nextBtnDisabled = q.type === "multiple_choice" && q.selectionMode === "multiple" && q.required && !isAnswered;
+          const nextBtnDisabled = q.type === "multiple_choice" && q.selectionMode === "multiple" && q.required && !isAnswered && !hasBlankUnansweredTrigger;
 
           return (
             <Fragment key={q.id}>
@@ -1631,6 +1639,13 @@ export function ChecklistRunner({
                             } else {
                               advanceQuestion(nextAnswers);
                             }
+                            return;
+                          }
+
+                          if (hasBlankUnansweredTrigger && isBlankAnswer(answers[q.id])) {
+                            const nextAnswers = { ...answers, [q.id]: UNANSWERED_SENTINEL };
+                            setAnswers(nextAnswers);
+                            advanceQuestion(nextAnswers);
                             return;
                           }
 

--- a/src/pages/checklists/ChecklistBuilderModal.tsx
+++ b/src/pages/checklists/ChecklistBuilderModal.tsx
@@ -19,7 +19,7 @@ import type {
 } from "./types";
 import { parseScheduleType, SCHEDULE_LABELS } from "./types";
 import { RESPONSE_TYPES, multipleChoiceSets } from "./data";
-import { ResponseTypePicker } from "./ResponseTypePicker";
+import { ResponseTypePicker, type ResponseTypePickerAnchorRect } from "./ResponseTypePicker";
 import { CustomRecurrencePicker } from "./CustomRecurrencePicker";
 import { linkableInfohubResources } from "@/lib/infohub-catalog";
 
@@ -31,8 +31,10 @@ const MC_COLOR_OPTIONS = [
   { label: "Green", value: "bg-status-ok/10 border-status-ok/40 text-status-ok" },
   { label: "Yellow", value: "bg-status-warn/10 border-status-warn/40 text-status-warn" },
   { label: "Red", value: "bg-status-error/10 border-status-error/40 text-status-error" },
+  { label: "Blue", value: "bg-blue-100 border-blue-300 text-blue-700" },
   { label: "Neutral", value: "bg-muted text-muted-foreground border-border" },
 ];
+const DEFAULT_MC_COLOR = MC_COLOR_OPTIONS[MC_COLOR_OPTIONS.length - 1].value;
 
 interface ChecklistBuilderModalProps {
   onClose: () => void;
@@ -86,8 +88,8 @@ export function ChecklistBuilderModal({
     id: "sec-default", name: "", questions: [{ id: "q-1", text: "", responseType: "checkbox", required: true, config: {} }],
   }]);
   const [showResponsePicker, setShowResponsePicker] = useState<
-    | { scope: "main"; sectionIdx: number; questionIdx: number }
-    | { scope: "followup"; sectionIdx: number; questionIdx: number; ruleIdx: number; triggerIdx: number }
+    | { scope: "main"; sectionIdx: number; questionIdx: number; anchorRect: ResponseTypePickerAnchorRect }
+    | { scope: "followup"; sectionIdx: number; questionIdx: number; ruleIdx: number; triggerIdx: number; anchorRect: ResponseTypePickerAnchorRect }
     | null
   >(null);
   const [requiredError, setRequiredError] = useState("");
@@ -565,7 +567,13 @@ export function ChecklistBuilderModal({
                   </div>
 
                   <div className="flex items-center justify-between">
-                    <button onClick={() => setShowResponsePicker({ scope: "main", sectionIdx: si, questionIdx: qi })}
+                    <button
+                      onClick={e => setShowResponsePicker({
+                        scope: "main",
+                        sectionIdx: si,
+                        questionIdx: qi,
+                        anchorRect: e.currentTarget.getBoundingClientRect(),
+                      })}
                       className="text-xs px-3 py-1.5 rounded-full border border-border text-muted-foreground hover:border-sage/40 transition-colors flex items-center gap-1">
                       {responseTypeLabel(q.responseType)}
                       <ChevronDown size={10} />
@@ -728,19 +736,33 @@ export function ChecklistBuilderModal({
                                 }}
                                 className="flex-1 border border-border rounded-lg px-3 py-2 text-sm bg-background focus:outline-none focus:ring-1 focus:ring-ring"
                               />
-                              <select
-                                value={questionChoiceColors[choiceIdx] ?? MC_COLOR_OPTIONS[3].value}
-                                onChange={e => {
-                                  const nextColors = [...questionChoiceColors];
-                                  nextColors[choiceIdx] = e.target.value;
-                                  updateQuestion(si, qi, { choiceColors: nextColors });
-                                }}
-                                className="w-28 text-xs border border-border rounded-lg px-2 py-2 bg-background focus:outline-none focus:ring-1 focus:ring-ring"
-                              >
-                                {MC_COLOR_OPTIONS.map(option => (
-                                  <option key={option.label} value={option.value}>{option.label}</option>
-                                ))}
-                              </select>
+                              <div className="flex flex-wrap justify-end gap-1.5 min-w-[220px]">
+                                {MC_COLOR_OPTIONS.map(option => {
+                                  const selectedColor = questionChoiceColors[choiceIdx] ?? DEFAULT_MC_COLOR;
+                                  const isSelected = selectedColor === option.value;
+                                  return (
+                                    <button
+                                      key={option.label}
+                                      type="button"
+                                      aria-pressed={isSelected}
+                                      onClick={() => {
+                                        const nextColors = [...questionChoiceColors];
+                                        nextColors[choiceIdx] = option.value;
+                                        updateQuestion(si, qi, { choiceColors: nextColors });
+                                      }}
+                                      className={cn(
+                                        "px-2.5 py-1 rounded-full border text-[11px] font-medium transition-all whitespace-nowrap",
+                                        option.value,
+                                        isSelected
+                                          ? "ring-2 ring-ring ring-offset-2 ring-offset-background shadow-sm"
+                                          : "opacity-75 hover:opacity-100",
+                                      )}
+                                    >
+                                      {option.label}
+                                    </button>
+                                  );
+                                })}
+                              </div>
                               <button
                                 type="button"
                                 onClick={() => {
@@ -764,14 +786,14 @@ export function ChecklistBuilderModal({
                           Choose a preset to add answer options.
                         </p>
                       )}
-                      <button
-                        type="button"
-                        onClick={() => updateQuestion(si, qi, {
-                          choices: [...questionChoices, `Option ${questionChoices.length + 1}`],
-                          choiceColors: [...questionChoiceColors, MC_COLOR_OPTIONS[3].value],
-                        })}
-                        className="text-xs text-sage hover:text-sage-deep transition-colors flex items-center gap-1"
-                      >
+                              <button
+                                type="button"
+                                onClick={() => updateQuestion(si, qi, {
+                                  choices: [...questionChoices, `Option ${questionChoices.length + 1}`],
+                                  choiceColors: [...questionChoiceColors, DEFAULT_MC_COLOR],
+                                })}
+                                className="text-xs text-sage hover:text-sage-deep transition-colors flex items-center gap-1"
+                              >
                         <Plus size={11} /> Add option
                       </button>
                     </div>
@@ -952,21 +974,29 @@ export function ChecklistBuilderModal({
                       { key: "gt", label: "Greater than" },
                       { key: "between", label: "Between" },
                       { key: "not_between", label: "Not between" },
+                      { key: "unanswered", label: "Not provided" },
                     ];
                     const CHOICE_COMPARATORS: { key: LogicComparator; label: string }[] = [
-                      { key: "is", label: "Is" }, { key: "is_not", label: "Is not" },
+                      { key: "is", label: "Is" }, { key: "is_not", label: "Is not" }, { key: "unanswered", label: "Not provided" },
                     ];
                     const TEXT_COMPARATORS: { key: LogicComparator; label: string }[] = [
-                      { key: "is", label: "Is" }, { key: "is_not", label: "Is not" },
+                      { key: "is", label: "Is" }, { key: "is_not", label: "Is not" }, { key: "unanswered", label: "Not provided" },
                     ];
                     const comparators = isNumericType ? NUMERIC_COMPARATORS : isMcType ? CHOICE_COMPARATORS : TEXT_COMPARATORS;
+                    const describeCondition = (rule: LogicRule) => {
+                      if (rule.comparator === "unanswered") return "left unanswered";
+                      const label = comparators.find(c => c.key === rule.comparator)?.label || rule.comparator;
+                      if (rule.comparator === "between" || rule.comparator === "not_between") {
+                        return `answered ${label.toLowerCase()} ${rule.value}${rule.valueTo ? ` and ${rule.valueTo}` : ""}`;
+                      }
+                      return `answered ${label.toLowerCase()} ${rule.value}`;
+                    };
 
                     const TRIGGER_OPTIONS: { key: LogicTriggerType; label: string; icon: React.ElementType }[] = [
                       { key: "ask_question", label: "Ask question", icon: MessageSquare },
                       { key: "notify", label: "Notify (email)", icon: Bell },
                       { key: "require_note", label: "Require note", icon: FileText },
                       { key: "require_media", label: "Require media", icon: Image },
-                      { key: "require_action", label: "Create action", icon: AlertTriangle },
                     ];
 
                     const mcChoices = questionChoices.length > 0 ? questionChoices : ["Yes", "No", "N/A"];
@@ -998,8 +1028,7 @@ export function ChecklistBuilderModal({
                       }
                       if (triggerType === "require_action") {
                         const qLabel = q.text || `Question ${qi + 1}`;
-                        const cLabel = `${comparators.find(c => c.key === rule.comparator)?.label || rule.comparator} ${rule.value}${rule.valueTo ? ` – ${rule.valueTo}` : ""}`;
-                        triggerConfig.actionTitle = `Action required: "${qLabel}" answered ${cLabel}`;
+                        triggerConfig.actionTitle = `Action required: "${qLabel}" ${describeCondition(rule)}`;
                       }
                       updateRule(ri, { triggers: [...rule.triggers, { type: triggerType, config: triggerConfig }] });
                     };
@@ -1031,13 +1060,24 @@ export function ChecklistBuilderModal({
                                 <div className="flex items-center gap-1.5 flex-wrap">
                                   <span className="text-xs text-muted-foreground">If answer</span>
                                   <select value={rule.comparator}
-                                    onChange={e => updateRule(ri, { comparator: e.target.value as LogicComparator })}
+                                    onChange={e => {
+                                      const nextComparator = e.target.value as LogicComparator;
+                                      updateRule(ri, {
+                                        comparator: nextComparator,
+                                        value: nextComparator === "unanswered" ? "" : rule.value,
+                                        valueTo: nextComparator === "unanswered" ? undefined : rule.valueTo,
+                                      });
+                                    }}
                                     className="text-xs border border-border rounded-lg px-2 py-1.5 bg-muted focus:outline-none focus:ring-1 focus:ring-ring">
                                     {comparators.map(c => (
                                       <option key={c.key} value={c.key}>{c.label.toLowerCase()}</option>
                                     ))}
                                   </select>
-                                  {isMcType ? (
+                                  {rule.comparator === "unanswered" ? (
+                                    <span className="text-xs border border-border rounded-lg px-2 py-1.5 bg-background text-muted-foreground">
+                                      No response provided
+                                    </span>
+                                  ) : isMcType ? (
                                     <select value={rule.value}
                                       onChange={e => updateRule(ri, { value: e.target.value })}
                                       className="text-xs border border-border rounded-lg px-2 py-1.5 bg-muted focus:outline-none focus:ring-1 focus:ring-ring">
@@ -1182,10 +1222,10 @@ export function ChecklistBuilderModal({
                                       <Plus size={11} /> trigger
                                     </button>
                                     <div className="hidden group-focus-within:block absolute left-0 top-full mt-1 bg-card border border-border rounded-lg shadow-lg z-10 py-1 min-w-[160px]">
-                                      {TRIGGER_OPTIONS.filter(t => !rule.triggers.some(rt => rt.type === t.key)).map(t => (
-                                        <button key={t.key} onClick={() => addTrigger(ri, t.key)}
-                                          className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-muted/50 transition-colors">
-                                          <t.icon size={13} className="text-sage shrink-0" />
+                    {TRIGGER_OPTIONS.filter(t => t.key !== "require_action" && !rule.triggers.some(rt => rt.type === t.key)).map(t => (
+                      <button key={t.key} onClick={() => addTrigger(ri, t.key)}
+                        className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-muted/50 transition-colors">
+                        <t.icon size={13} className="text-sage shrink-0" />
                                           <span className="text-xs text-foreground">{t.label}</span>
                                         </button>
                                       ))}
@@ -1258,6 +1298,7 @@ export function ChecklistBuilderModal({
       )}
       {showResponsePicker && (
         <ResponseTypePicker
+          anchorRect={showResponsePicker.anchorRect}
           onSelect={(type, mcSetId) => {
             const mcSet = mcSetId ? multipleChoiceSets.find(m => m.id === mcSetId) : null;
             if (showResponsePicker.scope === "main") {

--- a/src/pages/checklists/FollowUpQuestionEditor.tsx
+++ b/src/pages/checklists/FollowUpQuestionEditor.tsx
@@ -1,6 +1,5 @@
 import { useRef, useState } from "react";
 import {
-  AlertTriangle,
   Bell,
   Camera,
   ChevronDown,
@@ -25,14 +24,16 @@ import type {
   ResponseType,
 } from "./types";
 import { RESPONSE_TYPES, multipleChoiceSets } from "./data";
-import { ResponseTypePicker } from "./ResponseTypePicker";
+import { ResponseTypePicker, type ResponseTypePickerAnchorRect } from "./ResponseTypePicker";
 
 const MC_COLOR_OPTIONS = [
   { label: "Green", value: "bg-status-ok/10 border-status-ok/40 text-status-ok" },
   { label: "Yellow", value: "bg-status-warn/10 border-status-warn/40 text-status-warn" },
   { label: "Red", value: "bg-status-error/10 border-status-error/40 text-status-error" },
+  { label: "Blue", value: "bg-blue-100 border-blue-300 text-blue-700" },
   { label: "Neutral", value: "bg-muted text-muted-foreground border-border" },
 ];
+const DEFAULT_MC_COLOR = MC_COLOR_OPTIONS[MC_COLOR_OPTIONS.length - 1].value;
 
 const responseTypeLabel = (type: ResponseType) => RESPONSE_TYPES.find(r => r.key === type)?.label || "Response type";
 const getQuestionChoices = (q: QuestionDef) => q.choices?.length
@@ -66,7 +67,7 @@ export function FollowUpQuestionEditor({
   label?: string;
   depth?: number;
 }) {
-  const [showResponsePicker, setShowResponsePicker] = useState(false);
+  const [showResponsePicker, setShowResponsePicker] = useState<ResponseTypePickerAnchorRect | null>(null);
   const imgInputRef = useRef<HTMLInputElement | null>(null);
 
   const cfg = question.config || {};
@@ -275,19 +276,33 @@ export function FollowUpQuestionEditor({
                     }}
                     className="flex-1 border border-border rounded-lg px-3 py-2 text-sm bg-background focus:outline-none focus:ring-1 focus:ring-ring"
                   />
-                  <select
-                    value={questionChoiceColors[choiceIdx] ?? MC_COLOR_OPTIONS[3].value}
-                    onChange={e => {
-                      const nextColors = [...questionChoiceColors];
-                      nextColors[choiceIdx] = e.target.value;
-                      updateQuestion({ choiceColors: nextColors });
-                    }}
-                    className="w-28 text-xs border border-border rounded-lg px-2 py-2 bg-background focus:outline-none focus:ring-1 focus:ring-ring"
-                  >
-                    {MC_COLOR_OPTIONS.map(option => (
-                      <option key={option.label} value={option.value}>{option.label}</option>
-                    ))}
-                  </select>
+                  <div className="flex flex-wrap justify-end gap-1.5 min-w-[220px]">
+                    {MC_COLOR_OPTIONS.map(option => {
+                      const selectedColor = questionChoiceColors[choiceIdx] ?? DEFAULT_MC_COLOR;
+                      const isSelected = selectedColor === option.value;
+                      return (
+                        <button
+                          key={option.label}
+                          type="button"
+                          aria-pressed={isSelected}
+                          onClick={() => {
+                            const nextColors = [...questionChoiceColors];
+                            nextColors[choiceIdx] = option.value;
+                            updateQuestion({ choiceColors: nextColors });
+                          }}
+                          className={cn(
+                            "px-2.5 py-1 rounded-full border text-[11px] font-medium transition-all whitespace-nowrap",
+                            option.value,
+                            isSelected
+                              ? "ring-2 ring-ring ring-offset-2 ring-offset-background shadow-sm"
+                              : "opacity-75 hover:opacity-100",
+                          )}
+                        >
+                          {option.label}
+                        </button>
+                      );
+                    })}
+                  </div>
                   <button
                     type="button"
                     onClick={() => {
@@ -315,7 +330,7 @@ export function FollowUpQuestionEditor({
             type="button"
             onClick={() => updateQuestion({
               choices: [...questionChoices, `Option ${questionChoices.length + 1}`],
-              choiceColors: [...questionChoiceColors, MC_COLOR_OPTIONS[3].value],
+              choiceColors: [...questionChoiceColors, DEFAULT_MC_COLOR],
             })}
             className="text-xs text-sage hover:text-sage-deep transition-colors flex items-center gap-1"
           >
@@ -398,7 +413,7 @@ export function FollowUpQuestionEditor({
         />
         <button
           type="button"
-          onClick={() => setShowResponsePicker(true)}
+          onClick={e => setShowResponsePicker(e.currentTarget.getBoundingClientRect())}
           className="text-xs px-3 py-1.5 rounded-full border border-border text-muted-foreground hover:border-sage/40 transition-colors flex items-center gap-1"
         >
           {responseTypeLabel(question.responseType)}
@@ -432,6 +447,7 @@ export function FollowUpQuestionEditor({
 
       {showResponsePicker && (
         <ResponseTypePicker
+          anchorRect={showResponsePicker}
           onSelect={(type, mcSetId) => {
             setResponseType(type, mcSetId);
             setShowResponsePicker(false);
@@ -469,14 +485,23 @@ function LogicRulesEditor({
     { key: "gt", label: "Greater than" },
     { key: "between", label: "Between" },
     { key: "not_between", label: "Not between" },
+    { key: "unanswered", label: "Not provided" },
   ];
   const CHOICE_COMPARATORS: { key: LogicComparator; label: string }[] = [
-    { key: "is", label: "Is" }, { key: "is_not", label: "Is not" },
+    { key: "is", label: "Is" }, { key: "is_not", label: "Is not" }, { key: "unanswered", label: "Not provided" },
   ];
   const TEXT_COMPARATORS: { key: LogicComparator; label: string }[] = [
-    { key: "is", label: "Is" }, { key: "is_not", label: "Is not" },
+    { key: "is", label: "Is" }, { key: "is_not", label: "Is not" }, { key: "unanswered", label: "Not provided" },
   ];
   const comparators = isNumericType ? NUMERIC_COMPARATORS : isMcType ? CHOICE_COMPARATORS : TEXT_COMPARATORS;
+  const describeCondition = (rule: LogicRule) => {
+    if (rule.comparator === "unanswered") return "left unanswered";
+    const label = comparators.find(c => c.key === rule.comparator)?.label || rule.comparator;
+    if (rule.comparator === "between" || rule.comparator === "not_between") {
+      return `answered ${label.toLowerCase()} ${rule.value}${rule.valueTo ? ` and ${rule.valueTo}` : ""}`;
+    }
+    return `answered ${label.toLowerCase()} ${rule.value}`;
+  };
   const mcChoices = getQuestionChoices(question).length > 0 ? getQuestionChoices(question) : ["Yes", "No", "N/A"];
 
   const updateQuestion = (update: Partial<QuestionDef>) => onChange({ ...question, ...update });
@@ -504,8 +529,7 @@ function LogicRulesEditor({
     const triggerConfig: LogicTrigger["config"] = {};
     if (triggerType === "require_action") {
       const qLabel = question.text || "Follow-up question";
-      const cLabel = `${comparators.find(c => c.key === rule.comparator)?.label || rule.comparator} ${rule.value}${rule.valueTo ? ` – ${rule.valueTo}` : ""}`;
-      triggerConfig.actionTitle = `Action required: "${qLabel}" answered ${cLabel}`;
+      triggerConfig.actionTitle = `Action required: "${qLabel}" ${describeCondition(rule)}`;
     }
     if (triggerType === "ask_question") {
       triggerConfig.questionText = `Follow-up: ${question.text || "Question"}`;
@@ -520,7 +544,6 @@ function LogicRulesEditor({
     { key: "notify", label: "Notify (email)", icon: Bell },
     { key: "require_note", label: "Require note", icon: FileText },
     { key: "require_media", label: "Require media", icon: Image },
-    { key: "require_action", label: "Create action", icon: AlertTriangle },
   ];
 
   return (
@@ -542,14 +565,25 @@ function LogicRulesEditor({
                 <span className="text-xs text-muted-foreground">If answer</span>
                 <select
                   value={rule.comparator}
-                  onChange={e => updateRule(ri, { comparator: e.target.value as LogicComparator })}
+                  onChange={e => {
+                    const nextComparator = e.target.value as LogicComparator;
+                    updateRule(ri, {
+                      comparator: nextComparator,
+                      value: nextComparator === "unanswered" ? "" : rule.value,
+                      valueTo: nextComparator === "unanswered" ? undefined : rule.valueTo,
+                    });
+                  }}
                   className="text-xs border border-border rounded-lg px-2 py-1.5 bg-muted focus:outline-none focus:ring-1 focus:ring-ring"
                 >
                   {comparators.map(c => (
                     <option key={c.key} value={c.key}>{c.label.toLowerCase()}</option>
                   ))}
                 </select>
-                {isMcType ? (
+                {rule.comparator === "unanswered" ? (
+                  <span className="text-xs border border-border rounded-lg px-2 py-1.5 bg-background text-muted-foreground">
+                    No response provided
+                  </span>
+                ) : isMcType ? (
                   <select
                     value={rule.value}
                     onChange={e => updateRule(ri, { value: e.target.value })}
@@ -692,7 +726,7 @@ function LogicRulesEditor({
                     <Plus size={11} /> trigger
                   </button>
                   <div className="hidden group-focus-within:block absolute left-0 top-full mt-1 bg-card border border-border rounded-lg shadow-lg z-10 py-1 min-w-[160px]">
-                    {TRIGGER_OPTIONS.filter(t => !rule.triggers.some(rt => rt.type === t.key)).map(t => (
+                    {TRIGGER_OPTIONS.filter(t => t.key !== "require_action" && !rule.triggers.some(rt => rt.type === t.key)).map(t => (
                       <button
                         key={t.key}
                         onClick={() => addTrigger(ri, t.key)}

--- a/src/pages/checklists/types.ts
+++ b/src/pages/checklists/types.ts
@@ -48,7 +48,7 @@ export type ResponseType =
   // kiosk runner falls back to plain text input for all three
   | "datetime" | "signature" | "person";
 
-export type LogicComparator = "is" | "is_not" | "lt" | "lte" | "eq" | "neq" | "gte" | "gt" | "between" | "not_between";
+export type LogicComparator = "is" | "is_not" | "lt" | "lte" | "eq" | "neq" | "gte" | "gt" | "between" | "not_between" | "unanswered";
 export type LogicTriggerType = "ask_question" | "notify" | "require_note" | "require_media" | "require_action";
 
 export interface LogicTrigger {

--- a/src/test/pages/Kiosk.test.tsx
+++ b/src/test/pages/Kiosk.test.tsx
@@ -984,6 +984,63 @@ describe("Kiosk — Checklist Runner", () => {
     });
   });
 
+  it("executes unanswered triggers after skipping a blank question", async () => {
+    renderRunner({
+      id: "ck-unanswered",
+      title: "Unanswered Trigger Checklist",
+      location_id: "00000000-0000-0000-0000-000000000011",
+      time_of_day: "anytime",
+      due_time: null,
+      visibility_from: null,
+      visibility_until: null,
+      questions: [
+        {
+          id: "q-base",
+          text: "Optional note",
+          type: "text",
+          required: false,
+          config: {
+            logicRules: [
+              {
+                id: "lr-unanswered",
+                comparator: "unanswered",
+                value: "",
+                triggers: [
+                  {
+                    type: "ask_question",
+                    config: {
+                      followUpQuestion: {
+                        id: "q-unanswered-follow",
+                        text: "Why was this left blank?",
+                        responseType: "text",
+                        required: true,
+                        config: {},
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        {
+          id: "q-final",
+          text: "Final question",
+          type: "text",
+          required: true,
+        },
+      ],
+    });
+
+    expect(screen.queryByText("Why was this left blank?")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /next/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Why was this left blank?")).toBeInTheDocument();
+    });
+  });
+
   it("executes require-note triggers by inserting a required note step", async () => {
     renderRunner({
       id: "ck-note-trigger",

--- a/src/test/pages/checklists/ChecklistBuilderModal.test.tsx
+++ b/src/test/pages/checklists/ChecklistBuilderModal.test.tsx
@@ -185,6 +185,7 @@ describe("ChecklistBuilderModal - new checklist", () => {
 
     fireEvent.click(within(followUpEditor).getByRole("button", { name: /Add logic/i }));
     fireEvent.click(within(followUpEditor).getByRole("button", { name: /trigger/i }));
+    expect(within(followUpEditor).queryByText("Create action")).not.toBeInTheDocument();
     fireEvent.click(within(followUpEditor).getByText("Notify (email)"));
 
     fireEvent.change(screen.getByPlaceholderText(/Morning Opening Checklist/), {
@@ -213,6 +214,45 @@ describe("ChecklistBuilderModal - new checklist", () => {
     expect(trigger.type).toBe("ask_question");
     expect(trigger.config.followUpQuestion.text).toBe("Did you recheck the fridge?");
     expect(trigger.config.followUpQuestion.config.logicRules[0].triggers[0].type).toBe("notify");
+  });
+
+  it("lets logic rules use a not-provided comparator and keep triggers attached", () => {
+    renderWithClient(<ChecklistBuilderModal onClose={onClose} onAdd={onAdd} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Add logic/i }));
+    fireEvent.change(screen.getByDisplayValue("is"), { target: { value: "unanswered" } });
+    expect(screen.getByText(/No response provided/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /trigger/i }));
+    fireEvent.click(screen.getByText("Require note"));
+
+    fireEvent.change(screen.getByPlaceholderText(/Morning Opening Checklist/), {
+      target: { value: "Unanswered Checklist" },
+    });
+    fireEvent.click(screen.getByText("Create checklist"));
+
+    const saved = onAdd.mock.calls[0][0] as any;
+    expect(saved.sections[0].questions[0].config.logicRules[0].comparator).toBe("unanswered");
+    expect(saved.sections[0].questions[0].config.logicRules[0].value).toBe("");
+    expect(saved.sections[0].questions[0].config.logicRules[0].triggers[0].type).toBe("require_note");
+  });
+
+  it("shows colored multiple-choice options and hides the create action trigger option", async () => {
+    renderWithClient(<ChecklistBuilderModal onClose={onClose} onAdd={onAdd} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Checkbox" }));
+    fireEvent.click(screen.getByText("Good"));
+
+    await waitFor(() => {
+      const blueColorButtons = screen.getAllByRole("button", { name: "Blue" });
+      expect(blueColorButtons[0]).toHaveClass("bg-blue-100");
+      fireEvent.click(blueColorButtons[0]);
+      expect(blueColorButtons[0]).toHaveAttribute("aria-pressed", "true");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Add logic/i }));
+    fireEvent.click(screen.getByRole("button", { name: /trigger/i }));
+    expect(screen.queryByText("Create action")).not.toBeInTheDocument();
   });
 
   it("shows Start date picker", () => {
@@ -347,10 +387,22 @@ describe("ChecklistBuilderModal - new checklist", () => {
 
     const optionInputs = screen.getAllByDisplayValue(/Good|Fair|Poor|N\/A/);
     fireEvent.change(optionInputs[0], { target: { value: "Perhaps" } });
+    const blueColorButtons = screen.getAllByRole("button", { name: "Blue" });
+    fireEvent.click(blueColorButtons[0]);
+    expect(blueColorButtons[0]).toHaveAttribute("aria-pressed", "true");
 
     fireEvent.click(screen.getByText("Add option"));
     expect(screen.getByDisplayValue("Perhaps")).toBeInTheDocument();
     expect(screen.getByDisplayValue("Option 5")).toBeInTheDocument();
+  });
+
+  it("hides Create action from the trigger menu until the full flow exists", () => {
+    renderWithClient(<ChecklistBuilderModal onClose={onClose} onAdd={onAdd} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Add logic/i }));
+    fireEvent.click(screen.getByRole("button", { name: /trigger/i }));
+
+    expect(screen.queryByText("Create action")).not.toBeInTheDocument();
   });
 
   it("keeps number questions in single-value mode by default", () => {


### PR DESCRIPTION
This bucket tightens checklist logic and builder UX:

- adds the not-provided trigger condition
- removes the unfinished Create action trigger option
- makes multiple-choice color selection visibly preview the chosen color and adds Blue
- adds/updates regressions for unanswered, trigger visibility, and color selection

Closes #210
Closes #212
Closes #215

#211 was validated by the existing kiosk runtime tests in this branch and will be tracked separately if we need a follow-up patch.