### PR TITLE
fix: wire VITE_GOOGLE_MAPS_API_KEY into GitHub Pages build

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -45,6 +45,7 @@ jobs:
           VITE_STRIPE_PRICE_GROWTH_MONTHLY: ${{ vars.VITE_STRIPE_PRICE_GROWTH_MONTHLY }}
           VITE_STRIPE_PRICE_GROWTH_ANNUAL: ${{ vars.VITE_STRIPE_PRICE_GROWTH_ANNUAL }}
           VITE_STRIPE_CUSTOMER_PORTAL_URL: ${{ vars.VITE_STRIPE_CUSTOMER_PORTAL_URL }}
+          VITE_GOOGLE_MAPS_API_KEY: ${{ secrets.VITE_GOOGLE_MAPS_API_KEY }}
         run: bun run build
 
       - name: Upload Pages artifact


### PR DESCRIPTION
## Summary
The Google Maps Places autocomplete was silently degrading to a plain text input in production because `VITE_GOOGLE_MAPS_API_KEY` was never injected into the build. The component and all supporting code is already fully implemented — it just needed the key passed through.

## What changed
- `.github/workflows/github-pages.yml`: added `VITE_GOOGLE_MAPS_API_KEY: ${{ secrets.VITE_GOOGLE_MAPS_API_KEY }}` to the build step

## To activate after merging
Add the secret in GitHub → Settings → Secrets and variables → Actions → New repository secret:
- Name: `VITE_GOOGLE_MAPS_API_KEY`  
- Value: your Google Cloud API key (see GOLIVE.md for setup steps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)