### PR TITLE
B1: fix GitHub Pages routing loop, stale lint directives, jsPDF build warning

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -19,7 +19,7 @@
           return;
         }
 
-        if (searchParams.get("p")) {
+        if (searchParams.get("p") !== null) {
           window.location.replace(basePath + "/" + search + hash);
           return;
         }

--- a/src/components/PlacesAutocompleteInput.tsx
+++ b/src/components/PlacesAutocompleteInput.tsx
@@ -104,7 +104,6 @@ export function PlacesAutocompleteInput({
   const [loading, setLoading] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const svcRef = useRef<any>(null);
 
   // Close dropdown when clicking outside
@@ -119,7 +118,6 @@ export function PlacesAutocompleteInput({
   }, []);
 
   const getAutocompleteService = useCallback(() => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const g = (window as any).google;
     if (!ready || !g?.maps?.places) return null;
     if (!svcRef.current) {
@@ -140,7 +138,6 @@ export function PlacesAutocompleteInput({
       { input: input.trim() },
       (results: Prediction[] | null, status: string) => {
         setLoading(false);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const OK = (window as any).google.maps.places.PlacesServiceStatus.OK;
         if (status === OK && results?.length) {
           setPredictions(results);
@@ -166,13 +163,11 @@ export function PlacesAutocompleteInput({
     onChange(p.description);
 
     // Fetch place details to get lat/lng
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const g = (window as any).google;
     const helperDiv = document.createElement("div");
     const placeSvc = new g.maps.places.PlacesService(helperDiv);
     placeSvc.getDetails(
       { placeId: p.place_id, fields: ["geometry", "formatted_address", "place_id", "opening_hours"] },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (place: any, status: string) => {
         if (status === g.maps.places.PlacesServiceStatus.OK && place?.geometry) {
           onPlaceSelect({

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -175,7 +175,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     return () => subscription.unsubscribe();
   // fetchTeamMember uses only supabase (module-level) and stable state setters.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const retrySetup = () => {

--- a/src/lib/github-pages-routing.ts
+++ b/src/lib/github-pages-routing.ts
@@ -15,7 +15,12 @@ function unwrapNestedFallbackRoute(fallbackRoute: string): string {
     const nestedRoute = url.searchParams.get("p");
 
     if (!nestedRoute) {
-      return `${url.pathname}${url.search}${url.hash}`;
+      // Always strip any residual ?p= (e.g. empty ?p=) so the restored URL
+      // never carries the sentinel param — preventing re-encoding on the
+      // next page refresh.
+      url.searchParams.delete("p");
+      const cleanSearch = url.searchParams.toString() ? `?${url.searchParams.toString()}` : "";
+      return `${url.pathname}${cleanSearch}${url.hash}`;
     }
 
     currentRoute = normalizeFallbackRoute(nestedRoute);

--- a/src/pages/Kiosk.tsx
+++ b/src/pages/Kiosk.tsx
@@ -2218,7 +2218,6 @@ export default function Kiosk() {
   useEffect(() => {
     if (!locationId) return;
     drainQueue(async (payload) => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { location_id: _stripped, ...safePayload } = payload as any;
       const { error } = await supabase.from("checklist_logs").insert(safePayload);
       if (error) throw new Error(error.message);

--- a/src/pages/checklists/ChecklistsTab.tsx
+++ b/src/pages/checklists/ChecklistsTab.tsx
@@ -70,7 +70,7 @@ export function ChecklistsTab() {
   }));
 
   // PDF download helper
-  const downloadChecklistPdf = (cl: typeof dbChecklists[0]) =>
+  const downloadChecklistPdf = async (cl: typeof dbChecklists[0]) =>
     exportChecklistTemplatePdf({
       title: cl.title,
       schedule: getScheduleLabel(cl.schedule ? String(cl.schedule) : null),
@@ -149,7 +149,7 @@ export function ChecklistsTab() {
     });
   };
 
-  const handleContextAction = (action: string) => {
+  const handleContextAction = async (action: string) => {
     if (!contextMenu) return;
     if (action === "edit" && contextMenu.type === "checklist") {
       const cl = checklists.find(c => c.id === contextMenu.id);
@@ -175,7 +175,7 @@ export function ChecklistsTab() {
       if (orig) saveChecklistMut.mutate({ ...orig, id: "", title: `${orig.title} (copy)` });
     } else if (action === "download" && contextMenu.type === "checklist") {
       const orig = dbChecklists.find(c => c.id === contextMenu.id);
-      if (orig) downloadChecklistPdf(orig);
+      if (orig) await downloadChecklistPdf(orig);
     }
   };
 

--- a/src/test/lib/export-utils.test.ts
+++ b/src/test/lib/export-utils.test.ts
@@ -21,8 +21,7 @@ function makeMockDoc() {
 }
 
 // Module-level reference to the current mock doc — the vi.mock closure always reads this
-// eslint-disable-next-line prefer-const
-let _doc = makeMockDoc();
+const _doc = makeMockDoc();
 const mockAutoTable = vi.fn();
 
 vi.mock("jspdf", () => ({

--- a/src/test/lib/github-pages-routing.test.ts
+++ b/src/test/lib/github-pages-routing.test.ts
@@ -36,6 +36,23 @@ describe("github-pages-routing", () => {
     ).toBe("/olia-your-daily-operations/admin/location");
   });
 
+  it("strips a residual empty ?p= sentinel so it is never re-encoded on the next refresh", () => {
+    // ?p=%2Fadmin%3Fp%3D decodes to /admin?p= — the inner ?p= is empty and
+    // must be stripped from the restored URL, otherwise the next page refresh
+    // would re-encode it and the sentinel would grow.
+    expect(
+      buildGitHubPagesRoute("?p=%2Fadmin%3Fp%3D", "/olia-your-daily-operations/"),
+    ).toBe("/olia-your-daily-operations/admin");
+  });
+
+  it("preserves non-sentinel query params while stripping ?p= from the restored route", () => {
+    // ?p=%2Fadmin%3Ftab%3Dreporting — the inner route has a real query param
+    // (tab=reporting) that must survive while any ?p= is stripped.
+    expect(
+      buildGitHubPagesRoute("?p=%2Fadmin%3Ftab%3Dreporting", "/olia-your-daily-operations/"),
+    ).toBe("/olia-your-daily-operations/admin?tab=reporting");
+  });
+
   it("builds a GitHub Pages-safe auth redirect URL", () => {
     expect(buildPublicAuthRedirectUrl("https://dorabuilds.github.io/olia-your-daily-operations", "/auth/callback")).toBe(
       "https://dorabuilds.github.io/olia-your-daily-operations?p=%2Fauth%2Fcallback",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig(({ mode }) => ({
     },
   },
   build: {
-    chunkSizeWarningLimit: 600,
+    chunkSizeWarningLimit: 500,
     rollupOptions: {
       output: {
         manualChunks(id) {


### PR DESCRIPTION
## Issues
Closes #133 · Closes #102 · Closes #109

## Changes

**#133 — GitHub Pages recursive `?p=` URL on subpage refresh**
Two guard gaps allowed the SPA fallback param to survive into the restored URL and get re-encoded on every refresh:
- `public/404.html`: guard changed from falsy `get("p")` to `!== null`
- `src/lib/github-pages-routing.ts`: always strip `?p=` before returning the restored path
- 2 new routing tests added

**#102 — Remove stale `eslint-disable` directives**
8 stale directives removed from `PlacesAutocompleteInput`, `AuthContext`, `Kiosk`, and `export-utils.test.ts`. 1 in `Billing.tsx` kept (still valid).

**#109 — Fix jsPDF build warning**
- Reverted `chunkSizeWarningLimit` 600→500 (the raised limit was masking the issue)
- Made `downloadChecklistPdf` / `handleContextAction` in `ChecklistsTab` properly `async`/`await`

## Test plan
- [x] `bun run milestone` green (lint + tests + build)
- [ ] Refresh `/admin`, `/infohub/library`, `/reporting` on the deployed GitHub Pages build — URL stays stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)