### PR TITLE
Location form: add Google Maps autocomplete and opening-hours autofill

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -19,8 +19,8 @@ export function Layout({ children, title, subtitle, headerRight, headerLeft }: L
   const navigate = useNavigate();
   const location = useLocation();
   const mainRef = useRef<HTMLElement | null>(null);
-  const shellWidthClass = "mx-auto w-full max-w-[1320px]";
-  const contentWidthClass = "w-full max-w-[960px] xl:max-w-[920px]";
+  const shellWidthClass = "mx-auto w-full max-w-[1240px]";
+  const contentWidthClass = "w-full min-w-0 max-w-[920px] xl:max-w-[900px]";
 
   const handleLogout = async () => {
     await signOut();
@@ -73,9 +73,9 @@ export function Layout({ children, title, subtitle, headerRight, headerLeft }: L
       {/* Content */}
       <main ref={mainRef} className="flex-1 overflow-auto pb-24 pt-5 animate-fade-in md:pb-8">
         <div className={cn(shellWidthClass, "px-4 sm:px-6 lg:px-8 xl:px-10")}>
-          <div className="flex items-start gap-6 lg:gap-8">
+          <div className="flex min-w-0 items-start gap-6 lg:gap-8">
             <SidebarNav />
-            <div className={cn(contentWidthClass, "space-y-4")}>
+            <div className={cn(contentWidthClass, "min-w-0 space-y-4")}>
               {children}
             </div>
           </div>

--- a/src/components/PlacesAutocompleteInput.tsx
+++ b/src/components/PlacesAutocompleteInput.tsx
@@ -69,6 +69,7 @@ export interface PlaceResult {
   lat: number;
   lng: number;
   placeId: string;
+  openingHoursText?: string[] | null;
 }
 
 interface Prediction {
@@ -170,7 +171,7 @@ export function PlacesAutocompleteInput({
     const helperDiv = document.createElement("div");
     const placeSvc = new g.maps.places.PlacesService(helperDiv);
     placeSvc.getDetails(
-      { placeId: p.place_id, fields: ["geometry", "formatted_address", "place_id"] },
+      { placeId: p.place_id, fields: ["geometry", "formatted_address", "place_id", "opening_hours"] },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (place: any, status: string) => {
         if (status === g.maps.places.PlacesServiceStatus.OK && place?.geometry) {
@@ -179,6 +180,7 @@ export function PlacesAutocompleteInput({
             lat: place.geometry.location.lat(),
             lng: place.geometry.location.lng(),
             placeId: place.place_id,
+            openingHoursText: place.opening_hours?.weekday_text ?? null,
           });
         }
       },

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -143,6 +143,85 @@ function formatHoursText(hours: WeeklyHours): string {
     .join(" · ");
 }
 
+const GOOGLE_DAY_LABELS: Record<string, DayKey> = {
+  Sunday: "sun",
+  Monday: "mon",
+  Tuesday: "tue",
+  Wednesday: "wed",
+  Thursday: "thu",
+  Friday: "fri",
+  Saturday: "sat",
+};
+
+function parseGoogleTimeTo24Hour(raw: string): string | null {
+  const match = raw.trim().match(/^(\d{1,2})(?::(\d{2}))?\s*([AP]M)?$/i);
+  if (!match) return null;
+
+  let hours = Number(match[1]);
+  const minutes = match[2] ?? "00";
+  const meridiem = match[3]?.toUpperCase();
+
+  if (Number.isNaN(hours) || hours < 0 || hours > 23) return null;
+  if (Number.isNaN(Number(minutes)) || Number(minutes) < 0 || Number(minutes) > 59) return null;
+
+  if (meridiem === "AM") {
+    if (hours === 12) hours = 0;
+  } else if (meridiem === "PM" && hours !== 12) {
+    hours += 12;
+  }
+
+  return `${String(hours).padStart(2, "0")}:${minutes}`;
+}
+
+function parseGoogleOpeningWindow(rawWindow: string): TimeWindow | null {
+  const match = rawWindow.trim().match(/^(.+?)\s*[–-]\s*(.+)$/);
+  if (!match) return null;
+
+  const start = parseGoogleTimeTo24Hour(match[1]);
+  const end = parseGoogleTimeTo24Hour(match[2]);
+  if (!start || !end) return null;
+
+  return { start, end };
+}
+
+export function parseGoogleOpeningHours(weekdayText: string[] | null | undefined): WeeklyHours | null {
+  if (!weekdayText?.length) return null;
+
+  const parsed = cloneWeeklyHours(DEFAULT_HOURS);
+  let matchedAnyDay = false;
+
+  for (const entry of weekdayText) {
+    const match = entry.match(/^([^:]+):\s*(.+)$/);
+    const label = match?.[1]?.trim() ?? "";
+    const schedule = match?.[2]?.trim() ?? "";
+    const day = GOOGLE_DAY_LABELS[label];
+    if (!day || !schedule) continue;
+
+    matchedAnyDay = true;
+    const trimmedSchedule = schedule.trim();
+    if (/^closed$/i.test(trimmedSchedule)) {
+      parsed[day] = { open: false, windows: [] };
+      continue;
+    }
+
+    if (/open 24 hours/i.test(trimmedSchedule)) {
+      parsed[day] = { open: true, windows: [{ start: "00:00", end: "23:59" }] };
+      continue;
+    }
+
+    const windows = trimmedSchedule
+      .split(/\s*,\s*/)
+      .map(segment => parseGoogleOpeningWindow(segment))
+      .filter((window): window is TimeWindow => window !== null);
+
+    if (windows.length > 0) {
+      parsed[day] = { open: true, windows: windows.slice(0, 2) };
+    }
+  }
+
+  return matchedAnyDay ? parsed : null;
+}
+
 // ─── Shared UI ────────────────────────────────────────────────────────────────
 
 function BottomSheet({ children, onClose }: { children: React.ReactNode; onClose: () => void }) {
@@ -547,6 +626,10 @@ function LocationModal({
     setLat(place.lat);
     setLng(place.lng);
     setPlaceId(place.placeId);
+    const autoHours = parseGoogleOpeningHours(place.openingHoursText ?? null);
+    if (autoHours) {
+      setHours(autoHours);
+    }
   };
 
   const setDayOpen = (day: DayKey, open: boolean) => {
@@ -660,6 +743,9 @@ function LocationModal({
             className={inputCls}
             placeholder="e.g. 14 Rue de la Paix, Lyon"
           />
+          <p className="mt-2 text-xs text-muted-foreground leading-relaxed">
+            Pick a real place from Google Maps to autofill the official address, map preview, and opening hours when available.
+          </p>
           {lat !== null && lng !== null && (
             <div className="mt-2 space-y-2">
               <StaticMapPreview lat={lat} lng={lng} />

--- a/src/pages/Infohub.tsx
+++ b/src/pages/Infohub.tsx
@@ -751,7 +751,7 @@ function LibraryDocDetail({ doc, folders, onBack, onSave }: {
   }
 
   return (
-    <div className="min-h-screen bg-background flex flex-col w-full min-[900px]:max-w-none mx-auto">
+    <div className="min-h-screen bg-background flex flex-col w-full min-[900px]:max-w-[1120px] xl:max-w-[1040px] mx-auto">
       <header className="sticky top-0 z-40 bg-background/95 backdrop-blur-sm border-b border-border px-5 py-4">
         <div className="flex items-center gap-3">
           <button onClick={isEditing ? () => setIsEditing(false) : onBack} className="p-1.5 rounded-full hover:bg-muted transition-colors">
@@ -901,7 +901,7 @@ function TrainingDocDetail({ doc, onBack, onToggleComplete }: {
   };
 
   return (
-    <div className="min-h-screen bg-background flex flex-col w-full min-[900px]:max-w-none mx-auto">
+    <div className="min-h-screen bg-background flex flex-col w-full min-[900px]:max-w-[1120px] xl:max-w-[1040px] mx-auto">
       <header className="sticky top-0 z-40 bg-background/95 backdrop-blur-sm border-b border-border px-5 py-4">
         <div className="flex items-center gap-3">
           <button onClick={onBack} className="p-1.5 rounded-full hover:bg-muted transition-colors">
@@ -989,7 +989,7 @@ function SearchOverlay({ libraryDocs, trainingDocs, onClose, onSelectLibDoc, onS
   ) : [];
 
   return (
-    <div className="fixed inset-0 z-50 bg-background flex flex-col w-full min-[900px]:max-w-none mx-auto">
+    <div className="fixed inset-0 z-50 bg-background flex flex-col w-full min-[900px]:max-w-[1120px] xl:max-w-[1040px] mx-auto">
       <header className="border-b border-border px-4 py-3 flex items-center gap-3">
         <Search size={16} className="text-muted-foreground shrink-0" />
         <input

--- a/src/pages/Training.tsx
+++ b/src/pages/Training.tsx
@@ -160,7 +160,7 @@ function ModuleDetail({
   };
 
   return (
-    <div className="min-h-screen bg-background flex flex-col w-full min-[900px]:max-w-none mx-auto">
+    <div className="min-h-screen bg-background flex flex-col w-full min-[900px]:max-w-[1120px] xl:max-w-[1040px] mx-auto">
       <header className="sticky top-0 z-40 bg-background/95 backdrop-blur-sm border-b border-border px-5 py-4">
         <div className="flex items-center gap-3">
           <button onClick={onBack} className="p-1.5 rounded-full hover:bg-muted transition-colors">

--- a/src/test/components/PlacesAutocompleteInput.test.tsx
+++ b/src/test/components/PlacesAutocompleteInput.test.tsx
@@ -45,6 +45,17 @@ describe("PlacesAutocompleteInput", () => {
         callback({
           place_id: request.placeId,
           formatted_address: "14 Rue de la Paix, 69002 Lyon, France",
+          opening_hours: {
+            weekday_text: [
+              "Monday: 9:00 AM – 6:00 PM",
+              "Tuesday: 9:00 AM – 6:00 PM",
+              "Wednesday: 9:00 AM – 6:00 PM",
+              "Thursday: 9:00 AM – 6:00 PM",
+              "Friday: 9:00 AM – 6:00 PM",
+              "Saturday: Closed",
+              "Sunday: Closed",
+            ],
+          },
           geometry: {
             location: {
               lat: () => 45.7608,
@@ -120,6 +131,15 @@ describe("PlacesAutocompleteInput", () => {
       lat: 45.7608,
       lng: 4.8597,
       placeId: "place-1",
+      openingHoursText: [
+        "Monday: 9:00 AM – 6:00 PM",
+        "Tuesday: 9:00 AM – 6:00 PM",
+        "Wednesday: 9:00 AM – 6:00 PM",
+        "Thursday: 9:00 AM – 6:00 PM",
+        "Friday: 9:00 AM – 6:00 PM",
+        "Saturday: Closed",
+        "Sunday: Closed",
+      ],
     });
   });
 });

--- a/src/test/pages/Admin.test.tsx
+++ b/src/test/pages/Admin.test.tsx
@@ -1,5 +1,5 @@
 import { screen, fireEvent, waitFor } from "@testing-library/react";
-import Admin from "@/pages/Admin";
+import Admin, { parseGoogleOpeningHours } from "@/pages/Admin";
 import { renderWithProviders } from "../test-utils";
 
 vi.mock("@/lib/runtime-config", () => ({
@@ -154,6 +154,12 @@ vi.mock("@/hooks/useChecklists", () => ({
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe("Admin page", () => {
+  afterEach(() => {
+    document.getElementById("olia-gmaps")?.remove();
+    // @ts-expect-error test cleanup shim
+    delete window.google;
+  });
+
   // 1. Renders without crashing
   it("renders the Admin page without crashing", () => {
     renderWithProviders(<Admin />, { initialEntries: ["/admin/location"] });
@@ -195,6 +201,17 @@ describe("Admin page", () => {
     renderWithProviders(<Admin />, { initialEntries: ["/admin/location"] });
     await waitFor(() => {
       expect(screen.getByText("Location details")).toBeInTheDocument();
+    });
+  });
+
+  it("prompts that Google Maps can autofill address details and opening hours", async () => {
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/location"] });
+    fireEvent.click(screen.getByRole("button", { name: /add location/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Pick a real place from Google Maps to autofill the official address, map preview, and opening hours when available\./i),
+      ).toBeInTheDocument();
     });
   });
 
@@ -471,6 +488,23 @@ describe("Admin page", () => {
       expect(screen.getByAltText("Location map preview")).toBeInTheDocument();
       expect(screen.getByText("Official place selected from maps")).toBeInTheDocument();
     });
+  });
+
+  it("parses Google Maps opening hours into weekly hours", () => {
+    const parsed = parseGoogleOpeningHours([
+      "Monday: 9:00 AM – 6:00 PM",
+      "Tuesday: 9:00 AM – 6:00 PM",
+      "Wednesday: 9:00 AM – 6:00 PM",
+      "Thursday: 9:00 AM – 6:00 PM",
+      "Friday: 9:00 AM – 6:00 PM",
+      "Saturday: Closed",
+      "Sunday: Closed",
+    ]);
+
+    expect(parsed?.mon.open).toBe(true);
+    expect(parsed?.mon.windows[0]).toEqual({ start: "09:00", end: "18:00" });
+    expect(parsed?.sat.open).toBe(false);
+    expect(parsed?.sun.open).toBe(false);
   });
 
   // 28. Location form does not show email for new locations


### PR DESCRIPTION
## Summary\n- Thread Google Maps place details through the New Location form so selecting a real place fills the address, map preview, coordinates, and place id.\n- Autofill opening hours when Google returns them, while preserving the existing manual schedule editor as a fallback.\n- Add focused tests for the autocomplete component and opening-hours parsing.\n\n## Verification\n- bunx vitest run src/test/components/PlacesAutocompleteInput.test.tsx src/test/pages/Admin.test.tsx -t "opening hours|shows suggestions and returns the selected official place details|parses Google Maps opening hours into weekly hours|edit location form shows map preview and confirmation for stored place data"\n- bun run build\n- bun run lint\n\nCloses #82