### PR TITLE
Tighten authenticated page widths

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -19,8 +19,8 @@ export function Layout({ children, title, subtitle, headerRight, headerLeft }: L
   const navigate = useNavigate();
   const location = useLocation();
   const mainRef = useRef<HTMLElement | null>(null);
-  const shellWidthClass = "mx-auto w-full max-w-[1320px]";
-  const contentWidthClass = "w-full max-w-[960px] xl:max-w-[920px]";
+  const shellWidthClass = "mx-auto w-full max-w-[1240px]";
+  const contentWidthClass = "w-full min-w-0 max-w-[920px] xl:max-w-[900px]";
 
   const handleLogout = async () => {
     await signOut();
@@ -73,9 +73,9 @@ export function Layout({ children, title, subtitle, headerRight, headerLeft }: L
       {/* Content */}
       <main ref={mainRef} className="flex-1 overflow-auto pb-24 pt-5 animate-fade-in md:pb-8">
         <div className={cn(shellWidthClass, "px-4 sm:px-6 lg:px-8 xl:px-10")}>
-          <div className="flex items-start gap-6 lg:gap-8">
+          <div className="flex min-w-0 items-start gap-6 lg:gap-8">
             <SidebarNav />
-            <div className={cn(contentWidthClass, "space-y-4")}>
+            <div className={cn(contentWidthClass, "min-w-0 space-y-4")}>
               {children}
             </div>
           </div>

--- a/src/pages/Infohub.tsx
+++ b/src/pages/Infohub.tsx
@@ -751,7 +751,7 @@ function LibraryDocDetail({ doc, folders, onBack, onSave }: {
   }
 
   return (
-    <div className="min-h-screen bg-background flex flex-col w-full min-[900px]:max-w-none mx-auto">
+    <div className="min-h-screen bg-background flex flex-col w-full min-[900px]:max-w-[1120px] xl:max-w-[1040px] mx-auto">
       <header className="sticky top-0 z-40 bg-background/95 backdrop-blur-sm border-b border-border px-5 py-4">
         <div className="flex items-center gap-3">
           <button onClick={isEditing ? () => setIsEditing(false) : onBack} className="p-1.5 rounded-full hover:bg-muted transition-colors">
@@ -901,7 +901,7 @@ function TrainingDocDetail({ doc, onBack, onToggleComplete }: {
   };
 
   return (
-    <div className="min-h-screen bg-background flex flex-col w-full min-[900px]:max-w-none mx-auto">
+    <div className="min-h-screen bg-background flex flex-col w-full min-[900px]:max-w-[1120px] xl:max-w-[1040px] mx-auto">
       <header className="sticky top-0 z-40 bg-background/95 backdrop-blur-sm border-b border-border px-5 py-4">
         <div className="flex items-center gap-3">
           <button onClick={onBack} className="p-1.5 rounded-full hover:bg-muted transition-colors">
@@ -989,7 +989,7 @@ function SearchOverlay({ libraryDocs, trainingDocs, onClose, onSelectLibDoc, onS
   ) : [];
 
   return (
-    <div className="fixed inset-0 z-50 bg-background flex flex-col w-full min-[900px]:max-w-none mx-auto">
+    <div className="fixed inset-0 z-50 bg-background flex flex-col w-full min-[900px]:max-w-[1120px] xl:max-w-[1040px] mx-auto">
       <header className="border-b border-border px-4 py-3 flex items-center gap-3">
         <Search size={16} className="text-muted-foreground shrink-0" />
         <input

--- a/src/pages/Training.tsx
+++ b/src/pages/Training.tsx
@@ -160,7 +160,7 @@ function ModuleDetail({
   };
 
   return (
-    <div className="min-h-screen bg-background flex flex-col w-full min-[900px]:max-w-none mx-auto">
+    <div className="min-h-screen bg-background flex flex-col w-full min-[900px]:max-w-[1120px] xl:max-w-[1040px] mx-auto">
       <header className="sticky top-0 z-40 bg-background/95 backdrop-blur-sm border-b border-border px-5 py-4">
         <div className="flex items-center gap-3">
           <button onClick={onBack} className="p-1.5 rounded-full hover:bg-muted transition-colors">


### PR DESCRIPTION
## Summary\n- tighten the authenticated shell widths so primary pages do not stretch awkwardly on large screens\n- constrain the full-screen Infohub and Training detail views to a comfortable desktop width\n- keep the current visual language and page behavior intact\n\n## Verification\n- bun run test src/test/components/Layout.test.tsx src/test/pages/Infohub.test.tsx src/test/pages/Infohub.extended.test.tsx src/test/pages/Training.test.tsx src/test/pages/Admin.test.tsx\n- bun run build\n\nCloses #92