### PR TITLE
fix: alert email required on all locations

### DIFF
--- a/src/pages/admin/MyLocationTab.tsx
+++ b/src/pages/admin/MyLocationTab.tsx
@@ -149,10 +149,15 @@ export function MyLocationTab({
               </div>
             );
           })()}
-          {currentLocation.contact_email && (
+          {currentLocation.contact_email ? (
             <div className="flex items-start gap-2">
               <Mail size={13} className="text-muted-foreground mt-0.5 shrink-0" />
               <p className="text-sm text-foreground">{currentLocation.contact_email}</p>
+            </div>
+          ) : (
+            <div className="flex items-start gap-2 rounded-xl border border-status-warn/40 bg-status-warn/10 px-3 py-2">
+              <Mail size={13} className="text-status-warn mt-0.5 shrink-0" />
+              <p className="text-xs text-status-warn font-medium">No alert email set — tap Edit to add one so out-of-range and notification alerts can be delivered.</p>
             </div>
           )}
           {currentLocation.contact_phone && (

--- a/src/pages/admin/SharedUI.tsx
+++ b/src/pages/admin/SharedUI.tsx
@@ -636,15 +636,17 @@ export function LocationModal({
             ))}
           </div>
         </FormField>
-        {location && (
-          <FormField label="Location email">
-            <input
-              type="email" value={email}
-              onChange={e => setEmail(e.target.value)}
-              placeholder="e.g. main@olia.app" className={inputCls}
-            />
-          </FormField>
-        )}
+        <FormField label="Alert email (required)">
+          <input
+            type="email" value={email}
+            onChange={e => setEmail(e.target.value)}
+            placeholder="e.g. main@olia.app" className={inputCls}
+            required
+          />
+          <p className="mt-1.5 text-xs text-muted-foreground leading-relaxed">
+            Out-of-range alerts and operational notifications are sent here.
+          </p>
+        </FormField>
         <FormField label="Location phone (optional)">
           <input
             type="tel" value={phone}
@@ -652,7 +654,7 @@ export function LocationModal({
             placeholder="e.g. +33 4 78 00 11 22" className={inputCls}
           />
         </FormField>
-        <SaveButton disabled={!name.trim()} label={location ? "Save changes" : "Add location"} />
+        <SaveButton disabled={!name.trim() || !email.trim()} label={location ? "Save changes" : "Add location"} />
       </form>
     </BottomSheet>
   );


### PR DESCRIPTION
## Summary
- **Email field shown for new locations**: Previously the "Location email" field was wrapped in `{location && (...)}` so it only appeared when *editing* an existing location — meaning brand new locations could never have an email set at creation time.
- **Email is now required**: The Save button is blocked until both name and email are filled. Label updated to "Alert email (required)" with a hint explaining it's used for out-of-range and notification alerts.
- **Warning banner when email is missing**: The My Location overview now shows an amber warning if no alert email is set, with a prompt to edit. Previously a missing email would just be silently omitted from the display.

## Why this matters
Without an alert email on the location, out-of-range number alerts from the kiosk are silently dropped — the DB trigger finds no recipient and skips the email with no indication to the user.

## Test plan
- [ ] Create a new location → email field is visible and required → Save is blocked until filled
- [ ] Edit an existing location that has no email → warning banner visible → edit → add email → save → banner gone
- [ ] Edit an existing location that already has an email → no warning → saves normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)