### PR TITLE
Store admin PINs as plain text; eye icon always works

### DIFF
--- a/src/hooks/useTeamMembers.ts
+++ b/src/hooks/useTeamMembers.ts
@@ -3,7 +3,6 @@ import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/contexts/AuthContext";
 import type { TeamMember, ManagerPermissions } from "@/lib/admin-repository";
 import { DEFAULT_PERMISSIONS, getInitials } from "@/lib/admin-repository";
-import { hashPin } from "@/hooks/useStaffProfiles";
 
 export function useTeamMembers() {
   const { teamMember } = useAuth();
@@ -12,7 +11,7 @@ export function useTeamMembers() {
     queryFn: async () => {
       const { data, error } = await supabase
         .from("team_members")
-        .select("id, organization_id, name, email, role, location_ids, permissions, pin_reset_required")
+        .select("id, organization_id, name, email, role, location_ids, permissions, pin, pin_reset_required")
         .order("name");
       if (error) throw error;
       return ((data ?? []) as any[])
@@ -47,7 +46,7 @@ export function useSaveTeamMember() {
           permissions: tm.permissions ?? DEFAULT_PERMISSIONS,
         };
         if (tm.rawPin) {
-          updatePayload.pin = await hashPin(tm.rawPin);
+          updatePayload.pin = tm.rawPin;
           updatePayload.pin_reset_required = false;
         } else if (tm.pin_reset_required !== undefined) {
           updatePayload.pin_reset_required = tm.pin_reset_required;
@@ -74,7 +73,7 @@ export function useSaveTeamMember() {
         permissions: tm.permissions ?? DEFAULT_PERMISSIONS,
       };
       if (tm.rawPin) {
-        insertPayload.pin = await hashPin(tm.rawPin);
+        insertPayload.pin = tm.rawPin;
       }
       insertPayload.pin_reset_required = tm.pin_reset_required ?? (tm.role === "Owner");
 
@@ -95,10 +94,9 @@ export function useSaveAdminPin() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async ({ memberId, rawPin }: { memberId: string; rawPin: string }) => {
-      const hashed = await hashPin(rawPin);
       const { error } = await supabase
         .from("team_members")
-        .update({ pin: hashed })
+        .update({ pin: rawPin, pin_reset_required: false })
         .eq("id", memberId);
       if (error) {
         // Surface the real Supabase message (e.g. RLS violation details)

--- a/src/pages/admin/AccountTab.tsx
+++ b/src/pages/admin/AccountTab.tsx
@@ -13,7 +13,7 @@ import {
   type Location, type StaffProfile, type TeamMember, type ManagerPermissions,
   type AuditLogEntry, type StaffDepartment,
   DEFAULT_ADMIN_PIN, DEFAULT_PERMISSIONS,
-  getInitials, formatTimestamp,
+  getInitials,
 } from "@/lib/admin-repository";
 import { usePlan } from "@/hooks/usePlan";
 import { PLAN_LABELS, PLAN_PRICES } from "@/lib/plan-features";
@@ -82,9 +82,7 @@ export function AccountTab({
   const [profileEmail, setProfileEmail] = useState(authUserEmail ?? currentAccount?.email ?? "");
   const [pin, setPin] = useState("");
   const [showNewPin, setShowNewPin] = useState(false);
-  const [justSavedPin, setJustSavedPin] = useState<string | null>(null);
   const [revealCurrentPin, setRevealCurrentPin] = useState(false);
-  const [revealCountdown, setRevealCountdown] = useState(0);
   const [showAddDepartment, setShowAddDepartment] = useState(false);
   const [profileSaving, setProfileSaving] = useState(false);
   const [pinSaving, setPinSaving] = useState(false);
@@ -155,10 +153,8 @@ export function AccountTab({
     if (!currentAccount || pin.length !== 4) return;
     setPinSaving(true);
     try {
-      const rawPin = pin;
-      await saveAdminPin.mutateAsync({ memberId: currentAccount.id, rawPin });
+      await saveAdminPin.mutateAsync({ memberId: currentAccount.id, rawPin: pin });
       setPin("");
-      setJustSavedPin(rawPin);
       toast.success("Admin PIN updated");
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Could not update admin PIN");
@@ -166,19 +162,6 @@ export function AccountTab({
       setPinSaving(false);
     }
   };
-
-  // Reveal current PIN for 30s after saving
-  useEffect(() => {
-    if (!revealCurrentPin) return;
-    setRevealCountdown(30);
-    const interval = setInterval(() => {
-      setRevealCountdown(prev => {
-        if (prev <= 1) { clearInterval(interval); setRevealCurrentPin(false); return 0; }
-        return prev - 1;
-      });
-    }, 1000);
-    return () => clearInterval(interval);
-  }, [revealCurrentPin]);
 
   // Department management
   const [renamingDepartment, setRenamingDepartment] = useState<{ index: number; value: string } | null>(null);
@@ -314,21 +297,18 @@ export function AccountTab({
                 <input
                   readOnly
                   type={revealCurrentPin ? "text" : "password"}
-                  value={justSavedPin ?? "0000"}
+                  value={currentAccount?.pin ?? ""}
+                  placeholder="••••"
                   className="w-full border border-border rounded-xl px-3 py-2.5 pr-9 text-sm bg-muted/50 text-muted-foreground tracking-[0.3em] cursor-default select-none"
                 />
                 <button
                   type="button"
-                  onClick={() => {
-                    if (!justSavedPin) { toast("Set a new PIN first — it will be visible here for 30 seconds after saving."); return; }
-                    setRevealCurrentPin(v => !v);
-                  }}
+                  onClick={() => setRevealCurrentPin(v => !v)}
                   className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
                 >
                   {revealCurrentPin ? <EyeOff size={14} /> : <Eye size={14} />}
                 </button>
               </div>
-              {revealCurrentPin && <p className="text-[10px] text-muted-foreground">Hiding in {revealCountdown}s</p>}
             </div>
             {/* New PIN */}
             <div className="space-y-1">

--- a/supabase/migrations/20260417000001_plaintext_admin_pin.sql
+++ b/supabase/migrations/20260417000001_plaintext_admin_pin.sql
@@ -1,0 +1,85 @@
+-- ─── Switch admin PINs from SHA-256 hashes to plain text ─────────────────────
+--
+-- Previously, team_members.pin stored a SHA-256 hex digest and
+-- validate_admin_pin() re-hashed the incoming PIN server-side before
+-- comparing. This made it impossible to display the current PIN to the owner.
+--
+-- New approach: store the raw 4-digit PIN as plain text. The PIN is only used
+-- for kiosk access (not auth), so plain text is an acceptable trade-off for
+-- usability.
+--
+-- Existing rows have hashed PINs that cannot be reversed. We set
+-- pin_reset_required = true for all of them so owners are prompted to set a
+-- new (plain-text) PIN on next login.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- 1. Force PIN reset for all team members whose pin looks like a SHA-256 hash
+--    (64-char hex string). This ensures they set a new plain-text PIN.
+UPDATE public.team_members
+SET pin_reset_required = true
+WHERE length(pin) = 64
+  AND pin ~ '^[0-9a-f]{64}$';
+
+-- 2. Update validate_admin_pin to compare the raw PIN directly (no hashing).
+CREATE OR REPLACE FUNCTION public.validate_admin_pin(p_pin text, p_location_id uuid)
+RETURNS TABLE (
+  id uuid,
+  organization_id uuid,
+  name text,
+  email text,
+  role text,
+  location_ids uuid[],
+  permissions jsonb
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+STABLE
+SET search_path = public
+AS $$
+BEGIN
+  IF auth.role() = 'authenticated' THEN
+    RETURN QUERY
+      SELECT
+        tm.id,
+        tm.organization_id,
+        tm.name,
+        tm.email,
+        tm.role,
+        tm.location_ids,
+        tm.permissions
+      FROM public.locations target
+      JOIN public.team_members tm
+        ON tm.organization_id = target.organization_id
+     WHERE target.id = p_location_id
+       AND target.organization_id = public.current_org_id()
+       AND tm.pin = p_pin
+       AND (
+         tm.role = 'Owner'
+         OR p_location_id = ANY(COALESCE(tm.location_ids, ARRAY[]::uuid[]))
+       )
+     ORDER BY (tm.role = 'Owner') DESC, tm.created_at ASC
+     LIMIT 1;
+  ELSE
+    RETURN QUERY
+      SELECT
+        tm.id,
+        tm.organization_id,
+        tm.name,
+        tm.email,
+        tm.role,
+        tm.location_ids,
+        tm.permissions
+      FROM public.locations target
+      JOIN public.team_members tm
+        ON tm.organization_id = target.organization_id
+     WHERE target.id = p_location_id
+       AND tm.pin = p_pin
+       AND (
+         tm.role = 'Owner'
+         OR p_location_id = ANY(COALESCE(tm.location_ids, ARRAY[]::uuid[]))
+       )
+     ORDER BY (tm.role = 'Owner') DESC, tm.created_at ASC
+     LIMIT 1;
+  END IF;
+END;
+$$;


### PR DESCRIPTION
## Summary
- **`useTeamMembers.ts`**: Removed SHA-256 hashing from `useSaveAdminPin` and `useSaveTeamMember`; added `pin` to the select query so it's loaded with each team member
- **`AccountTab.tsx`**: Current PIN field now reads from `currentAccount.pin` (the database), so the eye icon works anytime — not just for 30s after saving. Removed the `justSavedPin` state and the 30-second countdown entirely.
- **New migration**: `validate_admin_pin` RPC updated to compare plain text (`tm.pin = p_pin`). Existing rows with hashed PINs (64-char hex) get `pin_reset_required = true` so owners are prompted to set a new PIN on next login.

## ⚠️ After merging: run the migration in Supabase
The migration needs to be applied to the live database. Then set a new PIN from Admin → Account → Security — after that the eye icon will always show it.

## Test plan
- [ ] Set a new PIN → eye icon immediately reveals it
- [ ] Refresh page → eye icon still reveals the PIN (reads from DB)
- [ ] Kiosk admin login with the new plain-text PIN works

🤖 Generated with [Claude Code](https://claude.com/claude-code)