### PR TITLE
fix: PIN update removes pin_reset_required from payload, question-type picker always centered

### DIFF
--- a/src/hooks/useTeamMembers.ts
+++ b/src/hooks/useTeamMembers.ts
@@ -98,7 +98,7 @@ export function useSaveAdminPin() {
       const hashed = await hashPin(rawPin);
       const { error } = await supabase
         .from("team_members")
-        .update({ pin: hashed, pin_reset_required: false })
+        .update({ pin: hashed })
         .eq("id", memberId);
       if (error) {
         // Surface the real Supabase message (e.g. RLS violation details)

--- a/src/pages/checklists/ChecklistBuilderModal.tsx
+++ b/src/pages/checklists/ChecklistBuilderModal.tsx
@@ -19,7 +19,7 @@ import type {
 } from "./types";
 import { parseScheduleType, SCHEDULE_LABELS } from "./types";
 import { RESPONSE_TYPES, multipleChoiceSets } from "./data";
-import { ResponseTypePicker, type ResponseTypePickerAnchorRect } from "./ResponseTypePicker";
+import { ResponseTypePicker } from "./ResponseTypePicker";
 import { CustomRecurrencePicker } from "./CustomRecurrencePicker";
 import { linkableInfohubResources } from "@/lib/infohub-catalog";
 
@@ -88,8 +88,8 @@ export function ChecklistBuilderModal({
     id: "sec-default", name: "", questions: [{ id: "q-1", text: "", responseType: "checkbox", required: true, config: {} }],
   }]);
   const [showResponsePicker, setShowResponsePicker] = useState<
-    | { scope: "main"; sectionIdx: number; questionIdx: number; anchorRect: ResponseTypePickerAnchorRect }
-    | { scope: "followup"; sectionIdx: number; questionIdx: number; ruleIdx: number; triggerIdx: number; anchorRect: ResponseTypePickerAnchorRect }
+    | { scope: "main"; sectionIdx: number; questionIdx: number }
+    | { scope: "followup"; sectionIdx: number; questionIdx: number; ruleIdx: number; triggerIdx: number }
     | null
   >(null);
   const [requiredError, setRequiredError] = useState("");
@@ -568,11 +568,10 @@ export function ChecklistBuilderModal({
 
                   <div className="flex items-center justify-between">
                     <button
-                      onClick={e => setShowResponsePicker({
+                      onClick={() => setShowResponsePicker({
                         scope: "main",
                         sectionIdx: si,
                         questionIdx: qi,
-                        anchorRect: e.currentTarget.getBoundingClientRect(),
                       })}
                       className="text-xs px-3 py-1.5 rounded-full border border-border text-muted-foreground hover:border-sage/40 transition-colors flex items-center gap-1">
                       {responseTypeLabel(q.responseType)}
@@ -1298,7 +1297,6 @@ export function ChecklistBuilderModal({
       )}
       {showResponsePicker && (
         <ResponseTypePicker
-          anchorRect={showResponsePicker.anchorRect}
           onSelect={(type, mcSetId) => {
             const mcSet = mcSetId ? multipleChoiceSets.find(m => m.id === mcSetId) : null;
             if (showResponsePicker.scope === "main") {

--- a/src/pages/checklists/FollowUpQuestionEditor.tsx
+++ b/src/pages/checklists/FollowUpQuestionEditor.tsx
@@ -24,7 +24,7 @@ import type {
   ResponseType,
 } from "./types";
 import { RESPONSE_TYPES, multipleChoiceSets } from "./data";
-import { ResponseTypePicker, type ResponseTypePickerAnchorRect } from "./ResponseTypePicker";
+import { ResponseTypePicker } from "./ResponseTypePicker";
 
 const MC_COLOR_OPTIONS = [
   { label: "Green", value: "bg-status-ok/10 border-status-ok/40 text-status-ok" },
@@ -67,7 +67,7 @@ export function FollowUpQuestionEditor({
   label?: string;
   depth?: number;
 }) {
-  const [showResponsePicker, setShowResponsePicker] = useState<ResponseTypePickerAnchorRect | null>(null);
+  const [showResponsePicker, setShowResponsePicker] = useState(false);
   const imgInputRef = useRef<HTMLInputElement | null>(null);
 
   const cfg = question.config || {};
@@ -413,7 +413,7 @@ export function FollowUpQuestionEditor({
         />
         <button
           type="button"
-          onClick={e => setShowResponsePicker(e.currentTarget.getBoundingClientRect())}
+          onClick={() => setShowResponsePicker(true)}
           className="text-xs px-3 py-1.5 rounded-full border border-border text-muted-foreground hover:border-sage/40 transition-colors flex items-center gap-1"
         >
           {responseTypeLabel(question.responseType)}
@@ -447,12 +447,11 @@ export function FollowUpQuestionEditor({
 
       {showResponsePicker && (
         <ResponseTypePicker
-          anchorRect={showResponsePicker}
           onSelect={(type, mcSetId) => {
             setResponseType(type, mcSetId);
-            setShowResponsePicker(null);
+            setShowResponsePicker(false);
           }}
-          onClose={() => setShowResponsePicker(null)}
+          onClose={() => setShowResponsePicker(false)}
         />
       )}
     </div>


### PR DESCRIPTION
## Fixes

**#241 — PIN update: remove `pin_reset_required` from payload**
PostgREST's schema cache on the hosted Supabase instance doesn't include the `pin_reset_required` column yet (migration applied but cache not reloaded). `useSaveAdminPin` was sending `{ pin, pin_reset_required: false }` — the unknown column caused the entire update to fail. Fix: only send `{ pin: hashed }`.

**#245 — Question-type picker: always open as centered modal**
The picker was using `getBoundingClientRect()` to position itself absolutely, landing at the top of the page when the builder was scrolled. Removed `anchorRect` from all call sites in `ChecklistBuilderModal.tsx` and `FollowUpQuestionEditor.tsx` — the picker now always opens as a `fixed inset-0` centered overlay regardless of scroll position.

## Test plan
- [ ] Admin → Account → enter 4-digit PIN → "Admin PIN updated" toast ✅
- [ ] Checklist builder → add question → question-type picker opens centered on screen ✅
- [ ] `bun run build` passes ✅

Closes #241, #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)