### PR TITLE
feat: remove 'See plans' CTA from UpgradePrompt on native

### DIFF
--- a/src/components/UpgradePrompt.tsx
+++ b/src/components/UpgradePrompt.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from "react-router-dom";
-import { Sparkles, X } from "lucide-react";
+import { Sparkles, X, ExternalLink } from "lucide-react";
 import { PLAN_LABELS, type Plan } from "@/lib/plan-features";
+import { useIsNativeApp } from "@/hooks/useIsNativeApp";
 
 interface UpgradePromptProps {
   feature: string;          // Human-readable feature name, e.g. "AI checklist builder"
@@ -14,6 +15,7 @@ export function UpgradePrompt({
   onClose,
 }: UpgradePromptProps) {
   const navigate = useNavigate();
+  const isNative = useIsNativeApp();
 
   return (
     <div className="fixed inset-0 z-[60] flex items-end justify-center bg-foreground/20 backdrop-blur-sm animate-fade-in sm:items-center sm:px-4 sm:py-8">
@@ -49,12 +51,24 @@ export function UpgradePrompt({
           >
             Not now
           </button>
-          <button
-            onClick={() => { onClose(); navigate("/billing"); }}
-            className="flex-1 py-2.5 rounded-xl text-sm font-medium bg-sage text-primary-foreground hover:bg-sage-deep transition-colors"
-          >
-            See plans
-          </button>
+          {isNative ? (
+            <a
+              href="https://olia.app/billing"
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={onClose}
+              className="flex-1 py-2.5 rounded-xl text-sm font-medium bg-sage text-primary-foreground hover:bg-sage-deep transition-colors flex items-center justify-center gap-1.5"
+            >
+              Upgrade at olia.app <ExternalLink size={12} />
+            </a>
+          ) : (
+            <button
+              onClick={() => { onClose(); navigate("/billing"); }}
+              className="flex-1 py-2.5 rounded-xl text-sm font-medium bg-sage text-primary-foreground hover:bg-sage-deep transition-colors"
+            >
+              See plans
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/src/test/components/UpgradePrompt.test.tsx
+++ b/src/test/components/UpgradePrompt.test.tsx
@@ -4,6 +4,7 @@ import { PLAN_LABELS } from "@/lib/plan-features";
 import { renderWithProviders } from "../test-utils";
 
 const mockNavigate = vi.fn();
+const mockUseIsNativeApp = vi.fn().mockReturnValue(false);
 
 vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
@@ -24,12 +25,17 @@ vi.mock("@/lib/supabase", () => ({
   },
 }));
 
+vi.mock("@/hooks/useIsNativeApp", () => ({
+  useIsNativeApp: () => mockUseIsNativeApp(),
+}));
+
 describe("UpgradePrompt", () => {
   const onClose = vi.fn();
 
   beforeEach(() => {
     onClose.mockClear();
     mockNavigate.mockReset();
+    mockUseIsNativeApp.mockReturnValue(false);
   });
 
   it("renders the feature name", () => {
@@ -65,14 +71,13 @@ describe("UpgradePrompt", () => {
     renderWithProviders(
       <UpgradePrompt feature="AI checklist builder" onClose={onClose} />
     );
-    // The X button has an SVG inside — find it by role button or by aria label
     const closeBtn = document.querySelector("button[class*='rounded-full']");
     expect(closeBtn).not.toBeNull();
     fireEvent.click(closeBtn!);
     expect(onClose).toHaveBeenCalled();
   });
 
-  it("calls onClose and navigates when 'See plans' is clicked", () => {
+  it("calls onClose and navigates when 'See plans' is clicked on web", () => {
     renderWithProviders(
       <UpgradePrompt feature="AI checklist builder" onClose={onClose} />
     );
@@ -86,5 +91,40 @@ describe("UpgradePrompt", () => {
       <UpgradePrompt feature="File conversion" onClose={onClose} />
     );
     expect(screen.getByText("Upgrade to unlock")).toBeInTheDocument();
+  });
+
+  describe("native (iOS/Android)", () => {
+    beforeEach(() => { mockUseIsNativeApp.mockReturnValue(true); });
+
+    it("shows 'Upgrade at olia.app' link instead of 'See plans'", () => {
+      renderWithProviders(
+        <UpgradePrompt feature="AI checklist builder" onClose={onClose} />
+      );
+      expect(screen.getByText(/Upgrade at olia\.app/i)).toBeInTheDocument();
+      expect(screen.queryByText("See plans")).not.toBeInTheDocument();
+    });
+
+    it("still shows feature name and plan label on native", () => {
+      renderWithProviders(
+        <UpgradePrompt feature="CSV export" onClose={onClose} />
+      );
+      expect(screen.getByText("CSV export")).toBeInTheDocument();
+      expect(screen.getByText(PLAN_LABELS["growth"])).toBeInTheDocument();
+    });
+
+    it("still shows 'Not now' button on native", () => {
+      renderWithProviders(
+        <UpgradePrompt feature="AI checklist builder" onClose={onClose} />
+      );
+      expect(screen.getByText("Not now")).toBeInTheDocument();
+    });
+
+    it("does not navigate to /billing on native", () => {
+      renderWithProviders(
+        <UpgradePrompt feature="AI checklist builder" onClose={onClose} />
+      );
+      expect(screen.queryByText("See plans")).not.toBeInTheDocument();
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
Closes #280
Part of #276 (App Store compliance)

## What
On iOS/Android, the "See plans" button in the `UpgradePrompt` modal is replaced with an external link to `olia.app/billing`. The feature name, plan label, and "Not now" button are unchanged on both platforms.

## Why
"See plans" navigates to `/billing` which contains pricing — not allowed on native builds per App Store guidelines.

## Changes
- `src/components/UpgradePrompt.tsx` — import `useIsNativeApp`; swap CTA based on platform
- `src/test/components/UpgradePrompt.test.tsx` — mock `useIsNativeApp`; 4 new native tests; existing web tests updated

## Test plan
- [x] 11 tests pass (7 web + 4 native)
- [x] Web: "See plans" navigates to /billing unchanged
- [x] Native: "Upgrade at olia.app" link shown, no navigation to /billing

🤖 Generated with [Claude Code](https://claude.com/claude-code)