### PR TITLE
feat: staff email field + staff appear in notify trigger picker

### DIFF
--- a/src/hooks/useStaffProfiles.ts
+++ b/src/hooks/useStaffProfiles.ts
@@ -18,7 +18,7 @@ export function useStaffProfiles() {
       const { data, error } = await supabase
         .from("staff_profiles")
         // pin is intentionally excluded — managers must not see raw/hashed PINs after creation
-        .select("id, location_id, first_name, last_name, role, status, last_used_at, archived_at, created_at")
+        .select("id, location_id, first_name, last_name, role, status, email, last_used_at, archived_at, created_at")
         .order("first_name");
       if (error) throw error;
       return (data ?? []) as StaffProfile[];
@@ -54,6 +54,7 @@ export function useSaveStaffProfile() {
           last_name: sp.last_name,
           role: sp.role,
           status: sp.status ?? "active",
+          email: sp.email?.trim() || null,
         };
         // Only update pin when a new one was explicitly provided; otherwise
         // leave the existing hashed pin untouched.
@@ -81,6 +82,7 @@ export function useSaveStaffProfile() {
           last_name: sp.last_name,
           role: sp.role,
           status: sp.status ?? "active",
+          email: sp.email?.trim() || null,
           pin: await hashPin(sp.rawPin),
         };
         const { error } = await supabase.from("staff_profiles").insert(insertPayload);

--- a/src/lib/admin-repository.ts
+++ b/src/lib/admin-repository.ts
@@ -80,6 +80,7 @@ export interface StaffProfile {
   role: string;
   status: StaffStatus;
   pin: string;
+  email?: string | null;
   last_used_at: string | null;
   archived_at: string | null;
   created_at: string;

--- a/src/pages/admin/SharedUI.tsx
+++ b/src/pages/admin/SharedUI.tsx
@@ -166,6 +166,7 @@ export function StaffProfileModal({
   const [lastName, setLastName] = useState(profile?.last_name ?? "");
   const [locationId, setLocationId] = useState(profile?.location_id ?? locations[0]?.id ?? "");
   const [role, setRole] = useState(getRoleDepartment(profile?.role ?? departments[0]?.name ?? ""));
+  const [email, setEmail] = useState(profile?.email ?? "");
   // New staff: generate a PIN upfront; editing: leave empty (only set if manager enters a new one)
   const [pin, setPin] = useState(() => isEdit ? "" : generatePin());
 
@@ -180,6 +181,7 @@ export function StaffProfileModal({
       first_name: firstName.trim(),
       last_name: lastName.trim(),
       role,
+      email: email.trim() || null,
       status: profile?.status ?? "active",
       // rawPin triggers SHA-256 hashing in useSaveStaffProfile;
       // omit for edits where the manager didn't enter a new PIN (existing PIN preserved)
@@ -226,6 +228,16 @@ export function StaffProfileModal({
             onChange={e => setLastName(e.target.value)}
             placeholder="e.g. Garcia" className={inputCls}
           />
+        </FormField>
+        <FormField label="Email (optional)">
+          <input
+            type="email" value={email}
+            onChange={e => setEmail(e.target.value)}
+            placeholder="e.g. maria@yourplace.com" className={inputCls}
+          />
+          <p className="mt-1.5 text-xs text-muted-foreground leading-relaxed">
+            Used to send this staff member email alerts from checklist logic rules.
+          </p>
         </FormField>
         <FormField label="Role">
           <DepartmentRolePicker departments={departments} value={role} onChange={setRole} />

--- a/src/pages/checklists/ChecklistBuilderModal.tsx
+++ b/src/pages/checklists/ChecklistBuilderModal.tsx
@@ -160,30 +160,43 @@ export function ChecklistBuilderModal({
     (locationMode === "all" || selectedLocationIds.length === 0 || selectedLocationIds.includes(s.location_id))
   );
 
-  // Team members with emails — real notification recipients.
-  // Always include the authenticated owner as a fallback so the owner's own
-  // email appears even if the team_members query hasn't loaded yet or the
-  // owner's row email is missing (PostgREST schema cache issue).
+  // Notification recipients — team members (admins) + staff profiles with emails.
+  // Always include the authenticated owner as a fallback so their email
+  // appears even if the team_members query hasn't loaded yet.
   const notifyRecipients = (() => {
+    // Admin / team member emails
     const fromTeam = teamMembers.filter(m => m.email && m.email.trim().length > 0);
     const ownerEmail = authTeamMember?.email ?? user?.email ?? "";
     const ownerAlreadyIncluded = fromTeam.some(m => m.id === (authTeamMember?.id ?? user?.id));
-    if (ownerEmail && !ownerAlreadyIncluded) {
-      return [
-        {
-          id: authTeamMember?.id ?? user?.id ?? "owner",
-          name: authTeamMember?.name ?? user?.email ?? "Owner",
-          email: ownerEmail,
-          role: "Owner",
-          organization_id: authTeamMember?.organization_id ?? "",
-          location_ids: [] as string[],
-          permissions: {} as Record<string, boolean>,
-          pin_reset_required: false,
-        },
-        ...fromTeam,
-      ];
-    }
-    return fromTeam;
+    const teamList = ownerEmail && !ownerAlreadyIncluded
+      ? [
+          {
+            id: authTeamMember?.id ?? user?.id ?? "owner",
+            name: authTeamMember?.name ?? user?.email ?? "Owner",
+            email: ownerEmail,
+            role: "Owner",
+          },
+          ...fromTeam.map(m => ({ id: m.id, name: m.name, email: m.email, role: m.role })),
+        ]
+      : fromTeam.map(m => ({ id: m.id, name: m.name, email: m.email, role: m.role }));
+
+    // Kiosk staff members with an email set
+    const fromStaff = staffProfiles
+      .filter(s => s.email && s.email.trim().length > 0 && s.status === "active")
+      .map(s => ({
+        id: s.id,
+        name: [s.first_name, s.last_name].filter(Boolean).join(" "),
+        email: s.email as string,
+        role: s.role || "Staff",
+      }));
+
+    // Merge, de-duplicating by email address
+    const seen = new Set<string>();
+    return [...teamList, ...fromStaff].filter(r => {
+      if (seen.has(r.email)) return false;
+      seen.add(r.email);
+      return true;
+    });
   })();
 
   const formatTime12h = (time24: string) => {

--- a/supabase/migrations/20260415000002_staff_profiles_email.sql
+++ b/supabase/migrations/20260415000002_staff_profiles_email.sql
@@ -1,0 +1,10 @@
+-- ================================================================
+-- Add optional email column to staff_profiles
+-- ================================================================
+-- Staff members can now have an email address so they appear as
+-- selectable recipients in the checklist "Notify" logic rule trigger.
+-- The column is nullable — existing rows are unaffected.
+-- ================================================================
+
+ALTER TABLE public.staff_profiles
+  ADD COLUMN IF NOT EXISTS email text;


### PR DESCRIPTION
## Summary
- **Email field on staff profiles**: The "Add/Edit staff profile" form now has an optional Email field (between Last name and Role). Staff members who have an email set will appear as selectable recipients in the checklist "Notify" logic rule trigger.
- **Notify picker shows all people with emails**: The recipient dropdown in the checklist builder now merges admin team members AND active kiosk staff profiles who have an email — de-duplicated by address. Previously it only showed admin accounts.
- **DB migration**: Adds nullable `email` column to `staff_profiles` — fully backwards compatible, existing profiles unaffected.

## Priority order for email delivery
1. The specific email selected in the notify rule (`recipient_email` on the alert row) — goes directly to that person
2. If no `recipient_email` is set (e.g. out-of-range number alerts) — falls back to the location's alert email

## Test plan
- [ ] Admin → My Location → Staff → Add staff → email field is visible (optional)
- [ ] Add a staff member with an email → save
- [ ] Open Checklist Builder → add a "Notify" trigger → dropdown now shows that staff member alongside admin team members
- [ ] Save the checklist, complete it in kiosk with the triggering answer → email arrives at the staff member's address

🤖 Generated with [Claude Code](https://claude.com/claude-code)