### PR TITLE
Show map preview in location details after saving

### DIFF
--- a/src/pages/admin/MyLocationTab.tsx
+++ b/src/pages/admin/MyLocationTab.tsx
@@ -16,6 +16,7 @@ import {
   ROLE_COLOR_MAP,
   parseHours, formatHoursText,
 } from "./shared";
+import { StaticMapPreview } from "@/components/PlacesAutocompleteInput";
 
 export interface MyLocationTabProps {
   locations: Location[];
@@ -136,6 +137,9 @@ export function MyLocationTab({
               <MapPin size={13} className="text-muted-foreground mt-0.5 shrink-0" />
               <p className="text-sm text-foreground">{currentLocation.address}</p>
             </div>
+          )}
+          {currentLocation.lat != null && currentLocation.lng != null && (
+            <StaticMapPreview lat={currentLocation.lat} lng={currentLocation.lng} />
           )}
           {currentLocation.trading_hours && (() => {
             let display = currentLocation.trading_hours;


### PR DESCRIPTION
## Summary
- The map thumbnail now appears in the saved location details card (not just in the edit modal)
- No data changes — lat/lng was already being saved correctly, the view just wasn't displaying it

🤖 Generated with [Claude Code](https://claude.com/claude-code)