### PR TITLE
feat: replace Billing page with web-only message on native

### DIFF
--- a/src/pages/Billing.tsx
+++ b/src/pages/Billing.tsx
@@ -8,6 +8,7 @@ import { supabase } from "@/lib/supabase";
 import { usePlan } from "@/hooks/usePlan";
 import { useAuth } from "@/contexts/AuthContext";
 import { runtimeConfig } from "@/lib/runtime-config";
+import { useIsNativeApp } from "@/hooks/useIsNativeApp";
 import {
   PLAN_FEATURES,
   PLAN_LABELS,
@@ -122,6 +123,7 @@ export default function Billing() {
   const { teamMember } = useAuth();
   const qc = useQueryClient();
   const { plan, resolvedPlan, planStatus, hasStripeSubscription, billingUnavailable } = usePlan();
+  const isNative = useIsNativeApp();
   const [billing, setBilling] = useState<"monthly" | "annual">("monthly");
   const [loading, setLoading] = useState<Plan | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -312,6 +314,42 @@ export default function Billing() {
     : plan === "enterprise"
       ? "Unlimited locations included."
       : `${PLAN_FEATURES[resolvedPlan ?? plan].maxLocations === -1 ? "Unlimited" : PLAN_FEATURES[resolvedPlan ?? plan].maxLocations} location${PLAN_FEATURES[resolvedPlan ?? plan].maxLocations === 1 ? "" : "s"} included.`;
+
+  if (isNative) {
+    return (
+      <Layout
+        title="Billing"
+        subtitle="Manage your plan"
+        headerLeft={
+          <button
+            onClick={() => navigate("/admin")}
+            className="p-2 rounded-full hover:bg-muted transition-colors"
+            aria-label="Back"
+          >
+            <ArrowLeft size={18} className="text-muted-foreground" />
+          </button>
+        }
+      >
+        <section className="space-y-4 pb-6">
+          <div className="card-surface p-5 space-y-3">
+            <p className="text-sm font-medium text-foreground">Current plan</p>
+            <p className="text-xl font-display font-semibold text-foreground capitalize">{plan}</p>
+            <p className="text-sm text-muted-foreground">
+              To view plans, upgrade, or manage your subscription, visit us on the web.
+            </p>
+            <a
+              href="https://olia.app/billing"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-sage underline underline-offset-2"
+            >
+              Manage at olia.app <ExternalLink size={13} />
+            </a>
+          </div>
+        </section>
+      </Layout>
+    );
+  }
 
   return (
     <Layout

--- a/src/test/pages/Billing.test.tsx
+++ b/src/test/pages/Billing.test.tsx
@@ -37,14 +37,20 @@ vi.mock("@/contexts/AuthContext", () => ({
 }));
 
 const mockUsePlan = vi.fn();
+const mockUseIsNativeApp = vi.fn().mockReturnValue(false);
 
 vi.mock("@/hooks/usePlan", () => ({
   usePlan: () => mockUsePlan(),
 }));
 
+vi.mock("@/hooks/useIsNativeApp", () => ({
+  useIsNativeApp: () => mockUseIsNativeApp(),
+}));
+
 beforeEach(() => {
   mockInvoke.mockReset();
   mockInvoke.mockResolvedValue({ data: null, error: null });
+  mockUseIsNativeApp.mockReturnValue(false);
   mockUsePlan.mockReturnValue({
     plan: "starter",
     planStatus: "active",
@@ -209,10 +215,38 @@ describe("Billing page", () => {
       },
     });
     renderWithProviders(<Billing />);
-    // Multiple "Growth" elements exist - use getAllByText
     const growthElements = screen.getAllByText(PLAN_LABELS["growth"]);
     expect(growthElements.length).toBeGreaterThanOrEqual(1);
-    // Should show manage subscription link
     expect(screen.getByText("Manage subscription on Stripe")).toBeInTheDocument();
+  });
+
+  describe("native (iOS/Android)", () => {
+    beforeEach(() => { mockUseIsNativeApp.mockReturnValue(true); });
+
+    it("shows current plan name instead of pricing page", () => {
+      renderWithProviders(<Billing />);
+      expect(screen.getByText("starter")).toBeInTheDocument();
+    });
+
+    it("shows 'Manage at olia.app' link", () => {
+      renderWithProviders(<Billing />);
+      expect(screen.getByText(/Manage at olia\.app/i)).toBeInTheDocument();
+    });
+
+    it("does not show any plan prices", () => {
+      renderWithProviders(<Billing />);
+      expect(screen.queryByText(/€49/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/€99/)).not.toBeInTheDocument();
+    });
+
+    it("does not show plan comparison table", () => {
+      renderWithProviders(<Billing />);
+      expect(screen.queryByText("Recommended")).not.toBeInTheDocument();
+    });
+
+    it("does not show Monthly / Annual toggle", () => {
+      renderWithProviders(<Billing />);
+      expect(screen.queryByText("Monthly")).not.toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
Closes #278
Part of #276 (App Store compliance)

## What
On iOS/Android, the `/billing` route now renders a simple card showing the user's current plan name and a link to `olia.app/billing`. The full pricing/Stripe page is shown only on web.

## Why
`Billing.tsx` displays euro prices and Stripe checkout flows, which violate Apple App Store §3.1.1 on native.

## Changes
- `src/pages/Billing.tsx` — early return on `isNative` with stripped card
- `src/test/pages/Billing.test.tsx` — 5 new native tests; mock for `useIsNativeApp`

## Test plan
- [x] 21 tests pass (16 web + 5 native)
- [x] Web path: full pricing, Stripe, toggle unchanged
- [x] Native path: plan name shown, no prices, no comparison table, no toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)