### PR TITLE
fix: replace dead-end setup error with recovery screen

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -21,6 +21,7 @@ interface AuthContextValue {
   loading: boolean;
   setupError: string | null;   // set when setup_new_organization fails
   retrySetup: () => void;      // lets the UI offer a "Try again" button
+  completeSetup: (businessName: string) => Promise<void>; // recovery path when row is missing
   signOut: () => Promise<void>;
 }
 
@@ -31,6 +32,7 @@ const AuthContext = createContext<AuthContextValue>({
   loading: true,
   setupError: null,
   retrySetup: () => {},
+  completeSetup: async () => {},
   signOut: async () => {},
 });
 
@@ -115,13 +117,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         p_owner_name: safeOwnerName,
       });
 
-      if (rpcError) {
-        throw rpcError;
-      }
-
       localStorage.removeItem("olia_pending_onboarding");
 
-      // Re-fetch the newly created team_member row
+      // Always re-fetch after the RPC attempt. If the RPC returned an error
+      // (e.g. duplicate key — org already exists from a prior run), the row
+      // may already be there; re-fetching lets returning users recover without
+      // a setup error screen. Only surface setupError if both the RPC AND
+      // the re-fetch failed.
       const { data: newData, error: refetchError } = await supabase
         .from("team_members")
         .select("*")
@@ -129,7 +131,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         .single();
 
       if (!newData) {
-        console.error("[AuthContext] team_member row missing after setup:", refetchError);
+        if (rpcError) {
+          console.error("[AuthContext] setup_new_organization failed and row not found:", rpcError);
+        } else {
+          console.error("[AuthContext] team_member row missing after setup:", refetchError);
+        }
         setSetupError(
           "Your account setup is not complete. Please refresh the page and try again.",
         );
@@ -200,12 +206,54 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     );
   };
 
+  // Recovery path: called from the UI when the team_member row is missing
+  // and the user provides their business name manually (e.g. after a data reset).
+  const completeSetup = async (businessName: string) => {
+    if (!user) return;
+    setLoading(true);
+    setSetupError(null);
+
+    const ownerName = (user.user_metadata?.full_name as string | undefined)?.trim()
+      || (user.email?.split("@")[0] ?? "Owner");
+
+    const { error: rpcError } = await supabase.rpc("setup_new_organization", {
+      p_business_name: businessName.trim(),
+      p_owner_name: ownerName,
+    });
+
+    if (rpcError) {
+      console.error("[AuthContext] completeSetup RPC failed:", rpcError);
+      setSetupError(rpcError.message ?? "Setup failed. Please try again.");
+      setLoading(false);
+      return;
+    }
+
+    // Re-fetch the newly created row
+    const { data: newData, error: refetchError } = await supabase
+      .from("team_members")
+      .select("*")
+      .eq("id", user.id)
+      .single();
+
+    if (!newData) {
+      console.error("[AuthContext] completeSetup re-fetch failed:", refetchError);
+      setSetupError("Your account setup is not complete. Please refresh the page and try again.");
+      setTeamMember(null);
+      setLoading(false);
+      return;
+    }
+
+    setTeamMember(newData as TeamMemberProfile);
+    setSetupError(null);
+    setLoading(false);
+  };
+
   const signOut = async () => {
     await supabase.auth.signOut();
   };
 
   return (
-    <AuthContext.Provider value={{ user, session, teamMember, loading, setupError, retrySetup, signOut }}>
+    <AuthContext.Provider value={{ user, session, teamMember, loading, setupError, retrySetup, completeSetup, signOut }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -33,6 +33,79 @@ import {
   type ConfirmState,
 } from "./admin/SharedUI";
 
+// ─── SetupRecoveryScreen ──────────────────────────────────────────────────────
+
+function SetupRecoveryScreen({
+  onComplete,
+  onRetry,
+}: {
+  onComplete: (businessName: string) => Promise<void>;
+  onRetry: () => void;
+}) {
+  const [businessName, setBusinessName] = useState("");
+  const [completing, setCompleting] = useState(false);
+  const [completionError, setCompletionError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!businessName.trim()) return;
+    setCompleting(true);
+    setCompletionError(null);
+    try {
+      await onComplete(businessName.trim());
+    } catch (err: any) {
+      setCompletionError(err?.message ?? "Setup failed. Please try again.");
+    } finally {
+      setCompleting(false);
+    }
+  };
+
+  return (
+    <Layout title="Admin" subtitle="Setup required">
+      <div className="flex flex-col items-center justify-center py-16 px-4 text-center space-y-6">
+        <div className="w-16 h-16 rounded-2xl bg-status-error/10 flex items-center justify-center">
+          <X size={28} className="text-status-error" />
+        </div>
+        <div className="space-y-2">
+          <h2 className="font-display text-xl text-foreground">Account setup incomplete</h2>
+          <p className="text-sm text-muted-foreground max-w-xs leading-relaxed">
+            Your account setup is not complete. Enter your business name below to finish setting up your account.
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="w-full max-w-xs space-y-3">
+          <input
+            type="text"
+            value={businessName}
+            onChange={e => setBusinessName(e.target.value)}
+            placeholder="Business name"
+            className="w-full px-4 py-3 rounded-xl border border-border bg-card text-foreground text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-sage/30"
+            disabled={completing}
+            autoFocus
+          />
+          {completionError && (
+            <p className="text-xs text-status-error text-left leading-relaxed">{completionError}</p>
+          )}
+          <button
+            type="submit"
+            disabled={completing || !businessName.trim()}
+            className="w-full px-5 py-3 rounded-xl bg-sage text-primary-foreground text-sm font-semibold hover:bg-sage-deep transition-colors disabled:opacity-50"
+          >
+            {completing ? "Setting up…" : "Complete setup"}
+          </button>
+        </form>
+
+        <button
+          onClick={onRetry}
+          className="text-xs text-muted-foreground underline underline-offset-2"
+        >
+          Try refreshing instead
+        </button>
+      </div>
+    </Layout>
+  );
+}
+
 // ─── Admin Page ───────────────────────────────────────────────────────────────
 
 export default function Admin() {
@@ -40,7 +113,7 @@ export default function Admin() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const fromKiosk = searchParams.get("from") === "kiosk";
-  const { user, teamMember: authMember, setupError, retrySetup } = useAuth();
+  const { user, teamMember: authMember, setupError, retrySetup, completeSetup } = useAuth();
 
   // Resolve the kiosk-authenticated userId from sessionStorage (one-time use token).
   // If from=kiosk is in the URL but the token is missing or expired, redirect back to kiosk.
@@ -302,27 +375,7 @@ export default function Admin() {
 
   // ── Setup error screen — shown when setup_new_organization failed ────────────
   if (setupError) {
-    return (
-      <Layout title="Admin" subtitle="Setup required">
-        <div className="flex flex-col items-center justify-center py-16 px-4 text-center space-y-5">
-          <div className="w-16 h-16 rounded-2xl bg-status-error/10 flex items-center justify-center">
-            <X size={28} className="text-status-error" />
-          </div>
-          <div className="space-y-2">
-            <h2 className="font-display text-xl text-foreground">Account setup incomplete</h2>
-            <p className="text-sm text-muted-foreground max-w-xs leading-relaxed">
-              Your account setup is not complete. Please refresh the page and try again, or contact support if the problem persists.
-            </p>
-          </div>
-          <button
-            onClick={retrySetup}
-            className="flex items-center gap-2 px-5 py-3 rounded-xl bg-sage text-primary-foreground text-sm font-semibold hover:bg-sage-deep transition-colors"
-          >
-            Try again
-          </button>
-        </div>
-      </Layout>
-    );
+    return <SetupRecoveryScreen onComplete={completeSetup} onRetry={retrySetup} />;
   }
 
   return (


### PR DESCRIPTION
## Summary
- Replaces the dead-end "Try again" button on the setup error screen with a business name input form
- Adds `completeSetup()` to AuthContext which calls `setup_new_organization` directly with the entered name
- Fixes accounts whose `team_members` row was wiped (e.g. by the data reset migration) — they can now recover without signing up again

## Test plan
- [ ] Merge and deploy
- [ ] On the Admin page, if you see "Account setup incomplete", enter your business name and tap "Complete setup"
- [ ] Admin page should load normally afterwards

🤖 Generated with [Claude Code](https://claude.com/claude-code)