### PR TITLE
Standardise all Account tab CTA button sizes

### DIFF
--- a/src/pages/admin/AccountTab.tsx
+++ b/src/pages/admin/AccountTab.tsx
@@ -514,7 +514,7 @@ export function AccountTab({
           <div className="flex justify-end px-4 py-3 border-t border-border">
             <button
               onClick={handleAddLocationClick}
-              className="py-2 px-4 rounded-xl text-sm font-semibold bg-sage text-white hover:bg-sage-deep transition-colors flex items-center gap-2"
+              className="py-2 px-4 rounded-xl text-sm font-semibold bg-sage text-white hover:bg-sage-deep transition-colors flex items-center justify-center gap-2 min-w-[168px]"
             >
               <Plus size={14} /> Add location
             </button>
@@ -630,7 +630,7 @@ export function AccountTab({
           <div className="flex justify-end px-4 py-3 border-t border-border">
             <button
               onClick={onInviteMember}
-              className="py-2 px-4 rounded-xl text-sm font-semibold bg-sage text-white hover:bg-sage-deep transition-colors flex items-center gap-2"
+              className="py-2 px-4 rounded-xl text-sm font-semibold bg-sage text-white hover:bg-sage-deep transition-colors flex items-center justify-center gap-2 min-w-[168px]"
             >
               <Plus size={14} /> Add a team member
             </button>
@@ -736,7 +736,7 @@ export function AccountTab({
             {!showAddDepartment && (
               <button
                 onClick={() => setShowAddDepartment(true)}
-                className="py-2 px-4 rounded-xl text-sm font-semibold bg-sage text-white hover:bg-sage-deep transition-colors flex items-center gap-2"
+                className="py-2 px-4 rounded-xl text-sm font-semibold bg-sage text-white hover:bg-sage-deep transition-colors flex items-center justify-center gap-2 min-w-[168px]"
               >
                 <Plus size={14} /> Add department
               </button>
@@ -769,7 +769,7 @@ export function AccountTab({
           <div className="flex justify-end px-4 py-3">
             <button
               onClick={() => navigate("/billing")}
-              className="py-2 px-4 rounded-xl text-sm font-semibold bg-sage text-white hover:bg-sage-deep transition-colors flex items-center gap-2"
+              className="py-2 px-4 rounded-xl text-sm font-semibold bg-sage text-white hover:bg-sage-deep transition-colors flex items-center justify-center gap-2 min-w-[168px]"
             >
               Manage Billing
             </button>


### PR DESCRIPTION
## Summary
All four CTA buttons (Add location, Add a team member, Add department, Manage Billing) now have `min-w-[168px]` so they all render at the same width as the longest one ("Add a team member"), regardless of text length.

🤖 Generated with [Claude Code](https://claude.com/claude-code)