### PR TITLE
fix: Admin PIN update — send only pin fields, surface real error message

### DIFF
--- a/src/hooks/useTeamMembers.ts
+++ b/src/hooks/useTeamMembers.ts
@@ -85,6 +85,30 @@ export function useSaveTeamMember() {
   });
 }
 
+/**
+ * Dedicated PIN-only update hook.
+ * Sends only `pin` + `pin_reset_required` so unrelated fields (email, role, etc.)
+ * are never touched — avoids false unique-index conflicts and makes error messages
+ * actionable by surfacing the actual Supabase error text.
+ */
+export function useSaveAdminPin() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ memberId, rawPin }: { memberId: string; rawPin: string }) => {
+      const hashed = await hashPin(rawPin);
+      const { error } = await supabase
+        .from("team_members")
+        .update({ pin: hashed, pin_reset_required: false })
+        .eq("id", memberId);
+      if (error) {
+        // Surface the real Supabase message (e.g. RLS violation details)
+        throw new Error(error.message ?? "Could not update admin PIN");
+      }
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["team_members"] }),
+  });
+}
+
 export function useDeleteTeamMember() {
   const qc = useQueryClient();
   return useMutation({

--- a/src/pages/admin/AccountTab.tsx
+++ b/src/pages/admin/AccountTab.tsx
@@ -18,6 +18,7 @@ import {
 import { usePlan } from "@/hooks/usePlan";
 import { PLAN_LABELS, PLAN_PRICES } from "@/lib/plan-features";
 import { type ChecklistItem } from "@/hooks/useChecklists";
+import { useSaveAdminPin } from "@/hooks/useTeamMembers";
 import { PERM_LABELS, roleUsesDepartment } from "./shared";
 
 export interface AccountTabProps {
@@ -62,6 +63,7 @@ export function AccountTab({
 }: AccountTabProps) {
   const navigate = useNavigate();
   const { plan, planStatus, isActive } = usePlan();
+  const saveAdminPin = useSaveAdminPin();
   // Team member expand/collapse
   const [expandedMemberId, setExpandedMemberId] = useState<string | null>(null);
   const [pendingPerms, setPendingPerms] = useState<Record<string, ManagerPermissions>>({});
@@ -148,16 +150,7 @@ export function AccountTab({
     if (!currentAccount || pin.length !== 4) return;
     setPinSaving(true);
     try {
-      await onSaveAccount({
-        id: currentAccount.id,
-        name: currentAccount.name,
-        email: currentAccount.email,
-        role: currentAccount.role,
-        location_ids: currentAccount.location_ids,
-        permissions: currentAccount.permissions,
-        rawPin: pin,
-        pin_reset_required: false,
-      });
+      await saveAdminPin.mutateAsync({ memberId: currentAccount.id, rawPin: pin });
       setPin("");
       toast.success("Admin PIN updated");
     } catch (err) {


### PR DESCRIPTION
## Problem
Clicking "Create or reset PIN" on the Admin → Account tab showed **"Could not update admin PIN"** and the PIN was never saved.

**Root cause:** `savePin()` called the general-purpose `useSaveTeamMember` mutation, which sent ALL profile fields (name, email, role, permissions) alongside the new PIN hash. On hosted Supabase this update was rejected — the error returned is a `PostgrestError` object, **not** a native JS `Error`, so `err instanceof Error` evaluated to `false` and only the fallback message was shown, hiding the actual failure reason.

## Fix
- Added `useSaveAdminPin` hook in `useTeamMembers.ts` that sends **only** `{ pin, pin_reset_required }` — no other columns touched
- Wraps the Supabase error into a real `Error` so the toast shows the actual message if anything goes wrong in future
- `AccountTab.savePin()` now calls `saveAdminPin.mutateAsync()` instead of `onSaveAccount`

## Test plan
- [ ] Go to Admin → Account tab, enter a 4-digit PIN, click "Create or reset PIN" → toast shows "Admin PIN updated" ✅
- [ ] Open Kiosk, click Admin, enter the new PIN → access granted ✅
- [ ] `bun run build` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)