### PR TITLE
Rewrite operational alerts with user-friendly copy

### DIFF
--- a/src/lib/alert-copy.ts
+++ b/src/lib/alert-copy.ts
@@ -1,0 +1,74 @@
+export interface AlertCopy {
+  title: string;
+  body: string;
+  helper: string;
+}
+
+export interface AlertLike {
+  type: "error" | "warn";
+  message: string;
+  area: string | null;
+  time: string | null;
+  source: string | null;
+}
+
+function cleanMessage(message: string): string {
+  return message
+    .replace(/^Action required:\s*/i, "")
+    .replace(/^Action needed:\s*/i, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function extractQuotedSubject(message: string): string | null {
+  const quoted = message.match(/"([^"]+)"/)?.[1]?.trim();
+  if (quoted) return quoted.replace(/\s*-\s*$/, "").trim();
+
+  const cleaned = cleanMessage(message);
+  const split = cleaned.split(/\s+(?:answered|recorded)\s+/i)[0]?.trim();
+  return split || null;
+}
+
+function formatContext(alert: AlertLike): string {
+  const bits = [alert.area?.trim()].filter(Boolean) as string[];
+  if (alert.time?.trim()) bits.push(alert.time.trim());
+  return bits.length > 0 ? bits.join(" · ") : "Open the checklist for more detail.";
+}
+
+export function formatOperationalAlertCopy(alert: AlertLike): AlertCopy {
+  const message = alert.message.trim();
+  const lower = message.toLowerCase();
+  const subject = extractQuotedSubject(message);
+
+  if (lower.includes("outside the allowed range")) {
+    const range = message.match(/\(([^)]+)\)\s*$/)?.[1]?.trim();
+    const value = message.match(/recorded\s+(.+?)\s+—/i)?.[1]?.trim();
+    return {
+      title: "Response needs a review",
+      body: value ? `Recorded value: ${value}.` : "A recorded value is outside the expected range.",
+      helper: range ? `Allowed range: ${range}.` : formatContext(alert),
+    };
+  }
+
+  if (/(answered\s+is\s+n\/a|no response|not provided|left blank)/i.test(message)) {
+    return {
+      title: "Follow-up needed",
+      body: subject ? `${subject} was left unanswered.` : "A checklist step was left unanswered.",
+      helper: "A response was not provided, so this item needs attention.",
+    };
+  }
+
+  if (lower.startsWith("action required") || lower.startsWith("action needed")) {
+    return {
+      title: "Action needed",
+      body: subject ?? "A checklist step needs attention.",
+      helper: "Open the checklist to review the detail.",
+    };
+  }
+
+  return {
+    title: alert.type === "error" ? "Needs attention" : "Check this item",
+    body: subject ?? "A checklist step needs attention.",
+    helper: formatContext(alert),
+  };
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -11,6 +11,7 @@ import { useActions } from "@/hooks/useActions";
 import { useChecklists } from "@/hooks/useChecklists";
 import { useLocations } from "@/hooks/useLocations";
 import { computeMissedChecklists, computeOverdueActions } from "@/lib/overdue-utils";
+import { formatOperationalAlertCopy } from "@/lib/alert-copy";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -247,32 +248,30 @@ export default function Dashboard() {
             </div>
           ) : (
             <div className="space-y-2">
-              {visibleAlerts.map(alert => (
-                <button
-                  key={alert.id}
-                  type="button"
-                  onClick={() => navigate("/notifications")}
-                  className={cn(
-                    "w-full bg-card border border-border rounded-2xl px-4 py-3 flex items-start gap-3 border-l-4 text-left transition-colors hover:bg-muted/40 focus:outline-none focus:ring-1 focus:ring-ring",
-                    alert.type === "error" ? "border-l-status-error" : "border-l-status-warn"
-                  )}
-                  aria-label={`Open alerts and review ${alert.message}`}
-                >
-                  <AlertCircle size={15}
-                    className={cn("mt-0.5 shrink-0", alert.type === "error" ? "text-status-error" : "text-status-warn")}
-                  />
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium text-foreground leading-snug">{alert.message}</p>
-                    <div className="flex items-center gap-2 mt-0.5">
-                      <span className="text-xs text-muted-foreground">{alert.area}</span>
-                      {alert.time && (
-                        <><span className="text-muted-foreground/40">·</span>
-                        <span className="text-xs text-muted-foreground">{alert.time}</span></>
-                      )}
+              {visibleAlerts.map(alert => {
+                const copy = formatOperationalAlertCopy(alert);
+                return (
+                  <button
+                    key={alert.id}
+                    type="button"
+                    onClick={() => navigate("/notifications")}
+                    className={cn(
+                      "w-full bg-card border border-border rounded-2xl px-4 py-3 flex items-start gap-3 border-l-4 text-left transition-colors hover:bg-muted/40 focus:outline-none focus:ring-1 focus:ring-ring",
+                      alert.type === "error" ? "border-l-status-error" : "border-l-status-warn",
+                    )}
+                    aria-label={`Open alerts and review ${copy.title}`}
+                  >
+                    <AlertCircle size={15}
+                      className={cn("mt-0.5 shrink-0", alert.type === "error" ? "text-status-error" : "text-status-warn")}
+                    />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-semibold text-foreground leading-snug">{copy.title}</p>
+                      <p className="text-sm text-foreground/90 leading-snug mt-0.5">{copy.body}</p>
+                      <p className="text-xs text-muted-foreground mt-1">{copy.helper}</p>
                     </div>
-                  </div>
-                </button>
-              ))}
+                  </button>
+                );
+              })}
 
               {hasMore && (
                 <button

--- a/src/pages/Notifications.tsx
+++ b/src/pages/Notifications.tsx
@@ -3,6 +3,7 @@ import { Layout } from "@/components/Layout";
 import { AlertCircle, ArrowLeft, Trash2, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useAlerts, useDismissAlert, useClearAlerts } from "@/hooks/useAlerts";
+import { formatOperationalAlertCopy } from "@/lib/alert-copy";
 
 export default function Notifications() {
   const navigate = useNavigate();
@@ -54,39 +55,35 @@ export default function Notifications() {
           </div>
         ) : (
           <div className="card-surface divide-y divide-border overflow-hidden">
-            {alerts.map(alert => (
-              <div
-                key={alert.id}
-                className={cn(
-                  "flex items-start gap-3 p-4",
-                  alert.type === "error" ? "border-l-2 border-l-status-error" : "border-l-2 border-l-status-warn"
-                )}
-              >
-                <AlertCircle
-                  size={16}
-                  className={cn("mt-0.5 shrink-0", alert.type === "error" ? "text-status-error" : "text-status-warn")}
-                />
-                <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium text-foreground leading-snug">{alert.message}</p>
-                  <div className="flex items-center gap-2 mt-1">
-                    <span className="text-xs text-muted-foreground">{alert.area}</span>
-                    {alert.time && (
-                      <>
-                        <span className="text-muted-foreground/40">·</span>
-                        <span className="text-xs text-muted-foreground">{alert.time}</span>
-                      </>
-                    )}
-                  </div>
-                </div>
-                <button
-                  onClick={() => clearOne(alert.id)}
-                  className="p-1.5 rounded-full hover:bg-muted transition-colors shrink-0"
-                  aria-label="Dismiss alert"
+            {alerts.map(alert => {
+              const copy = formatOperationalAlertCopy(alert);
+              return (
+                <div
+                  key={alert.id}
+                  className={cn(
+                    "flex items-start gap-3 p-4",
+                    alert.type === "error" ? "border-l-2 border-l-status-error" : "border-l-2 border-l-status-warn",
+                  )}
                 >
-                  <X size={14} className="text-muted-foreground" />
-                </button>
-              </div>
-            ))}
+                  <AlertCircle
+                    size={16}
+                    className={cn("mt-0.5 shrink-0", alert.type === "error" ? "text-status-error" : "text-status-warn")}
+                  />
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-semibold text-foreground leading-snug">{copy.title}</p>
+                    <p className="text-sm text-foreground/90 leading-snug mt-0.5">{copy.body}</p>
+                    <p className="text-xs text-muted-foreground mt-1">{copy.helper}</p>
+                  </div>
+                  <button
+                    onClick={() => clearOne(alert.id)}
+                    className="p-1.5 rounded-full hover:bg-muted transition-colors shrink-0"
+                    aria-label="Dismiss alert"
+                  >
+                    <X size={14} className="text-muted-foreground" />
+                  </button>
+                </div>
+              );
+            })}
           </div>
         )}
       </section>

--- a/src/test/lib/alert-copy.test.ts
+++ b/src/test/lib/alert-copy.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { formatOperationalAlertCopy } from "@/lib/alert-copy";
+
+describe("formatOperationalAlertCopy", () => {
+  it("turns unanswered trigger text into friendly follow-up copy", () => {
+    const copy = formatOperationalAlertCopy({
+      type: "warn",
+      message: 'Action required: "Trigger test (n/a is the trigger) - " answered Is N/A',
+      area: "Kitchen",
+      time: "Now",
+      source: "action",
+    });
+
+    expect(copy.title).toBe("Follow-up needed");
+    expect(copy.body).toBe("Trigger test (n/a is the trigger) was left unanswered.");
+    expect(copy.helper).toBe("A response was not provided, so this item needs attention.");
+  });
+
+  it("turns out-of-range trigger text into a more readable review prompt", () => {
+    const copy = formatOperationalAlertCopy({
+      type: "error",
+      message: "Question Temperature + logic: recorded 1 — outside the allowed range (min 2, max 6)",
+      area: "Kitchen",
+      time: "12:32",
+      source: "action",
+    });
+
+    expect(copy.title).toBe("Response needs a review");
+    expect(copy.body).toBe("Recorded value: 1.");
+    expect(copy.helper).toBe("Allowed range: min 2, max 6.");
+  });
+});

--- a/src/test/pages/Dashboard.test.tsx
+++ b/src/test/pages/Dashboard.test.tsx
@@ -3,6 +3,7 @@ import Dashboard from "@/pages/Dashboard";
 import { renderWithProviders } from "../test-utils";
 
 const mockNavigate = vi.fn();
+const alertsState = { data: [] as any[] };
 
 const MOCK_LOCATIONS = [
   { id: "loc-1", name: "Main Branch" },
@@ -66,7 +67,7 @@ vi.mock("@/contexts/AuthContext", () => ({
 }));
 
 vi.mock("@/hooks/useAlerts", () => ({
-  useAlerts: vi.fn(() => ({ data: [] })),
+  useAlerts: vi.fn(() => alertsState),
   useCreateAlert: () => ({ mutate: vi.fn(), isPending: false }),
 }));
 
@@ -89,6 +90,7 @@ vi.mock("@/hooks/useLocations", () => ({
 describe("Dashboard page", () => {
   beforeEach(() => {
     mockNavigate.mockReset();
+    alertsState.data = [];
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-27T12:00:00Z"));
   });
@@ -163,6 +165,28 @@ describe("Dashboard page", () => {
     expect(screen.getByText("Operational alerts")).toBeInTheDocument();
     expect(screen.getByText("All clear")).toBeInTheDocument();
     expect(screen.getByText("It looks like everything is calm now.")).toBeInTheDocument();
+  });
+
+  it("renders user-friendly alert copy instead of the raw trigger text", () => {
+    alertsState.data = [
+      {
+        id: "a-1",
+        type: "warn",
+        message: 'Action required: "Trigger test (n/a is the trigger) - " answered Is N/A',
+        area: "Kitchen",
+        time: "Now",
+        source: "action",
+        dismissed_at: null,
+        created_at: "2026-03-09T09:00:00Z",
+      },
+    ];
+
+    renderWithProviders(<Dashboard />);
+
+    expect(screen.getByText("Follow-up needed")).toBeInTheDocument();
+    expect(screen.getByText("Trigger test (n/a is the trigger) was left unanswered.")).toBeInTheDocument();
+    expect(screen.getByText("A response was not provided, so this item needs attention.")).toBeInTheDocument();
+    expect(screen.queryByText(/Action required:/i)).not.toBeInTheDocument();
   });
 
   it("sorts location health from worst to best and opens reporting with the location filter", () => {

--- a/src/test/pages/Notifications.test.tsx
+++ b/src/test/pages/Notifications.test.tsx
@@ -70,7 +70,7 @@ describe("Notifications page", () => {
       {
         id: "a-1",
         type: "warn",
-        message: "Fridge temperature high",
+        message: 'Action required: "Trigger test (n/a is the trigger) - " answered Is N/A',
         area: "Kitchen",
         time: "09:00",
         source: "checklist",
@@ -79,7 +79,10 @@ describe("Notifications page", () => {
       },
     ];
     renderWithProviders(<Notifications />);
-    expect(screen.getByText("Fridge temperature high")).toBeInTheDocument();
+    expect(screen.getByText("Follow-up needed")).toBeInTheDocument();
+    expect(screen.getByText("Trigger test (n/a is the trigger) was left unanswered.")).toBeInTheDocument();
+    expect(screen.getByText("A response was not provided, so this item needs attention.")).toBeInTheDocument();
+    expect(screen.queryByText(/Action required:/i)).not.toBeInTheDocument();
   });
 
   it("shows 'Clear all' button when there are alerts", () => {


### PR DESCRIPTION
## Summary
- format operational alerts into calmer, user-friendly product copy instead of raw trigger strings
- use the new alert-copy layer on both the dashboard and notifications screens
- add focused regressions for the new alert messaging

## Verification
- `bunx vitest run src/test/lib/alert-copy.test.ts src/test/pages/Dashboard.test.tsx src/test/pages/Notifications.test.tsx`
- `bun run build`
- `bun run lint`

Closes #38