### PR TITLE
fix: auto sign-out when account data is missing instead of recovery form

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -21,7 +21,6 @@ interface AuthContextValue {
   loading: boolean;
   setupError: string | null;   // set when setup_new_organization fails
   retrySetup: () => void;      // lets the UI offer a "Try again" button
-  completeSetup: (businessName: string) => Promise<void>; // recovery path when row is missing
   signOut: () => Promise<void>;
 }
 
@@ -32,7 +31,6 @@ const AuthContext = createContext<AuthContextValue>({
   loading: true,
   setupError: null,
   retrySetup: () => {},
-  completeSetup: async () => {},
   signOut: async () => {},
 });
 
@@ -206,54 +204,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     );
   };
 
-  // Recovery path: called from the UI when the team_member row is missing
-  // and the user provides their business name manually (e.g. after a data reset).
-  const completeSetup = async (businessName: string) => {
-    if (!user) return;
-    setLoading(true);
-    setSetupError(null);
-
-    const ownerName = (user.user_metadata?.full_name as string | undefined)?.trim()
-      || (user.email?.split("@")[0] ?? "Owner");
-
-    const { error: rpcError } = await supabase.rpc("setup_new_organization", {
-      p_business_name: businessName.trim(),
-      p_owner_name: ownerName,
-    });
-
-    if (rpcError) {
-      console.error("[AuthContext] completeSetup RPC failed:", rpcError);
-      setSetupError(rpcError.message ?? "Setup failed. Please try again.");
-      setLoading(false);
-      return;
-    }
-
-    // Re-fetch the newly created row
-    const { data: newData, error: refetchError } = await supabase
-      .from("team_members")
-      .select("*")
-      .eq("id", user.id)
-      .single();
-
-    if (!newData) {
-      console.error("[AuthContext] completeSetup re-fetch failed:", refetchError);
-      setSetupError("Your account setup is not complete. Please refresh the page and try again.");
-      setTeamMember(null);
-      setLoading(false);
-      return;
-    }
-
-    setTeamMember(newData as TeamMemberProfile);
-    setSetupError(null);
-    setLoading(false);
-  };
-
   const signOut = async () => {
     await supabase.auth.signOut();
   };
 
   return (
-    <AuthContext.Provider value={{ user, session, teamMember, loading, setupError, retrySetup, completeSetup, signOut }}>
+    <AuthContext.Provider value={{ user, session, teamMember, loading, setupError, retrySetup, signOut }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { Layout } from "@/components/Layout";
-import { MapPin, X, ArrowLeft } from "lucide-react";
+import { MapPin, ArrowLeft } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
   type Location, type StaffProfile, type TeamMember, type ManagerPermissions,
@@ -33,79 +33,6 @@ import {
   type ConfirmState,
 } from "./admin/SharedUI";
 
-// ─── SetupRecoveryScreen ──────────────────────────────────────────────────────
-
-function SetupRecoveryScreen({
-  onComplete,
-  onRetry,
-}: {
-  onComplete: (businessName: string) => Promise<void>;
-  onRetry: () => void;
-}) {
-  const [businessName, setBusinessName] = useState("");
-  const [completing, setCompleting] = useState(false);
-  const [completionError, setCompletionError] = useState<string | null>(null);
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!businessName.trim()) return;
-    setCompleting(true);
-    setCompletionError(null);
-    try {
-      await onComplete(businessName.trim());
-    } catch (err: any) {
-      setCompletionError(err?.message ?? "Setup failed. Please try again.");
-    } finally {
-      setCompleting(false);
-    }
-  };
-
-  return (
-    <Layout title="Admin" subtitle="Setup required">
-      <div className="flex flex-col items-center justify-center py-16 px-4 text-center space-y-6">
-        <div className="w-16 h-16 rounded-2xl bg-status-error/10 flex items-center justify-center">
-          <X size={28} className="text-status-error" />
-        </div>
-        <div className="space-y-2">
-          <h2 className="font-display text-xl text-foreground">Account setup incomplete</h2>
-          <p className="text-sm text-muted-foreground max-w-xs leading-relaxed">
-            Your account setup is not complete. Enter your business name below to finish setting up your account.
-          </p>
-        </div>
-
-        <form onSubmit={handleSubmit} className="w-full max-w-xs space-y-3">
-          <input
-            type="text"
-            value={businessName}
-            onChange={e => setBusinessName(e.target.value)}
-            placeholder="Business name"
-            className="w-full px-4 py-3 rounded-xl border border-border bg-card text-foreground text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-sage/30"
-            disabled={completing}
-            autoFocus
-          />
-          {completionError && (
-            <p className="text-xs text-status-error text-left leading-relaxed">{completionError}</p>
-          )}
-          <button
-            type="submit"
-            disabled={completing || !businessName.trim()}
-            className="w-full px-5 py-3 rounded-xl bg-sage text-primary-foreground text-sm font-semibold hover:bg-sage-deep transition-colors disabled:opacity-50"
-          >
-            {completing ? "Setting up…" : "Complete setup"}
-          </button>
-        </form>
-
-        <button
-          onClick={onRetry}
-          className="text-xs text-muted-foreground underline underline-offset-2"
-        >
-          Try refreshing instead
-        </button>
-      </div>
-    </Layout>
-  );
-}
-
 // ─── Admin Page ───────────────────────────────────────────────────────────────
 
 export default function Admin() {
@@ -113,7 +40,7 @@ export default function Admin() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const fromKiosk = searchParams.get("from") === "kiosk";
-  const { user, teamMember: authMember, setupError, retrySetup, completeSetup } = useAuth();
+  const { user, teamMember: authMember, setupError, signOut } = useAuth();
 
   // Resolve the kiosk-authenticated userId from sessionStorage (one-time use token).
   // If from=kiosk is in the URL but the token is missing or expired, redirect back to kiosk.
@@ -373,10 +300,15 @@ export default function Admin() {
     ...(isOwner ? [{ key: "account" as const, label: "Account" }] : []),
   ];
 
-  // ── Setup error screen — shown when setup_new_organization failed ────────────
-  if (setupError) {
-    return <SetupRecoveryScreen onComplete={completeSetup} onRetry={retrySetup} />;
-  }
+  // ── Setup error — account data missing, sign out and redirect to signup ────────
+  // This happens when the team_members row doesn't exist and can't be created
+  // automatically (no business name in localStorage or user metadata). Rather than
+  // leaving the user in a broken state, sign them out and send them to signup so
+  // they can start fresh with a properly configured account.
+  useEffect(() => {
+    if (!setupError) return;
+    signOut().then(() => navigate("/signup?reason=account-reset", { replace: true }));
+  }, [setupError, signOut, navigate]);
 
   return (
     <>

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useNavigate, Link } from "react-router-dom";
+import { useNavigate, useSearchParams, Link } from "react-router-dom";
 import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/contexts/AuthContext";
 import { cn } from "@/lib/utils";
@@ -17,6 +17,8 @@ const DEFAULT_ADMIN_PIN_NOTICE_KEY = "olia_default_admin_pin_notice";
 
 export default function Signup() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const accountReset = searchParams.get("reason") === "account-reset";
   const { user } = useAuth();
   const [step, setStep] = useState<Step>("form");
   const [businessName, setBusinessName] = useState("");
@@ -231,6 +233,14 @@ export default function Signup() {
   return (
     <div className="min-h-screen bg-background flex flex-col items-center justify-center px-6 py-12">
       <div className="w-full max-w-sm space-y-8">
+        {/* Account-reset notice — shown when redirected from a broken auth state */}
+        {accountReset && (
+          <div className="rounded-xl bg-status-warn/10 border border-status-warn/20 px-4 py-3 text-sm text-foreground leading-relaxed">
+            <p className="font-medium mb-0.5">Your account data was not found.</p>
+            <p className="text-muted-foreground text-xs">Please create a new account to get started.</p>
+          </div>
+        )}
+
         {/* Logo */}
         <div className="text-center">
           <div className="w-14 h-14 rounded-2xl bg-sage flex items-center justify-center mx-auto mb-4">


### PR DESCRIPTION
## Summary
- Removes the business name recovery form from the Admin screen entirely
- When `setupError` is set (team_members row missing, can't auto-recover), Admin now automatically signs the user out and navigates to `/signup?reason=account-reset`
- The signup page shows a brief amber notice: "Your account data was not found — please create a new account to get started"
- Cleans up `completeSetup` from AuthContext and removes `SetupRecoveryScreen` from Admin.tsx

## Why
The recovery form was the wrong UX — users shouldn't see a broken internal state with a form asking for their business name inside the admin screen. If account data is missing, the correct path is to sign out and go through signup properly.

## Test plan
- [ ] Merge and deploy
- [ ] Refresh admin page — you should be redirected to `/signup` with an amber notice
- [ ] Fill in the signup form to create a fresh account

🤖 Generated with [Claude Code](https://claude.com/claude-code)