### PR TITLE
Widen map + kiosk column to 30% in My Location layout

### DIFF
--- a/src/pages/admin/MyLocationTab.tsx
+++ b/src/pages/admin/MyLocationTab.tsx
@@ -175,14 +175,14 @@ export function MyLocationTab({
         </div>
 
         {/* Right — map thumbnail + kiosk CTA */}
-        <div className="flex flex-col gap-2" style={{ width: 100 }}>
+        <div className="flex flex-col gap-2 w-[30%] shrink-0">
           {currentLocation.lat != null && currentLocation.lng != null && MAPS_API_KEY ? (
             <a
               href={`https://www.google.com/maps/search/?api=1&query=${currentLocation.lat},${currentLocation.lng}`}
               target="_blank"
               rel="noopener noreferrer"
               className="rounded-2xl overflow-hidden border border-border shadow-sm hover:opacity-80 transition-opacity block"
-              style={{ height: 100 }}
+              style={{ height: 120 }}
               title="Open in Google Maps"
             >
               <img
@@ -198,7 +198,7 @@ export function MyLocationTab({
               />
             </a>
           ) : (
-            <div className="rounded-2xl border border-border bg-muted flex items-center justify-center" style={{ height: 100 }}>
+            <div className="rounded-2xl border border-border bg-muted flex items-center justify-center" style={{ height: 120 }}>
               <MapPin size={18} className="text-muted-foreground" />
             </div>
           )}


### PR DESCRIPTION
## Summary
- Right column (map + Kiosk CTA) changed from fixed 100px to 30% width
- Left column (location details) takes remaining 70%
- Map thumbnail height increased to 120px

🤖 Generated with [Claude Code](https://claude.com/claude-code)