### PR TITLE
fix: return team_member from setup_new_organization to bypass RLS re-fetch

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -108,48 +108,42 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       return;
     }
 
-    // Step 3: Create org + team_member
+    // Step 3: Create org + team_member.
+    // The RPC is SECURITY DEFINER so it can read/write without RLS constraints.
+    // It returns the full team_member row directly — no second SELECT needed,
+    // which avoids the RLS re-fetch failure caused by search_path issues in
+    // current_org_id() on some Supabase connection pools.
     try {
-      const { error: rpcError } = await supabase.rpc("setup_new_organization", {
+      const { data: rpcData, error: rpcError } = await supabase.rpc("setup_new_organization", {
         p_business_name: businessName.trim(),
         p_owner_name: safeOwnerName,
       });
 
       localStorage.removeItem("olia_pending_onboarding");
 
-      // Always re-fetch after the RPC attempt. If the RPC returned an error
-      // (e.g. duplicate key — org already exists from a prior run), the row
-      // may already be there; re-fetching lets returning users recover without
-      // a setup error screen. Only surface setupError if both the RPC AND
-      // the re-fetch failed.
-      const { data: newData, error: refetchError } = await supabase
-        .from("team_members")
-        .select("*")
-        .eq("id", userId)
-        .single();
-
-      if (!newData) {
-        if (rpcError) {
-          console.error("[AuthContext] setup_new_organization failed and row not found:", rpcError);
-        } else {
-          console.error("[AuthContext] team_member row missing after setup:", refetchError);
-        }
-        setSetupError(
-          "Your account setup is not complete. Please refresh the page and try again.",
-        );
+      if (rpcError) {
+        console.error("[AuthContext] setup_new_organization failed:", rpcError);
+        setSetupError("Your account setup is not complete. Please refresh the page and try again.");
         setTeamMember(null);
         setLoading(false);
         return;
       }
 
-      setTeamMember(newData as TeamMemberProfile);
+      const newData = rpcData?.team_member as TeamMemberProfile | null;
+      if (!newData) {
+        console.error("[AuthContext] setup_new_organization returned no team_member:", rpcData);
+        setSetupError("Your account setup is not complete. Please refresh the page and try again.");
+        setTeamMember(null);
+        setLoading(false);
+        return;
+      }
+
+      setTeamMember(newData);
       setLoading(false);
     } catch (err) {
-      console.error("[AuthContext] setup_new_organization failed:", err);
+      console.error("[AuthContext] setup_new_organization threw:", err);
       localStorage.removeItem("olia_pending_onboarding");
-      setSetupError(
-        "Your account setup is not complete. Please refresh the page and try again.",
-      );
+      setSetupError("Your account setup is not complete. Please refresh the page and try again.");
       setTeamMember(null);
       setLoading(false);
     }

--- a/src/test/contexts/AuthContext.extended.test.tsx
+++ b/src/test/contexts/AuthContext.extended.test.tsx
@@ -246,13 +246,10 @@ describe("AuthContext extended — RPC error path", () => {
       JSON.stringify({ businessName: "Success Co", ownerName: "Happy User" }),
     );
 
-    // After RPC succeeds, a new team member row is returned
-    let callCount = 0;
-    mockTeamMemberSingle.mockImplementation(async () => {
-      callCount++;
-      if (callCount === 1) return { data: null, error: null }; // first check: no row
-      return {
-        data: {
+    // RPC now returns the team_member row directly — no re-fetch needed.
+    mockRpc.mockResolvedValueOnce({
+      data: {
+        team_member: {
           id: "user-ok",
           organization_id: "org-ok",
           name: "Happy User",
@@ -260,9 +257,11 @@ describe("AuthContext extended — RPC error path", () => {
           role: "Owner",
           location_ids: [],
           permissions: {},
+          pin_reset_required: false,
         },
-        error: null,
-      };
+        existed: false,
+      },
+      error: null,
     });
 
     const { result } = renderHook(() => useAuth(), { wrapper });

--- a/src/test/contexts/AuthContext.test.tsx
+++ b/src/test/contexts/AuthContext.test.tsx
@@ -181,14 +181,12 @@ describe("AuthContext", () => {
       JSON.stringify({ businessName: "Acme Café", ownerName: "Sarah Johnson" }),
     );
 
-    // First single() → null (no existing row, triggers setup).
-    // Second single() → the newly created row (re-fetch after RPC).
-    let fetchCount = 0;
-    mockTeamMemberSingle.mockImplementation(async () => {
-      fetchCount += 1;
-      if (fetchCount === 1) return { data: null, error: null };
-      return {
-        data: {
+    // No existing row — triggers setup.
+    mockTeamMemberSingle.mockResolvedValue({ data: null, error: null });
+    // RPC returns the team_member row directly (no re-fetch needed).
+    mockRpc.mockResolvedValueOnce({
+      data: {
+        team_member: {
           id: "user-1",
           organization_id: "org-new-1",
           name: "Sarah Johnson",
@@ -196,9 +194,11 @@ describe("AuthContext", () => {
           role: "Owner",
           location_ids: [],
           permissions: {},
+          pin_reset_required: true,
         },
-        error: null,
-      };
+        existed: false,
+      },
+      error: null,
     });
 
     const { result } = renderHook(() => useAuth(), { wrapper });

--- a/src/test/integration/auth-bootstrap.integration.test.ts
+++ b/src/test/integration/auth-bootstrap.integration.test.ts
@@ -316,14 +316,10 @@ describe("AuthContext bootstrap integration", () => {
   // ── First-time user — org created → teamMember populated ──────────────────
 
   it("populates teamMember.organization_id after setup_new_organization, so location saves cannot hit the !teamMember guard", async () => {
-    // First single() call returns null (no existing row).
-    // After RPC, the second single() call returns the newly created row.
-    let fetchCount = 0;
-    mockTeamMemberSingle.mockImplementation(async () => {
-      fetchCount += 1;
-      if (fetchCount === 1) return { data: null, error: null };
-      return {
-        data: {
+    // The RPC now returns the team_member row directly — no re-fetch needed.
+    mockRpc.mockResolvedValueOnce({
+      data: {
+        team_member: {
           id: "user-new-3",
           organization_id: "org-new-3",
           name: "Brand New Owner",
@@ -331,9 +327,11 @@ describe("AuthContext bootstrap integration", () => {
           role: "Owner",
           location_ids: [],
           permissions: {},
+          pin_reset_required: true,
         },
-        error: null,
-      };
+        existed: false,
+      },
+      error: null,
     });
 
     const { result } = renderHook(() => useAuth(), { wrapper: makeWrapper() });
@@ -356,9 +354,10 @@ describe("AuthContext bootstrap integration", () => {
     expect(result.current.setupError).toBeNull();
   });
 
-  it("sets setupError when team_member row is missing after setup_new_organization succeeds", async () => {
-    // Both single() calls return null — RPC ran but row is not visible yet (RLS race)
-    mockTeamMemberSingle.mockResolvedValue({ data: null, error: { message: "no rows" } });
+  it("sets setupError when setup_new_organization returns no team_member data", async () => {
+    // RPC succeeded but returned no team_member key (should not happen in practice,
+    // but guards against a future schema mismatch).
+    mockRpc.mockResolvedValueOnce({ data: {}, error: null });
 
     const { result } = renderHook(() => useAuth(), { wrapper: makeWrapper() });
     await waitFor(() => expect(result.current.loading).toBe(false));

--- a/supabase/migrations/20260508000001_setup_org_return_team_member.sql
+++ b/supabase/migrations/20260508000001_setup_org_return_team_member.sql
@@ -1,0 +1,141 @@
+-- ================================================================
+-- Return the full team_member row from setup_new_organization so the
+-- client never needs a second SELECT after setup. This eliminates the
+-- RLS re-fetch failure that caused setupError on new signups:
+--
+--   setup_new_organization runs as SECURITY DEFINER → can read/write
+--   team_members without RLS.  The subsequent re-fetch in AuthContext
+--   went through RLS which calls current_org_id() → requires a stable
+--   search_path.  When that path was wrong the re-fetch returned NULL
+--   and the user was bounced back to the signup page even though their
+--   org had been created successfully.
+--
+-- New return shape (both branches):
+--   { team_member: { id, organization_id, name, email, role,
+--                    location_ids, permissions, pin_reset_required },
+--     existed: true|false }
+-- ================================================================
+
+CREATE OR REPLACE FUNCTION public.setup_new_organization(
+  p_business_name TEXT,
+  p_location_name TEXT DEFAULT NULL,
+  p_owner_name    TEXT DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id              uuid := auth.uid();
+  v_user_email           text;
+  v_owner_name           text;
+  v_org_id               uuid;
+  v_conflicting_owner_id uuid;
+  v_tm                   jsonb;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(1, hashtext(v_user_id::text));
+
+  -- Returning user: row already exists — return it directly (SECURITY DEFINER
+  -- bypasses RLS so this always works regardless of search_path state).
+  IF EXISTS (SELECT 1 FROM team_members WHERE id = v_user_id) THEN
+    SELECT jsonb_build_object(
+      'id',                  tm.id,
+      'organization_id',     tm.organization_id,
+      'name',                tm.name,
+      'email',               tm.email,
+      'role',                tm.role,
+      'location_ids',        tm.location_ids,
+      'permissions',         tm.permissions,
+      'pin_reset_required',  tm.pin_reset_required
+    )
+    INTO v_tm
+    FROM team_members tm
+    WHERE tm.id = v_user_id;
+
+    RETURN jsonb_build_object('team_member', v_tm, 'existed', true);
+  END IF;
+
+  -- New user: resolve name + email from auth.users
+  SELECT
+    email,
+    COALESCE(raw_user_meta_data->>'full_name', split_part(email, '@', 1))
+  INTO v_user_email, v_owner_name
+  FROM auth.users
+  WHERE id = v_user_id;
+
+  IF p_owner_name IS NOT NULL AND trim(p_owner_name) != '' THEN
+    v_owner_name := trim(p_owner_name);
+  END IF;
+
+  -- Guard: another Owner row already exists with this email
+  SELECT tm.id
+  INTO v_conflicting_owner_id
+  FROM public.team_members tm
+  WHERE lower(trim(tm.email)) = lower(trim(v_user_email))
+    AND lower(tm.role) = 'owner'
+    AND tm.archived_at IS NULL
+    AND tm.id <> v_user_id
+  LIMIT 1;
+
+  IF v_conflicting_owner_id IS NOT NULL THEN
+    RAISE EXCEPTION
+      'An owner account with email % already exists. Please contact support so we can safely verify your organization access.',
+      v_user_email;
+  END IF;
+
+  -- Create org
+  INSERT INTO organizations (name, plan, plan_status)
+  VALUES (trim(p_business_name), 'starter', 'active')
+  RETURNING id INTO v_org_id;
+
+  -- Create team_member and capture its data in one step
+  INSERT INTO team_members (
+    id, organization_id, name, email, role,
+    location_ids, permissions, pin, pin_reset_required
+  ) VALUES (
+    v_user_id,
+    v_org_id,
+    v_owner_name,
+    v_user_email,
+    'Owner',
+    ARRAY[]::uuid[],
+    '{
+      "create_edit_checklists": true,
+      "assign_checklists": true,
+      "manage_staff_profiles": true,
+      "view_reporting": true,
+      "edit_location_details": true,
+      "manage_alerts": true,
+      "export_data": true,
+      "override_inactivity_threshold": true
+    }'::jsonb,
+    crypt('1234', gen_salt('bf', 12)),
+    true
+  );
+
+  -- Re-read the just-inserted row (SECURITY DEFINER — no RLS involved)
+  SELECT jsonb_build_object(
+    'id',                  tm.id,
+    'organization_id',     tm.organization_id,
+    'name',                tm.name,
+    'email',               tm.email,
+    'role',                tm.role,
+    'location_ids',        tm.location_ids,
+    'permissions',         tm.permissions,
+    'pin_reset_required',  tm.pin_reset_required
+  )
+  INTO v_tm
+  FROM team_members tm
+  WHERE tm.id = v_user_id;
+
+  RETURN jsonb_build_object('team_member', v_tm, 'existed', false);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.setup_new_organization(TEXT, TEXT, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.setup_new_organization(TEXT, TEXT, TEXT) TO authenticated;


### PR DESCRIPTION
## Summary
- **Root cause of accounts not being created:** after `setup_new_organization` inserted the new `team_member` row, `fetchTeamMember` did a second `SELECT` through RLS. That RLS policy calls `current_org_id()` which resolves `team_members` by search_path — returning `NULL` on Supabase connection pools with an empty `search_path`, silently blocking the row and triggering `setupError`
- **Fix:** `setup_new_organization` (a `SECURITY DEFINER` function — immune to search_path issues) now returns the full `team_member` row directly in its JSONB response. `AuthContext.fetchTeamMember` uses that data; no second `SELECT` needed
- Adds migration `20260508000001_setup_org_return_team_member.sql`
- Tests updated to mock the new RPC return shape

## Test plan
- [ ] Apply the migration to the Supabase project
- [ ] Sign up with a new email → verify OTP → land on Admin with "Add your first location" prompt (no redirect back to signup)
- [ ] Sign in with an existing account → normal Admin page loads
- [ ] All 1232 passing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)