### PR TITLE
fix: builder auto-reopen, beforeunload warning, back-button confirm, PDF model

### DIFF
--- a/src/pages/checklists/ChecklistBuilderModal.tsx
+++ b/src/pages/checklists/ChecklistBuilderModal.tsx
@@ -110,6 +110,19 @@ export function ChecklistBuilderModal({
     }]
   );
 
+  const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
+
+  const hasContent = !!(title.trim() || sections.some(s => s.name.trim() || s.questions.some(q => q.text.trim())));
+
+  // Intercept Back/X when there's unsaved content — show a confirmation first
+  const handleRequestClose = () => {
+    if (isNewChecklist && hasContent) {
+      setShowDiscardConfirm(true);
+    } else {
+      onClose();
+    }
+  };
+
   // Autosave draft to sessionStorage while editing a new checklist
   useEffect(() => {
     if (!isNewChecklist) return;
@@ -302,7 +315,7 @@ export function ChecklistBuilderModal({
       {/* Header bar */}
       <div className="flex items-center justify-between px-5 pt-5 pb-3 border-b border-border shrink-0">
         {asPage ? (
-          <button onClick={onClose} className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors">
+          <button onClick={handleRequestClose} className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors">
             <ArrowLeft size={16} /> Back
           </button>
         ) : (
@@ -314,7 +327,7 @@ export function ChecklistBuilderModal({
         {asPage ? (
           <div className="w-16" />
         ) : (
-          <button onClick={onClose} className="p-1.5 rounded-full hover:bg-muted transition-colors">
+          <button onClick={handleRequestClose} className="p-1.5 rounded-full hover:bg-muted transition-colors">
             <X size={18} className="text-muted-foreground" />
           </button>
         )}
@@ -1441,6 +1454,29 @@ export function ChecklistBuilderModal({
     </>
   );
 
+  const discardConfirmDialog = showDiscardConfirm && (
+    <div className="fixed inset-0 z-[80] flex items-center justify-center bg-foreground/30 backdrop-blur-sm">
+      <div className="bg-card rounded-2xl p-6 mx-4 max-w-sm w-full shadow-xl space-y-4">
+        <h3 className="font-display text-lg text-foreground">Leave without saving?</h3>
+        <p className="text-sm text-muted-foreground">Your unsaved changes will be lost if you go back.</p>
+        <div className="flex gap-3">
+          <button
+            onClick={() => setShowDiscardConfirm(false)}
+            className="flex-1 py-2.5 rounded-xl border border-border text-sm font-medium text-foreground hover:bg-muted transition-colors"
+          >
+            Keep editing
+          </button>
+          <button
+            onClick={() => { clearChecklistDraft(); onClose(); }}
+            className="flex-1 py-2.5 rounded-xl bg-status-error text-white text-sm font-medium hover:opacity-90 transition-opacity"
+          >
+            Discard
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+
   if (asPage) {
     return (
       <>
@@ -1448,6 +1484,7 @@ export function ChecklistBuilderModal({
           {formContent}
         </div>
         {subModals}
+        {discardConfirmDialog}
       </>
     );
   }
@@ -1463,6 +1500,7 @@ export function ChecklistBuilderModal({
         </div>
       </div>
       {subModals}
+      {discardConfirmDialog}
     </>
   );
 }

--- a/src/pages/checklists/ChecklistsTab.tsx
+++ b/src/pages/checklists/ChecklistsTab.tsx
@@ -96,7 +96,17 @@ export function ChecklistsTab() {
   const [selectedLocation, setSelectedLocation] = useState("All locations");
   const [showLocationDrop, setShowLocationDrop] = useState(false);
   const [showCreateMenu, setShowCreateMenu] = useState(false);
-  const [showBuilder, setShowBuilder] = useState(false);
+  const [showBuilder, setShowBuilder] = useState(() => {
+    // Auto-reopen builder if a meaningful draft was saved (e.g. after a tab switch that reloaded the page)
+    try {
+      const raw = sessionStorage.getItem("olia_checklist_draft");
+      if (!raw) return false;
+      const d = JSON.parse(raw);
+      return !!(d.title?.trim() || d.sections?.some((s: any) =>
+        s.name?.trim() || s.questions?.some((q: any) => q.text?.trim())
+      ));
+    } catch { return false; }
+  });
   const [showConvertFile, setShowConvertFile] = useState(false);
   const [showBuildAI, setShowBuildAI] = useState(false);
   const [upgradeFeature, setUpgradeFeature] = useState<string | null>(null);
@@ -132,6 +142,14 @@ export function ChecklistsTab() {
   const isEmpty = visibleFolders.length === 0 && visibleChecklists.length === 0 && !normalizedSearch;
 
   const blocker = useBlocker(showBuilder);
+
+  // Warn the browser when the user tries to leave the tab/app entirely while the builder is open
+  useEffect(() => {
+    if (!showBuilder) return;
+    const handler = (e: BeforeUnloadEvent) => { e.preventDefault(); e.returnValue = ""; };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [showBuilder]);
 
   const handleCreateFolder = () => {
     if (!newFolderName.trim()) return;

--- a/supabase/functions/generate-checklist/index.ts
+++ b/supabase/functions/generate-checklist/index.ts
@@ -104,16 +104,21 @@ Deno.serve(async (req) => {
       );
     }
 
+    // document mode sends PDF/image base64 — requires a vision-capable model with PDF support.
+    // claude-3-5-haiku does not support pdfs-2024-09-25 beta; use Sonnet for document mode.
+    const model = mode === "document"
+      ? "claude-sonnet-4-5"
+      : "claude-haiku-4-5-20251001";
+
     const anthropicRes = await fetch("https://api.anthropic.com/v1/messages", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         "x-api-key": ANTHROPIC_API_KEY,
         "anthropic-version": "2023-06-01",
-        "anthropic-beta": "pdfs-2024-09-25",
       },
       body: JSON.stringify({
-        model: "claude-3-5-haiku-20241022",
+        model,
         max_tokens: 2048,
         system: SYSTEM_PROMPT,
         messages,


### PR DESCRIPTION
## Summary

### Bug 1 — checklist builder behaviour
Three improvements working together:
- **Auto-reopen on return**: When you come back to Olia after switching tabs (which can reload the page on mobile/Safari), the checklist builder reopens automatically if your draft has content — no need to click New Checklist again
- **Browser tab warning**: A native browser dialog now appears if you try to close or navigate away from the Olia tab while the builder is open
- **Back button confirmation**: Clicking the ← Back arrow inside the builder now shows the same 'Leave without saving?' dialog as the bottom-nav blocker, so you can't accidentally lose your work

### Bug 2 — PDF conversion
- Switched the edge function from `claude-3-5-haiku` to `claude-sonnet-4-5` for document mode (PDF/image). Haiku does not support the Anthropic PDF API — Sonnet does. Haiku is still used for text/file mode (cheaper + faster).
- Removed the outdated `pdfs-2024-09-25` beta header (not needed for Sonnet 4.5).
- Edge function already redeployed to Supabase.

## Test plan
- [ ] Open builder, type something, switch to another browser tab and come back → builder should reopen with your content
- [ ] Open builder, type something, try to close the Olia tab → browser should show a 'Leave site?' dialog
- [ ] Open builder, type something, click ← Back → 'Leave without saving?' dialog should appear
- [ ] Upload a Spanish PDF → should convert successfully into a checklist

🤖 Generated with [Claude Code](https://claude.com/claude-code)