### PR TITLE
feat: checklist notify triggers now send emails on completion

### DIFF
--- a/src/pages/Kiosk.tsx
+++ b/src/pages/Kiosk.tsx
@@ -21,6 +21,7 @@ import { AdminLoginModal, PinEntryModal } from "./kiosk/PinEntryModal";
 import { ChecklistRunner } from "./kiosk/ChecklistRunner";
 import { CompletionScreen } from "./kiosk/CompletionScreen";
 import { useLiveClock } from "./kiosk/hooks";
+import { collectNotifyAlerts } from "./kiosk/logic-rules";
 
 // Re-export ChecklistRunner for backward compatibility (tests import from @/pages/Kiosk)
 export { ChecklistRunner };
@@ -329,6 +330,59 @@ export default function Kiosk() {
     }, 90000);
   };
 
+  /**
+   * After a checklist is completed, evaluate all logic rules and fire an
+   * `alerts` row for each matching "notify" trigger. The DB trigger
+   * (`trg_send_alert_email`) picks up each insert and sends the email via
+   * the Resend edge function.
+   *
+   * Uses a defensive try-with-recipient / retry-without pattern identical to
+   * the location_id guard above: if the `recipient_email` column isn't yet in
+   * the PostgREST schema cache (migration not applied), the second attempt
+   * still creates the alert row so it appears on the dashboard.
+   */
+  const fireNotifyAlerts = async (
+    questions: KioskChecklist["questions"],
+    answers: Record<string, any>,
+    orgId: string,
+    checklistTitle: string,
+  ) => {
+    const notifyAlerts = collectNotifyAlerts(questions, answers);
+    if (notifyAlerts.length === 0) return;
+
+    const timeLabel = new Date().toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit" });
+
+    for (const alert of notifyAlerts) {
+      const baseAlert = {
+        organization_id: orgId,
+        type: "info" as const,
+        message: alert.message,
+        area: checklistTitle,
+        time: timeLabel,
+        source: "checklist_rule",
+      };
+
+      // Try with recipient_email first (requires migration 20260415000001)
+      const { error: alertErr } = await supabase.from("alerts").insert({
+        ...baseAlert,
+        recipient_email: alert.recipientEmail,
+      });
+
+      if (alertErr && alertErr.message?.includes("recipient_email")) {
+        // Schema cache hasn't refreshed yet — insert without it so the alert
+        // still appears in the dashboard (email will go to location contact_email)
+        console.warn(
+          "fireNotifyAlerts: recipient_email column not in schema cache — " +
+          "retrying without it. Apply migration 20260415000001 and run: " +
+          "NOTIFY pgrst, 'reload schema';",
+        );
+        await supabase.from("alerts").insert(baseAlert);
+      } else if (alertErr) {
+        console.error("fireNotifyAlerts: alert insert failed:", alertErr.message);
+      }
+    }
+  };
+
   // ── Real checklists from Supabase ──────────────────────────────────────────
   const [kioskChecklists, setKioskChecklists] = useState<KioskChecklist[]>([]);
   const [checklistsLoading, setChecklistsLoading] = useState(false);
@@ -556,6 +610,14 @@ export default function Kiosk() {
         enqueueLog(logPayload);
       }
 
+      // Evaluate checklist logic rules and send notify-trigger emails.
+      // Runs even if the log insert failed so alerts are never silently dropped.
+      await fireNotifyAlerts(
+        selectedChecklist.questions,
+        answers,
+        selectedOrgId,
+        selectedChecklist.title,
+      );
     }
   };
 

--- a/src/pages/kiosk/logic-rules.ts
+++ b/src/pages/kiosk/logic-rules.ts
@@ -1,0 +1,132 @@
+/**
+ * Client-side evaluation of checklist logic rules.
+ *
+ * When a checklist is completed in the kiosk, each question's `config.logicRules`
+ * are evaluated against the submitted answers. Any matching rule with a `notify`
+ * trigger causes an alert row to be inserted, which fires the DB trigger
+ * → Edge Function → Resend email pipeline.
+ */
+
+import type { LogicComparator, LogicRule } from "@/pages/checklists/types";
+
+// ─── Rule evaluation ──────────────────────────────────────────────────────────
+
+/**
+ * Returns true if the submitted answer satisfies the rule's comparator + value.
+ */
+export function evaluateRule(
+  answer: any,
+  comparator: LogicComparator,
+  ruleValue: string,
+  ruleValueTo?: string,
+): boolean {
+  // "unanswered" does not depend on the value at all
+  if (comparator === "unanswered") {
+    return answer === undefined || answer === null || answer === "" || answer === false;
+  }
+
+  const strAnswer = answer === undefined || answer === null ? "" : String(answer).trim();
+  const numAnswer = Number(strAnswer);
+  const numValue  = Number(ruleValue);
+  const numValueTo = Number(ruleValueTo ?? "0");
+
+  switch (comparator) {
+    case "is":
+      // Case-insensitive string match (works for multiple_choice, checkbox, text)
+      return strAnswer.toLowerCase() === ruleValue.toLowerCase();
+
+    case "is_not":
+      return strAnswer.toLowerCase() !== ruleValue.toLowerCase();
+
+    case "eq":
+      return !Number.isNaN(numAnswer) && numAnswer === numValue;
+
+    case "neq":
+      return !Number.isNaN(numAnswer) && numAnswer !== numValue;
+
+    case "lt":
+      return !Number.isNaN(numAnswer) && numAnswer < numValue;
+
+    case "lte":
+      return !Number.isNaN(numAnswer) && numAnswer <= numValue;
+
+    case "gt":
+      return !Number.isNaN(numAnswer) && numAnswer > numValue;
+
+    case "gte":
+      return !Number.isNaN(numAnswer) && numAnswer >= numValue;
+
+    case "between":
+      return !Number.isNaN(numAnswer) && numAnswer >= numValue && numAnswer <= numValueTo;
+
+    case "not_between":
+      return !Number.isNaN(numAnswer) && !(numAnswer >= numValue && numAnswer <= numValueTo);
+
+    default:
+      return false;
+  }
+}
+
+// ─── Notify-trigger extraction ────────────────────────────────────────────────
+
+export interface NotifyAlert {
+  /** Email address from the rule's notify trigger config */
+  recipientEmail: string;
+  /** Human-readable description of what triggered the alert */
+  message: string;
+  /** Question text (used as the "area" field on the alert row) */
+  questionText: string;
+}
+
+/**
+ * Scans all questions' logic rules and returns one NotifyAlert per matching
+ * "notify" trigger. Duplicate recipient emails for the same question are
+ * de-duplicated.
+ */
+export function collectNotifyAlerts(
+  questions: Array<{
+    id: string;
+    text: string;
+    config?: { logicRules?: LogicRule[] };
+  }>,
+  answers: Record<string, any>,
+): NotifyAlert[] {
+  const alerts: NotifyAlert[] = [];
+
+  for (const question of questions) {
+    const rules = question.config?.logicRules;
+    if (!rules || rules.length === 0) continue;
+
+    const answer = answers[question.id];
+
+    for (const rule of rules) {
+      const matched = evaluateRule(answer, rule.comparator, rule.value, rule.valueTo);
+      if (!matched) continue;
+
+      for (const trigger of rule.triggers) {
+        if (trigger.type !== "notify") continue;
+
+        const recipientEmail = trigger.config?.notifyUser?.trim();
+        if (!recipientEmail) continue;
+
+        // Avoid duplicate alerts for the same recipient + question
+        const alreadyAdded = alerts.some(
+          a => a.recipientEmail === recipientEmail && a.questionText === question.text,
+        );
+        if (alreadyAdded) continue;
+
+        const answerStr =
+          answer === undefined || answer === null || answer === "" || answer === false
+            ? "unanswered"
+            : String(answer);
+        alerts.push({
+          recipientEmail,
+          questionText: question.text,
+          message: `"${question.text}" answered: ${answerStr} — notify rule triggered`,
+        });
+      }
+    }
+  }
+
+  return alerts;
+}

--- a/src/test/pages/kiosk/logic-rules.test.ts
+++ b/src/test/pages/kiosk/logic-rules.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from "vitest";
+import { evaluateRule, collectNotifyAlerts } from "@/pages/kiosk/logic-rules";
+import type { LogicRule } from "@/pages/checklists/types";
+
+// ─── evaluateRule ─────────────────────────────────────────────────────────────
+
+describe("evaluateRule", () => {
+  describe("unanswered", () => {
+    it("matches empty string", () => expect(evaluateRule("", "unanswered", "")).toBe(true));
+    it("matches undefined", () => expect(evaluateRule(undefined, "unanswered", "")).toBe(true));
+    it("matches null", () => expect(evaluateRule(null, "unanswered", "")).toBe(true));
+    it("matches false", () => expect(evaluateRule(false, "unanswered", "")).toBe(true));
+    it("does not match a real answer", () => expect(evaluateRule("yes", "unanswered", "")).toBe(false));
+    it("does not match zero", () => expect(evaluateRule("0", "unanswered", "")).toBe(false));
+  });
+
+  describe("is / is_not", () => {
+    it("is: matches case-insensitively", () => expect(evaluateRule("Yes", "is", "yes")).toBe(true));
+    it("is: does not match different value", () => expect(evaluateRule("No", "is", "yes")).toBe(false));
+    it("is_not: matches when different", () => expect(evaluateRule("No", "is_not", "yes")).toBe(true));
+    it("is_not: does not match same value", () => expect(evaluateRule("Yes", "is_not", "yes")).toBe(false));
+  });
+
+  describe("numeric comparators", () => {
+    it("eq: matches equal numbers", () => expect(evaluateRule("5", "eq", "5")).toBe(true));
+    it("eq: does not match different", () => expect(evaluateRule("4", "eq", "5")).toBe(false));
+    it("neq: matches when not equal", () => expect(evaluateRule("4", "neq", "5")).toBe(true));
+    it("lt: matches when less than", () => expect(evaluateRule("3", "lt", "5")).toBe(true));
+    it("lt: does not match equal", () => expect(evaluateRule("5", "lt", "5")).toBe(false));
+    it("lte: matches equal", () => expect(evaluateRule("5", "lte", "5")).toBe(true));
+    it("lte: matches less than", () => expect(evaluateRule("4", "lte", "5")).toBe(true));
+    it("gt: matches when greater", () => expect(evaluateRule("6", "gt", "5")).toBe(true));
+    it("gt: does not match equal", () => expect(evaluateRule("5", "gt", "5")).toBe(false));
+    it("gte: matches equal", () => expect(evaluateRule("5", "gte", "5")).toBe(true));
+    it("gte: matches greater than", () => expect(evaluateRule("6", "gte", "5")).toBe(true));
+    it("returns false for NaN answer on numeric comparator", () =>
+      expect(evaluateRule("abc", "eq", "5")).toBe(false));
+  });
+
+  describe("between / not_between", () => {
+    it("between: matches inside range", () =>
+      expect(evaluateRule("5", "between", "1", "10")).toBe(true));
+    it("between: matches on lower bound", () =>
+      expect(evaluateRule("1", "between", "1", "10")).toBe(true));
+    it("between: matches on upper bound", () =>
+      expect(evaluateRule("10", "between", "1", "10")).toBe(true));
+    it("between: does not match outside range", () =>
+      expect(evaluateRule("11", "between", "1", "10")).toBe(false));
+    it("not_between: matches outside range", () =>
+      expect(evaluateRule("0", "not_between", "1", "10")).toBe(true));
+    it("not_between: does not match inside range", () =>
+      expect(evaluateRule("5", "not_between", "1", "10")).toBe(false));
+  });
+
+  describe("unknown comparator", () => {
+    it("returns false for an unrecognised comparator", () =>
+      expect(evaluateRule("x", "unknown" as any, "x")).toBe(false));
+  });
+});
+
+// ─── collectNotifyAlerts ──────────────────────────────────────────────────────
+
+function makeRule(overrides: Partial<LogicRule> = {}): LogicRule {
+  return {
+    id: "r1",
+    comparator: "is",
+    value: "Yes",
+    triggers: [
+      { type: "notify", config: { notifyUser: "manager@example.com" } },
+    ],
+    ...overrides,
+  };
+}
+
+describe("collectNotifyAlerts", () => {
+  it("returns empty array when no questions have logic rules", () => {
+    const questions = [{ id: "q1", text: "Clean?", config: {} }];
+    expect(collectNotifyAlerts(questions, { q1: "Yes" })).toHaveLength(0);
+  });
+
+  it("returns empty array when no rules match", () => {
+    const questions = [{ id: "q1", text: "Clean?", config: { logicRules: [makeRule()] } }];
+    expect(collectNotifyAlerts(questions, { q1: "No" })).toHaveLength(0);
+  });
+
+  it("returns a notify alert when a rule matches", () => {
+    const questions = [{ id: "q1", text: "Clean?", config: { logicRules: [makeRule()] } }];
+    const alerts = collectNotifyAlerts(questions, { q1: "Yes" });
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].recipientEmail).toBe("manager@example.com");
+    expect(alerts[0].questionText).toBe("Clean?");
+    expect(alerts[0].message).toContain("Clean?");
+    expect(alerts[0].message).toContain("Yes");
+  });
+
+  it("ignores non-notify triggers", () => {
+    const questions = [{
+      id: "q1", text: "Q",
+      config: {
+        logicRules: [makeRule({
+          triggers: [{ type: "require_note" }],
+        })],
+      },
+    }];
+    expect(collectNotifyAlerts(questions, { q1: "Yes" })).toHaveLength(0);
+  });
+
+  it("ignores notify triggers with no email", () => {
+    const questions = [{
+      id: "q1", text: "Q",
+      config: {
+        logicRules: [makeRule({
+          triggers: [{ type: "notify", config: { notifyUser: "" } }],
+        })],
+      },
+    }];
+    expect(collectNotifyAlerts(questions, { q1: "Yes" })).toHaveLength(0);
+  });
+
+  it("de-duplicates same recipient + question", () => {
+    const rule1 = makeRule({ id: "r1" });
+    const rule2 = makeRule({ id: "r2", value: "Yes" });
+    const questions = [{ id: "q1", text: "Clean?", config: { logicRules: [rule1, rule2] } }];
+    const alerts = collectNotifyAlerts(questions, { q1: "Yes" });
+    expect(alerts).toHaveLength(1);
+  });
+
+  it("collects alerts from multiple questions", () => {
+    const questions = [
+      { id: "q1", text: "Clean?", config: { logicRules: [makeRule()] } },
+      { id: "q2", text: "Safe?", config: {
+        logicRules: [makeRule({ triggers: [{ type: "notify", config: { notifyUser: "safety@example.com" } }] })],
+      }},
+    ];
+    const alerts = collectNotifyAlerts(questions, { q1: "Yes", q2: "Yes" });
+    expect(alerts).toHaveLength(2);
+    expect(alerts.map(a => a.recipientEmail)).toContain("manager@example.com");
+    expect(alerts.map(a => a.recipientEmail)).toContain("safety@example.com");
+  });
+
+  it("shows 'unanswered' in the message for an empty answer", () => {
+    const questions = [{
+      id: "q1", text: "Clean?",
+      config: {
+        logicRules: [makeRule({ comparator: "unanswered", value: "" })],
+      },
+    }];
+    const alerts = collectNotifyAlerts(questions, { q1: "" });
+    expect(alerts[0].message).toContain("unanswered");
+  });
+});

--- a/supabase/migrations/20260415000001_alerts_recipient_email.sql
+++ b/supabase/migrations/20260415000001_alerts_recipient_email.sql
@@ -1,0 +1,88 @@
+-- ================================================================
+-- Add recipient_email to alerts for per-rule email targeting
+-- ================================================================
+-- Previously the email trigger always looked up the location's
+-- contact_email. Now a caller can supply a specific recipient_email
+-- on the alert row (e.g. from a checklist "notify" logic rule) and
+-- the trigger will use that instead.
+--
+-- Backwards-compatible: existing rows without recipient_email still
+-- fall back to the location contact_email lookup.
+-- ================================================================
+
+ALTER TABLE public.alerts
+  ADD COLUMN IF NOT EXISTS recipient_email text;
+
+-- Update the trigger function to prefer the per-row recipient when set.
+CREATE OR REPLACE FUNCTION public.send_alert_email_on_insert()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  _url       text;
+  _secret    text;
+  _recipient text;
+  _payload   jsonb;
+BEGIN
+  _url    := current_setting('app.supabase_url', true);
+  _secret := current_setting('app.alert_secret', true);
+
+  IF _url IS NULL OR _url = '' THEN
+    RAISE WARNING 'send_alert_email: app.supabase_url not set.';
+    RETURN NEW;
+  END IF;
+
+  IF _secret IS NULL OR _secret = '' THEN
+    RAISE WARNING 'send_alert_email: app.alert_secret not set.';
+    RETURN NEW;
+  END IF;
+
+  -- Use per-row recipient_email when present; otherwise fall back to the
+  -- location's contact_email (legacy behaviour for out-of-range alerts).
+  IF NEW.recipient_email IS NOT NULL AND NEW.recipient_email <> '' THEN
+    _recipient := NEW.recipient_email;
+  ELSE
+    SELECT COALESCE(NULLIF(l.contact_email, ''), NULLIF(l.alert_email, ''))
+      INTO _recipient
+      FROM public.locations l
+     WHERE l.organization_id = NEW.organization_id
+       AND COALESCE(NULLIF(l.contact_email, ''), NULLIF(l.alert_email, '')) IS NOT NULL
+     ORDER BY l.created_at
+     LIMIT 1;
+  END IF;
+
+  IF _recipient IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  _payload := jsonb_build_object(
+    'id',              NEW.id,
+    'type',            NEW.type,
+    'message',         NEW.message,
+    'area',            NEW.area,
+    'time',            NEW.time,
+    'source',          NEW.source,
+    'created_at',      NEW.created_at,
+    'organization_id', NEW.organization_id,
+    'recipient_email', _recipient
+  );
+
+  PERFORM extensions.net.http_post(
+    url     := _url || '/functions/v1/send-alert-email',
+    headers := jsonb_build_object(
+                 'Content-Type',   'application/json',
+                 'x-alert-secret', _secret
+               ),
+    body    := _payload::text,
+    timeout_milliseconds := 5000
+  );
+
+  RETURN NEW;
+
+EXCEPTION WHEN OTHERS THEN
+  RAISE WARNING 'send_alert_email: pg_net call failed: %', SQLERRM;
+  RETURN NEW;
+END;
+$$;


### PR DESCRIPTION
## Summary
- **Logic rule evaluator built**: A new pure module (`src/pages/kiosk/logic-rules.ts`) evaluates all comparator types (`is`, `is_not`, `eq`, `neq`, `lt`, `lte`, `gt`, `gte`, `between`, `not_between`, `unanswered`) against submitted answers. `collectNotifyAlerts()` returns all matching `notify` triggers from a completed checklist.
- **Wired into checklist completion**: `Kiosk.tsx handleComplete` now calls `fireNotifyAlerts()` after saving the log. For each matching rule with a `notify` trigger, an alert row is inserted with the specific team member's email from the rule config — which the existing DB trigger picks up and routes through the Resend edge function.
- **Per-rule email targeting**: New migration adds a `recipient_email` column to the `alerts` table and updates the trigger function to use it when set, falling back to the location `contact_email` for out-of-range alerts (fully backwards compatible).
- **Schema-cache safe**: Uses the same defensive pattern already in the codebase — if `recipient_email` isn't in PostgREST's cache yet, retries without it so the alert still appears in the dashboard.

## What had to be applied in Supabase first
The migration `20260415000001_alerts_recipient_email.sql` must be run in the Supabase SQL Editor for the email to go to the specific person selected in the rule. Without it, emails fall back to the location's contact email (already working).

## Test plan
- [ ] In Checklist Builder, add a question → add a logic rule → set trigger to "Notify" → select your email → save
- [ ] Complete the checklist in Kiosk, giving the answer that matches the rule
- [ ] Check inbox — email should arrive from Olia
- [ ] Check Dashboard → Alerts — an info alert should appear for the triggered rule
- [ ] Complete the checklist again with an answer that does NOT match → no extra alert

🤖 Generated with [Claude Code](https://claude.com/claude-code)