### PR TITLE
feat: hide Manage Billing button in AccountTab on native

### DIFF
--- a/src/pages/admin/AccountTab.tsx
+++ b/src/pages/admin/AccountTab.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/lib/admin-repository";
 import { usePlan } from "@/hooks/usePlan";
 import { PLAN_LABELS, PLAN_PRICES } from "@/lib/plan-features";
+import { useIsNativeApp } from "@/hooks/useIsNativeApp";
 import { type ChecklistItem } from "@/hooks/useChecklists";
 import { useSaveAdminPin } from "@/hooks/useTeamMembers";
 import { PERM_LABELS, roleUsesDepartment } from "./shared";
@@ -63,6 +64,7 @@ export function AccountTab({
 }: AccountTabProps) {
   const navigate = useNavigate();
   const { plan, planStatus, isActive } = usePlan();
+  const isNative = useIsNativeApp();
   const saveAdminPin = useSaveAdminPin();
   // Team member expand/collapse
   const [expandedMemberId, setExpandedMemberId] = useState<string | null>(null);
@@ -762,12 +764,23 @@ export function AccountTab({
             </span>
           </div>
           <div className="flex justify-end px-4 py-3">
-            <button
-              onClick={() => navigate("/billing")}
-              className="py-2 px-4 rounded-xl text-sm font-semibold bg-sage text-white hover:bg-sage-deep transition-colors flex items-center justify-center gap-2 w-52"
-            >
-              Manage Billing
-            </button>
+            {isNative ? (
+              <a
+                href="https://olia.app/billing"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="py-2 px-4 rounded-xl text-sm font-semibold bg-sage text-white hover:bg-sage-deep transition-colors flex items-center justify-center gap-2 w-52"
+              >
+                Manage at olia.app
+              </a>
+            ) : (
+              <button
+                onClick={() => navigate("/billing")}
+                className="py-2 px-4 rounded-xl text-sm font-semibold bg-sage text-white hover:bg-sage-deep transition-colors flex items-center justify-center gap-2 w-52"
+              >
+                Manage Billing
+              </button>
+            )}
           </div>
         </div>
       </section>

--- a/src/test/pages/Admin.test.tsx
+++ b/src/test/pages/Admin.test.tsx
@@ -61,6 +61,12 @@ vi.mock("@/contexts/AuthContext", () => ({
   AuthProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 
+// ─── useIsNativeApp mock (default: web) ──────────────────────────────────────
+const mockUseIsNativeApp = vi.fn().mockReturnValue(false);
+vi.mock("@/hooks/useIsNativeApp", () => ({
+  useIsNativeApp: () => mockUseIsNativeApp(),
+}));
+
 // ─── usePlan mock ─────────────────────────────────────────────────────────────
 vi.mock("@/hooks/usePlan", () => ({
   usePlan: () => ({
@@ -137,6 +143,7 @@ vi.mock("@/hooks/useTeamMembers", () => ({
   useTeamMembers: () => ({ data: mockTeam, isLoading: false }),
   useSaveTeamMember: () => mockSaveTeamMember,
   useDeleteTeamMember: () => ({ mutate: vi.fn() }),
+  useSaveAdminPin: () => ({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false }),
 }));
 
 const mockChecklists = [
@@ -674,11 +681,22 @@ describe("Admin page", () => {
     });
   });
 
-  // 38. Manage Billing button is visible
-  it("'Manage Billing' button is visible in Account tab", async () => {
+  // 38. Manage Billing button is visible on web
+  it("'Manage Billing' button is visible in Account tab on web", async () => {
+    mockUseIsNativeApp.mockReturnValue(false);
     renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
     await waitFor(() => {
       expect(screen.getByText("Manage Billing")).toBeInTheDocument();
+    });
+  });
+
+  // 38b. On native, 'Manage Billing' is replaced with external link
+  it("shows 'Manage at olia.app' link instead of 'Manage Billing' on native", async () => {
+    mockUseIsNativeApp.mockReturnValue(true);
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
+    await waitFor(() => {
+      expect(screen.getByText("Manage at olia.app")).toBeInTheDocument();
+      expect(screen.queryByText("Manage Billing")).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
Closes #279
Part of #276 (App Store compliance)

## What
On iOS/Android, the "Manage Billing" button in the Admin → Account tab billing card is replaced with an external link to `olia.app/billing`. On web it remains unchanged.

## Why
The button navigates to `/billing` which contains pricing and Stripe checkout — not allowed on native builds per App Store guidelines.

## Changes
- `src/pages/admin/AccountTab.tsx` — import `useIsNativeApp`, toggle between internal nav button and external link
- `src/test/pages/Admin.test.tsx` — added `useIsNativeApp` mock; added `useSaveAdminPin` to `useTeamMembers` mock (fixed 21 pre-existing test failures); added native-specific test

## Note on pre-existing test failures
Admin.test.tsx had 38 failing tests on `main` before this PR (missing `useSaveAdminPin` mock). This PR reduces that to 17 by adding the missing mock. The remaining 17 failures are stale content assertions from before the AccountTab redesign — tracked separately in #284.

## Test plan
- [x] New test: "Manage at olia.app" link shown on native, "Manage Billing" hidden
- [x] Existing test: "Manage Billing" still visible on web
- [x] `useSaveAdminPin` mock fix reduces pre-existing failures from 38 → 17

🤖 Generated with [Claude Code](https://claude.com/claude-code)