### PR TITLE
feat: add useIsNativeApp() hook for platform detection

### DIFF
--- a/src/hooks/useIsNativeApp.ts
+++ b/src/hooks/useIsNativeApp.ts
@@ -1,0 +1,15 @@
+import { Capacitor } from "@capacitor/core";
+
+/**
+ * Returns true when running inside a native iOS or Android Capacitor shell.
+ * Use this to hide billing/pricing UI that violates App Store guidelines.
+ */
+export function useIsNativeApp(): boolean {
+  const platform = Capacitor.getPlatform();
+  return platform === "ios" || platform === "android";
+}
+
+export function isNativeApp(): boolean {
+  const platform = Capacitor.getPlatform();
+  return platform === "ios" || platform === "android";
+}

--- a/src/test/hooks/useIsNativeApp.test.ts
+++ b/src/test/hooks/useIsNativeApp.test.ts
@@ -1,0 +1,48 @@
+import { renderHook } from "@testing-library/react";
+import { vi } from "vitest";
+
+const mockGetPlatform = vi.fn();
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: { getPlatform: mockGetPlatform },
+}));
+
+// Import after mock is set up
+const { useIsNativeApp, isNativeApp } = await import("@/hooks/useIsNativeApp");
+
+describe("useIsNativeApp", () => {
+  it("returns false on web", () => {
+    mockGetPlatform.mockReturnValue("web");
+    const { result } = renderHook(() => useIsNativeApp());
+    expect(result.current).toBe(false);
+  });
+
+  it("returns true on ios", () => {
+    mockGetPlatform.mockReturnValue("ios");
+    const { result } = renderHook(() => useIsNativeApp());
+    expect(result.current).toBe(true);
+  });
+
+  it("returns true on android", () => {
+    mockGetPlatform.mockReturnValue("android");
+    const { result } = renderHook(() => useIsNativeApp());
+    expect(result.current).toBe(true);
+  });
+});
+
+describe("isNativeApp (utility)", () => {
+  it("returns false on web", () => {
+    mockGetPlatform.mockReturnValue("web");
+    expect(isNativeApp()).toBe(false);
+  });
+
+  it("returns true on ios", () => {
+    mockGetPlatform.mockReturnValue("ios");
+    expect(isNativeApp()).toBe(true);
+  });
+
+  it("returns true on android", () => {
+    mockGetPlatform.mockReturnValue("android");
+    expect(isNativeApp()).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #277
Part of #276 (App Store compliance)

## What
Adds `useIsNativeApp()` React hook and `isNativeApp()` utility function that return `true` when the app is running on iOS or Android via Capacitor.

## Why
Foundation for all subsequent billing-strip PRs. Each PR in the #276 series will import this hook to conditionally hide pricing/Stripe UI on native builds.

## Changes
- `src/hooks/useIsNativeApp.ts` — hook + utility function
- `src/test/hooks/useIsNativeApp.test.ts` — 6 tests covering web/ios/android for both exports

## Test plan
- [x] 6 unit tests pass (web → false, ios → true, android → true)
- [x] `bun run milestone` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)