### PR TITLE
B6: Maestro flow updates, live smoke-test CI workflow

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,84 @@
+name: Post-Deploy Smoke Tests
+
+# Runs automatically after every successful GitHub Pages deploy.
+# Can also be triggered manually (workflow_dispatch) to test the live URL
+# at any time, or with a custom SMOKE_BASE_URL override.
+on:
+  workflow_run:
+    workflows:
+      - "GitHub Pages Deploy"
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      smoke_base_url:
+        description: "Override the live URL to smoke-test (leave blank to use the default GitHub Pages URL)"
+        required: false
+        default: ""
+
+concurrency:
+  group: smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: smoke
+    # Skip the job if the triggering deploy workflow failed
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Playwright + Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Resolve smoke base URL
+        id: resolve-url
+        run: |
+          # Priority: manual override → VITE_PUBLIC_SITE_URL repo var → derived from GITHUB_REPOSITORY
+          MANUAL="${{ github.event.inputs.smoke_base_url }}"
+          REPO_VAR="${{ vars.VITE_PUBLIC_SITE_URL }}"
+          OWNER="${{ github.repository_owner }}"
+          REPO="${{ github.event.repository.name }}"
+          DERIVED="https://${OWNER}.github.io/${REPO}"
+
+          if [ -n "$MANUAL" ]; then
+            SMOKE_URL="$MANUAL"
+          elif [ -n "$REPO_VAR" ]; then
+            SMOKE_URL="$REPO_VAR"
+          else
+            SMOKE_URL="$DERIVED"
+          fi
+
+          # Strip trailing slash for consistency
+          SMOKE_URL="${SMOKE_URL%/}"
+          echo "smoke_url=$SMOKE_URL" >> "$GITHUB_OUTPUT"
+          echo "Smoke base URL: $SMOKE_URL"
+
+      - name: Run smoke tests
+        env:
+          SMOKE_BASE_URL: ${{ steps.resolve-url.outputs.smoke_url }}
+        run: |
+          npx playwright test \
+            --config e2e/playwright.smoke.config.ts \
+            --reporter=list
+
+      - name: Upload smoke report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-report
+          path: |
+            e2e/playwright-report/smoke/
+            e2e/test-results/smoke/
+          retention-days: 14

--- a/.maestro/RELEASE_CHECKLIST.md
+++ b/.maestro/RELEASE_CHECKLIST.md
@@ -1,0 +1,150 @@
+# Olia Release Sign-Off Checklist
+
+Use this checklist before merging to `main` and after every production deploy.
+All gates must be green before a release is signed off.
+
+---
+
+## 1. Pre-Release Gates
+
+### 1a. Milestone gate (automated)
+
+Run this from the repo root. It must complete with zero failures:
+
+```bash
+~/.bun/bin/bun run milestone
+```
+
+This runs in sequence and fails fast:
+
+- [ ] `bun run lint` — zero ESLint errors
+- [ ] `bun run test:ci` — all unit tests pass AND all four coverage metrics (lines, functions, branches, statements) are at or above the configured thresholds
+- [ ] `bun run build` — production build succeeds with no errors or warnings
+
+### 1b. Maestro e2e flows (manual, requires simulator)
+
+Boot an iOS Simulator (or Android Emulator) with the app installed, then run:
+
+```bash
+~/.bun/bin/bun run e2e
+```
+
+All 10 flows must pass:
+
+- [ ] **01** `01-kiosk-setup.yaml` — Setup screen: branding, location prompt, Launch Kiosk button, System Online footer
+- [ ] **02** `02-kiosk-grid.yaml` — Grid screen: agenda heading, stat strip (Total / Completed / Remaining), Olia + Admin header
+- [ ] **03** `03-pin-entry-modal.yaml` — PIN modal: "Insert PIN" heading, subtitle text, circular numpad, START button, dismiss returns to grid
+- [ ] **04** `04-admin-login-modal.yaml` — Admin PIN modal: opens from grid Admin button, PIN input, Continue button, dismiss returns to grid
+- [ ] **05** `05-dashboard.yaml` — Dashboard: greeting visible when authenticated, bottom nav tabs visible
+- [ ] **06** `06-bottom-navigation.yaml` — All 5 nav tabs reachable: Dashboard, Checklists, Reporting, Infohub, Admin
+- [ ] **07** `07-checklists-tab.yaml` — Checklists page loads and page heading is visible
+- [ ] **08** `08-infohub-tab.yaml` — Infohub Library/Training sub-tabs visible, Training tap works
+- [ ] **09** `09-checklist-runner.yaml` — Full kiosk runner: setup → grid → PIN modal → digits → dismiss → back to grid
+- [ ] **10** `10-admin-page.yaml` — Admin page: My Location / Account tabs, "Launch Kiosk Mode" button, Manage Billing button in Account tab
+
+---
+
+## 2. Manual Smoke Checks
+
+Run these manually on a device or simulator connected to the staging/production Supabase project.
+
+### 2a. Authentication
+
+- [ ] Visiting `/dashboard` unauthenticated redirects to `/kiosk`
+- [ ] Kiosk Admin button opens the Admin PIN modal
+- [ ] A valid Admin PIN navigates to `/admin`
+- [ ] Signing out from Admin returns to `/kiosk`
+- [ ] Auth callback URL (Supabase email magic link / OAuth) resolves correctly after login
+
+### 2b. Kiosk flow
+
+- [ ] Setup screen shows the saved location (or the location picker) on re-open
+- [ ] Tapping "Launch Kiosk" loads the agenda grid
+- [ ] Checklist cards display correct titles fetched via `get_kiosk_checklists` RPC
+- [ ] Stat strip shows live counts (Total / Completed / Remaining)
+- [ ] Tapping a checklist card opens the PIN modal with circular numpad
+- [ ] An incorrect PIN shows "PIN not recognised" error
+- [ ] A correct PIN launches the checklist runner
+- [ ] System Online footer is visible in both setup and grid screens
+
+### 2c. Admin area
+
+- [ ] My Location tab loads with team member list and "Launch Kiosk Mode" button
+- [ ] Account tab is visible only for Owner role
+- [ ] Account tab shows the billing card with current plan name and "Manage Billing" button
+- [ ] "Manage Billing" navigates to `/billing`
+- [ ] Creating, editing, and deleting a team member works end-to-end
+
+### 2d. Checklists
+
+- [ ] Checklists page loads the folder/checklist tree from Supabase
+- [ ] Creating a new checklist folder and checklist works
+- [ ] Drag-to-reorder folders updates order correctly
+- [ ] Reporting tab (`/reporting`) loads with Today / This Week / This Month period tabs
+- [ ] Export PDF and Export CSV produce downloadable files
+
+### 2e. Infohub
+
+- [ ] Library sub-tab loads at `/infohub/library`
+- [ ] Training sub-tab loads at `/infohub/training`
+- [ ] Direct navigation to `/infohub` redirects to `/infohub/library`
+- [ ] Documents section shows folders/docs (or empty state)
+
+### 2f. Dashboard
+
+- [ ] Greeting shows correct time-of-day salutation with authenticated user's name
+- [ ] Stat strip counts match live Supabase data
+- [ ] Compliance score ring renders (green ≥ 85%, amber ≥ 65%, red < 65%)
+- [ ] Alerts panel reflects current alerts from `useAlerts` hook (30 s refresh)
+
+---
+
+## 3. Deployment Steps
+
+### 3a. GitHub Pages (web)
+
+Deployment is automatic on merge to `main` via `.github/workflows/github-pages.yml`.
+
+1. [ ] Merge the release branch to `main`
+2. [ ] Confirm the **github-pages** workflow completes successfully in GitHub Actions
+3. [ ] Confirm the **pr-unit-tests** workflow shows green on the merge commit
+
+### 3b. Native builds (iOS / Android)
+
+Only required for App Store / Play Store releases:
+
+```bash
+~/.bun/bin/bun run cap:ios     # build + sync + open Xcode
+~/.bun/bin/bun run cap:android # build + sync + open Android Studio
+```
+
+- [ ] iOS build compiles without errors in Xcode
+- [ ] Android build compiles without errors in Android Studio
+- [ ] App version number bumped in `package.json` (and synced to `Info.plist` / `build.gradle`)
+
+---
+
+## 4. Post-Deploy Verification
+
+After the GitHub Pages deployment URL is live:
+
+- [ ] Home URL loads the kiosk setup screen (not a blank page or 404)
+- [ ] Deep-linking to `/dashboard` correctly redirects unauthenticated users to `/kiosk` (routing loop fix is active — see `404.html` + `index.html` redirect script)
+- [ ] Auth callback URL resolves (Supabase `SITE_URL` and `REDIRECT_URLS` match the deployed origin)
+- [ ] Hard refresh on any sub-route (e.g. `/admin`) does not produce a 404
+- [ ] No JS console errors on initial load
+- [ ] Kiosk loads and shows checklists (RLS anon policy + `get_kiosk_checklists` RPC is active)
+
+---
+
+## 5. Sign-Off
+
+| Gate | Owner | Status |
+|------|-------|--------|
+| `bun run milestone` green | Engineer | ☐ |
+| All 10 Maestro flows pass | Engineer | ☐ |
+| Manual smoke checks complete | QA / Engineer | ☐ |
+| GitHub Pages deployment green | CI | ☐ |
+| Post-deploy routing + auth verified | Engineer | ☐ |
+
+**Release signed off by:** ___________________  **Date:** ___________

--- a/.maestro/flows/03-pin-entry-modal.yaml
+++ b/.maestro/flows/03-pin-entry-modal.yaml
@@ -33,7 +33,7 @@ name: "Kiosk — PIN Entry Modal"
 - assertVisible:
     text: "Insert PIN"
 - assertVisible:
-    text: "Authorize personnel access"
+    text: "You're doing great — let's get started."
 - assertVisible:
     text: "START"
 

--- a/.maestro/flows/06-bottom-navigation.yaml
+++ b/.maestro/flows/06-bottom-navigation.yaml
@@ -1,7 +1,8 @@
 ---
 # Flow 06 — Bottom Navigation
-# Verifies all 4 bottom nav tabs work once authenticated.
+# Verifies all 5 bottom nav tabs work once authenticated.
 # Skips gracefully if not logged in (all tapOn are optional on kiosk screen).
+# Nav tabs (left to right): Dashboard, Checklists, Reporting, Infohub, Admin
 appId: com.olia.operations
 name: "Navigation — Bottom Tab Bar"
 
@@ -17,6 +18,12 @@ name: "Navigation — Bottom Tab Bar"
     optional: true
 - waitForAnimationToEnd
 - takeScreenshot: "06-nav-checklists"
+
+- tapOn:
+    text: "Reporting"
+    optional: true
+- waitForAnimationToEnd
+- takeScreenshot: "06-nav-reporting"
 
 - tapOn:
     text: "Infohub"

--- a/.maestro/flows/07-checklists-tab.yaml
+++ b/.maestro/flows/07-checklists-tab.yaml
@@ -1,6 +1,7 @@
 ---
 # Flow 07 — Checklists Tab
-# Requires authentication. Taps the Checklists nav item and verifies sub-tabs.
+# Requires authentication. Taps the Checklists nav item and verifies the list.
+# Reporting is its own dedicated nav tab (/reporting) — not a sub-tab here.
 # All assertions optional — passes gracefully when not authenticated.
 appId: com.olia.operations
 name: "Checklists — Tab Page"
@@ -18,22 +19,9 @@ name: "Checklists — Tab Page"
 - waitForAnimationToEnd
 - takeScreenshot: "07-checklists-tab"
 
-# ── Sub-tabs ──────────────────────────────────────────────────────────────────
-- tapOn:
-    text: "Reporting"
-    optional: true
-- waitForAnimationToEnd
-- takeScreenshot: "07-checklists-reporting"
-
+# ── Page heading ──────────────────────────────────────────────────────────────
 - assertVisible:
-    text: "Today"
-    optional: true
-- assertVisible:
-    text: "This Week"
-    optional: true
-
-- tapOn:
     text: "Checklists"
     optional: true
-- waitForAnimationToEnd
+
 - takeScreenshot: "07-checklists-list"

--- a/.maestro/flows/08-infohub-tab.yaml
+++ b/.maestro/flows/08-infohub-tab.yaml
@@ -1,6 +1,7 @@
 ---
 # Flow 08 — Infohub Tab
-# Verifies the Info Hub page loads with document/training sections.
+# Verifies the Info Hub page loads with Library / Training sub-tabs.
+# /infohub redirects to /infohub/library; Training sub-tab navigates to /infohub/training.
 appId: com.olia.operations
 name: "Infohub — Tab Page"
 
@@ -8,7 +9,7 @@ name: "Infohub — Tab Page"
 - launchApp
 
 - evalScript: |
-    window.location.href = '/infohub';
+    window.location.href = '/infohub/library';
 - waitForAnimationToEnd
 
 # ── Page heading ──────────────────────────────────────────────────────────────
@@ -16,17 +17,17 @@ name: "Infohub — Tab Page"
     text: "Infohub"
     optional: true
 
-# ── Sub-sections visible ──────────────────────────────────────────────────────
+# ── Sub-tabs visible (Library is default, Training also present) ──────────────
 - assertVisible:
-    text: "Documents"
+    text: "Library"
     optional: true
 - assertVisible:
     text: "Training"
     optional: true
 
-- takeScreenshot: "08-infohub-tab"
+- takeScreenshot: "08-infohub-library"
 
-# ── Tap Training section ──────────────────────────────────────────────────────
+# ── Tap Training sub-tab ──────────────────────────────────────────────────────
 - tapOn:
     text: "Training"
     optional: true

--- a/.maestro/flows/10-admin-page.yaml
+++ b/.maestro/flows/10-admin-page.yaml
@@ -51,7 +51,7 @@ name: "Admin — Page"
 
 # ── Launch Kiosk button ────────────────────────────────────────────────────────
 - assertVisible:
-    text: "Launch Kiosk"
+    text: "Launch Kiosk Mode"
     optional: true
 
 - takeScreenshot: "10-admin-my-location-tab"

--- a/e2e/playwright.smoke.config.ts
+++ b/e2e/playwright.smoke.config.ts
@@ -1,0 +1,38 @@
+/**
+ * Playwright config for post-deploy smoke tests against the live GitHub Pages
+ * URL.  Used only by .github/workflows/smoke.yml.
+ *
+ * Key differences from the default playwright.config.ts:
+ *  - testMatch targets only smoke-live.spec.ts
+ *  - baseURL is irrelevant here; smoke-live.spec.ts constructs absolute URLs
+ *    from SMOKE_BASE_URL itself so that the spec works without a running server.
+ *  - retries: 2  — flake tolerance for live network latency
+ *  - No webServer block — tests hit the already-deployed Pages URL directly
+ */
+
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: ".",
+  testMatch: ["smoke-live.spec.ts"],
+  timeout: 30_000,
+  retries: 2,
+  reporter: [
+    ["list"],
+    ["html", { open: "never", outputFolder: "playwright-report/smoke" }],
+  ],
+  outputDir: "test-results/smoke",
+
+  use: {
+    headless: true,
+    screenshot: "only-on-failure",
+    trace: "on-first-retry",
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/e2e/smoke-live.spec.ts
+++ b/e2e/smoke-live.spec.ts
@@ -1,0 +1,84 @@
+/**
+ * Post-deploy smoke regression — runs against the live GitHub Pages URL.
+ *
+ * These checks are intentionally minimal: they verify the deployed artefact
+ * is reachable and the SPA shell is working, NOT full feature flows.
+ *
+ * The target URL is controlled by the SMOKE_BASE_URL environment variable
+ * (set in the smoke.yml workflow). When running locally you can pass it as:
+ *   SMOKE_BASE_URL=https://<owner>.github.io/<repo> npx playwright test e2e/smoke-live.spec.ts --config e2e/playwright.smoke.config.ts
+ *
+ * Checks:
+ *  1. App root loads (HTTP 200, page has content)
+ *  2. /kiosk loads and shows "What's on the agenda"
+ *  3. Protected route /dashboard redirects to /kiosk (not a 404)
+ *  4. Protected route /admin redirects to /kiosk (not a 404)
+ *  5. No uncaught JavaScript errors on the home page
+ */
+
+import { test, expect } from "@playwright/test";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve an app path relative to SMOKE_BASE_URL.
+ * The base URL may or may not include a trailing slash.
+ */
+function url(path: string): string {
+  const base = (process.env.SMOKE_BASE_URL ?? "").replace(/\/$/, "");
+  return `${base}${path}`;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test.describe("Smoke: app root", () => {
+  test("root URL returns HTTP 200 and has page content", async ({ page }) => {
+    const response = await page.goto(url("/"));
+    // GitHub Pages serves 200 for the SPA index even with a base path
+    expect(response?.status()).toBe(200);
+    // The HTML shell must have some content — not a blank page
+    const body = await page.locator("body").innerHTML();
+    expect(body.trim().length).toBeGreaterThan(0);
+  });
+
+  test("no uncaught JavaScript errors on the home page", async ({ page }) => {
+    const jsErrors: string[] = [];
+    page.on("pageerror", (err) => jsErrors.push(err.message));
+
+    await page.goto(url("/"));
+    // Give React a moment to hydrate
+    await page.waitForLoadState("networkidle");
+
+    expect(jsErrors).toHaveLength(0);
+  });
+});
+
+test.describe("Smoke: /kiosk", () => {
+  test("loads and shows 'What's on the agenda'", async ({ page }) => {
+    await page.goto(url("/kiosk"));
+    await expect(page.getByText(/what's on the agenda/i)).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+});
+
+test.describe("Smoke: protected routes redirect to /kiosk", () => {
+  test("/dashboard redirects to /kiosk — not a 404", async ({ page }) => {
+    await page.goto(url("/dashboard"));
+    await page.waitForLoadState("networkidle");
+
+    // The app should land on /kiosk (ProtectedRoute behaviour), not a blank/404
+    await expect(page.getByText(/what's on the agenda/i)).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test("/admin redirects to /kiosk — not a 404", async ({ page }) => {
+    await page.goto(url("/admin"));
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.getByText(/what's on the agenda/i)).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **#111** Maestro e2e flows updated to match current UI copy:
  - Flow 03: subtitle → "You're doing great — let's get started."
  - Flow 06: Reporting tab added (now top-level route)
  - Flow 07: stale Reporting sub-tab steps removed
  - Flow 08: "Documents" → "Library"
  - Flow 10: "Launch Kiosk" → "Launch Kiosk Mode"
  - New `.maestro/RELEASE_CHECKLIST.md` with pre-release gates, smoke checks, deployment steps, sign-off table
- **#142** GitHub Actions smoke workflow (`.github/workflows/smoke.yml`): triggers after Pages deploy, runs `e2e/smoke-live.spec.ts` (5 live checks — root 200, no JS errors, kiosk loads, /dashboard → kiosk redirect, /admin → kiosk redirect), uploads HTML report

## Test plan
- [ ] `bun run e2e:kiosk` — flows 01–03 pass on simulator
- [ ] Smoke workflow triggers automatically on next GitHub Pages deploy
- [ ] `bun run milestone` passes

Closes #111, #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)