### PR TITLE
Assign a default admin PIN on signup

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -11,6 +11,7 @@ interface TeamMemberProfile {
   role: string;
   location_ids: string[];
   permissions: Record<string, boolean>;
+  pin_reset_required?: boolean;
 }
 
 interface AuthContextValue {

--- a/src/hooks/useTeamMembers.ts
+++ b/src/hooks/useTeamMembers.ts
@@ -12,17 +12,18 @@ export function useTeamMembers() {
     queryFn: async () => {
       const { data, error } = await supabase
         .from("team_members")
-        .select("id, organization_id, name, email, role, location_ids, permissions")
+        .select("id, organization_id, name, email, role, location_ids, permissions, pin_reset_required")
         .order("name");
       if (error) throw error;
       return ((data ?? []) as any[])
         .filter((member) => member.organization_id === teamMember?.organization_id)
         .map((m) => ({
-        ...m,
-        initials: getInitials(m.name),
-        permissions: (m.permissions ?? DEFAULT_PERMISSIONS) as ManagerPermissions,
-        location_ids: m.location_ids ?? [],
-      })) as TeamMember[];
+          ...m,
+          initials: getInitials(m.name),
+          permissions: (m.permissions ?? DEFAULT_PERMISSIONS) as ManagerPermissions,
+          location_ids: m.location_ids ?? [],
+          pin_reset_required: m.pin_reset_required ?? false,
+        })) as TeamMember[];
     },
     enabled: !!teamMember?.organization_id,
   });
@@ -47,6 +48,9 @@ export function useSaveTeamMember() {
         };
         if (tm.rawPin) {
           updatePayload.pin = await hashPin(tm.rawPin);
+          updatePayload.pin_reset_required = false;
+        } else if (tm.pin_reset_required !== undefined) {
+          updatePayload.pin_reset_required = tm.pin_reset_required;
         }
 
         const { data: updated, error } = await supabase
@@ -72,6 +76,7 @@ export function useSaveTeamMember() {
       if (tm.rawPin) {
         insertPayload.pin = await hashPin(tm.rawPin);
       }
+      insertPayload.pin_reset_required = tm.pin_reset_required ?? (tm.role === "Owner");
 
       const { error } = await supabase.from("team_members").insert(insertPayload);
       if (error) throw error;

--- a/src/lib/admin-repository.ts
+++ b/src/lib/admin-repository.ts
@@ -94,6 +94,7 @@ export interface TeamMember {
   initials: string;
   permissions: ManagerPermissions;
   pin?: string | null;
+  pin_reset_required?: boolean;
 }
 
 export interface AuditLogEntry {
@@ -110,6 +111,8 @@ export interface AuditLogEntry {
 export function generatePin(): string {
   return String(Math.floor(1000 + Math.random() * 9000));
 }
+
+export const DEFAULT_ADMIN_PIN = "1234";
 
 export function getInitials(name: string): string {
   return name

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -16,7 +16,7 @@ import {
   type Location, type StaffProfile, type TeamMember, type ManagerPermissions,
   type AuditLogEntry, type AccountRole,
   type StaffDepartment,
-  DEFAULT_PERMISSIONS, DEFAULT_STAFF_DEPARTMENTS, flattenStaffDepartments, getRoleDepartment,
+  DEFAULT_ADMIN_PIN, DEFAULT_PERMISSIONS, DEFAULT_STAFF_DEPARTMENTS, flattenStaffDepartments, getRoleDepartment,
   getInitials, daysAgo, daysAgoTooltip, staffDisplayName, formatTimestamp, generatePin,
 } from "@/lib/admin-repository";
 import { useAuth } from "@/contexts/AuthContext";
@@ -387,7 +387,12 @@ function TeamMemberModal({
   const [role, setRole] = useState<AccountRole>(member?.role ?? "Manager");
   const [locationIds, setLocationIds] = useState<string[]>(member?.location_ids ?? []);
   const [perms, setPerms] = useState<ManagerPermissions>(member?.permissions ?? { ...DEFAULT_PERMISSIONS });
-  const [pin, setPin] = useState(() => member?.id ? "" : generatePin());
+  const [pin, setPin] = useState(() => member?.id ? "" : (role === "Owner" ? DEFAULT_ADMIN_PIN : generatePin()));
+
+  useEffect(() => {
+    if (member?.id) return;
+    setPin(role === "Owner" ? DEFAULT_ADMIN_PIN : generatePin());
+  }, [member?.id, role]);
 
   const toggleLocation = (id: string) => {
     setLocationIds(prev => prev.includes(id) ? prev.filter(l => l !== id) : [...prev, id]);
@@ -452,7 +457,9 @@ function TeamMemberModal({
             </p>
           ) : (
             <p className="text-xs text-amber-600/80 bg-amber-50 rounded-lg px-3 py-2 mb-2 leading-relaxed">
-              This PIN is used for kiosk/admin access. Generate one now so the account owner can log in from the kiosk.
+              {role === "Owner"
+                ? `New owner accounts start with PIN ${DEFAULT_ADMIN_PIN} and should change it immediately for security.`
+                : "This PIN is used for kiosk access. Generate one now so the staff member can log in."}
             </p>
           )}
           <div className="flex gap-2">
@@ -1163,6 +1170,7 @@ function AccountTab({
     permissions: DEFAULT_PERMISSIONS,
   } : null);
   const assignedLocationIds = currentAccount?.location_ids ?? [];
+  const needsDefaultPinChange = Boolean(currentAccount?.pin_reset_required);
   const [profileName, setProfileName] = useState(authUserName ?? currentAccount?.name ?? "");
   const [profileEmail, setProfileEmail] = useState(authUserEmail ?? currentAccount?.email ?? "");
   const [pin, setPin] = useState("");
@@ -1243,6 +1251,7 @@ function AccountTab({
         location_ids: currentAccount.location_ids,
         permissions: currentAccount.permissions,
         rawPin: pin,
+        pin_reset_required: false,
       });
       setPin("");
       toast.success("Admin PIN updated");
@@ -1410,6 +1419,13 @@ function AccountTab({
             Admin app sign-in uses email codes. Use a 4-digit PIN for kiosk-side admin access, or create a new PIN if the old one was forgotten.
           </p>
         </div>
+
+        {needsDefaultPinChange && (
+          <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs leading-relaxed text-amber-900">
+            New owner accounts start with PIN <span className="font-semibold">{DEFAULT_ADMIN_PIN}</span>.
+            Change it right away for security before using kiosk mode.
+          </div>
+        )}
 
         <div className="space-y-3">
           <label className="space-y-1 block">
@@ -2220,6 +2236,7 @@ export default function Admin() {
                 initials: getInitials(authMember.name),
                 location_ids: authMember.location_ids,
                 permissions: authMember.permissions,
+                pin_reset_required: authMember.pin_reset_required ?? false,
               } : null}
               authMemberId={authMember?.id}
               authUserEmail={user?.email}

--- a/src/test/hooks/useTeamMembers.test.tsx
+++ b/src/test/hooks/useTeamMembers.test.tsx
@@ -128,17 +128,46 @@ describe("useSaveTeamMember", () => {
         role: "Owner",
         location_ids: [],
         permissions: {},
-        rawPin: "1234",
+      rawPin: "1234",
       } as any);
     });
 
     expect(update).toHaveBeenCalledWith(
       expect.objectContaining({
         pin: expect.any(String),
+        pin_reset_required: false,
       }),
     );
     const payload = update.mock.calls[0][0];
     expect(payload.pin).toHaveLength(64);
+  });
+
+  it("marks a newly created owner PIN as needing a reset", async () => {
+    const insert = vi.fn().mockResolvedValue({ error: null });
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue({ data: [], error: null }),
+      update: vi.fn().mockReturnValue({ eq: vi.fn() }),
+      insert,
+      delete: vi.fn().mockReturnThis(),
+    });
+
+    const { result } = renderHook(() => useSaveTeamMember(), { wrapper: makeWrapper() });
+    await act(async () => {
+      await result.current.mutateAsync({
+        name: "Test Owner",
+        email: "owner@example.com",
+        role: "Owner",
+        location_ids: [],
+        permissions: {},
+        rawPin: "1234",
+      } as any);
+    });
+
+    expect(insert).toHaveBeenCalledWith(expect.objectContaining({
+      pin_reset_required: true,
+    }));
   });
 
   it("fails loudly when an existing team member update affects no rows", async () => {

--- a/src/test/pages/Admin.test.tsx
+++ b/src/test/pages/Admin.test.tsx
@@ -54,7 +54,7 @@ vi.mock("@/contexts/AuthContext", () => ({
   useAuth: () => ({
     user: { id: "u1", email: "manager@example.com" },
     session: { user: { id: "u1" } },
-    teamMember: { id: "u1", organization_id: "org1", name: "Sarah", email: "sarah@example.com", role: "Owner", location_ids: [], permissions: {} },
+    teamMember: { id: "u1", organization_id: "org1", name: "Sarah", email: "sarah@example.com", role: "Owner", location_ids: [], permissions: {}, pin_reset_required: true },
     loading: false,
     signOut: vi.fn(),
   }),
@@ -93,7 +93,7 @@ const mockStaff = [
 ];
 
 const mockTeam = [
-  { id: "tm1", name: "Sarah Owner", email: "sarah@example.com", role: "Owner", initials: "SO", location_ids: ["l1"], permissions: { create_edit_checklists: true, assign_checklists: true, manage_staff_profiles: true, view_reporting: true, edit_location_details: true, manage_alerts: true, export_data: true, override_inactivity_threshold: true } },
+  { id: "tm1", name: "Sarah Owner", email: "sarah@example.com", role: "Owner", initials: "SO", location_ids: ["l1"], pin_reset_required: true, permissions: { create_edit_checklists: true, assign_checklists: true, manage_staff_profiles: true, view_reporting: true, edit_location_details: true, manage_alerts: true, export_data: true, override_inactivity_threshold: true } },
   { id: "tm2", name: "Mike Manager", email: "mike@example.com", role: "Manager", initials: "MM", location_ids: ["l2"], permissions: { create_edit_checklists: true, assign_checklists: true, manage_staff_profiles: false, view_reporting: true, edit_location_details: false, manage_alerts: false, export_data: false, override_inactivity_threshold: false } },
 ];
 
@@ -382,6 +382,7 @@ describe("Admin page", () => {
     await waitFor(() => {
       expect(screen.getByText("My account")).toBeInTheDocument();
       expect(screen.getByText("Security")).toBeInTheDocument();
+      expect(screen.getAllByText((_, element) => element?.textContent?.includes("New owner accounts start with PIN 1234") ?? false).length).toBeGreaterThan(0);
       expect(screen.getByText("Assigned locations")).toBeInTheDocument();
       expect(screen.getByText("Role and permissions")).toBeInTheDocument();
       expect(screen.getByDisplayValue("Sarah")).toBeInTheDocument();

--- a/supabase/migrations/20260413000003_default_admin_pin.sql
+++ b/supabase/migrations/20260413000003_default_admin_pin.sql
@@ -1,0 +1,120 @@
+-- ================================================================
+-- Brand-new owner accounts start with a known admin PIN.
+--
+-- This keeps kiosk/admin access predictable immediately after signup,
+-- while the Admin UI clearly prompts the owner to change it.
+-- ================================================================
+
+ALTER TABLE public.team_members
+  ADD COLUMN IF NOT EXISTS pin_reset_required boolean NOT NULL DEFAULT false;
+
+ALTER TABLE IF EXISTS public.team_members_cleanup_backup
+  ADD COLUMN IF NOT EXISTS pin_reset_required boolean;
+
+CREATE OR REPLACE FUNCTION public.setup_new_organization(
+  p_business_name TEXT,
+  p_location_name TEXT DEFAULT NULL,
+  p_owner_name    TEXT DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id              uuid := auth.uid();
+  v_user_email           text;
+  v_owner_name           text;
+  v_org_id               uuid;
+  v_conflicting_owner_id uuid;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(1, hashtext(v_user_id::text));
+
+  IF EXISTS (SELECT 1 FROM team_members WHERE id = v_user_id) THEN
+    SELECT organization_id INTO v_org_id
+    FROM team_members
+    WHERE id = v_user_id;
+
+    RETURN jsonb_build_object(
+      'organization_id', v_org_id,
+      'existed', true
+    );
+  END IF;
+
+  SELECT
+    email,
+    COALESCE(
+      raw_user_meta_data->>'full_name',
+      split_part(email, '@', 1)
+    )
+  INTO v_user_email, v_owner_name
+  FROM auth.users
+  WHERE id = v_user_id;
+
+  IF p_owner_name IS NOT NULL AND trim(p_owner_name) != '' THEN
+    v_owner_name := trim(p_owner_name);
+  END IF;
+
+  SELECT tm.id
+  INTO v_conflicting_owner_id
+  FROM public.team_members tm
+  WHERE lower(trim(tm.email)) = lower(trim(v_user_email))
+    AND lower(tm.role) = 'owner'
+    AND tm.archived_at IS NULL
+    AND tm.id <> v_user_id
+  LIMIT 1;
+
+  IF v_conflicting_owner_id IS NOT NULL THEN
+    RAISE EXCEPTION
+      'An owner account with email % already exists. Please contact support so we can safely verify your organization access.',
+      v_user_email;
+  END IF;
+
+  INSERT INTO organizations (name, plan, plan_status)
+  VALUES (trim(p_business_name), 'starter', 'active')
+  RETURNING id INTO v_org_id;
+
+  INSERT INTO team_members (
+    id,
+    organization_id,
+    name,
+    email,
+    role,
+    location_ids,
+    permissions,
+    pin,
+    pin_reset_required
+  ) VALUES (
+    v_user_id,
+    v_org_id,
+    v_owner_name,
+    v_user_email,
+    'Owner',
+    ARRAY[]::uuid[],
+    '{
+      "create_edit_checklists": true,
+      "assign_checklists": true,
+      "manage_staff_profiles": true,
+      "view_reporting": true,
+      "edit_location_details": true,
+      "manage_alerts": true,
+      "export_data": true,
+      "override_inactivity_threshold": true
+    }'::jsonb,
+    encode(extensions.digest('1234', 'sha256'), 'hex'),
+    true
+  );
+
+  RETURN jsonb_build_object(
+    'organization_id', v_org_id,
+    'existed', false
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.setup_new_organization(TEXT, TEXT, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.setup_new_organization(TEXT, TEXT, TEXT) TO authenticated;


### PR DESCRIPTION
## Summary
- assign new owner accounts a default admin PIN of `1234` during setup
- mark the default PIN as requiring a reset so Admin can prompt for a safer replacement
- update admin/team-member tests to cover the new signup and PIN-reset behavior

## Verification
- `bunx vitest run src/test/pages/Signup.test.tsx src/test/pages/Admin.test.tsx src/test/hooks/useTeamMembers.test.tsx`
- `bun run build`
- `bun run lint`

Closes #203