### PR TITLE
fix: correct Sonnet model ID for PDF conversion

### DIFF
--- a/supabase/functions/generate-checklist/index.ts
+++ b/supabase/functions/generate-checklist/index.ts
@@ -104,11 +104,8 @@ Deno.serve(async (req) => {
       );
     }
 
-    // document mode sends PDF/image base64 — requires a vision-capable model with PDF support.
-    // claude-3-5-haiku does not support pdfs-2024-09-25 beta; use Sonnet for document mode.
-    const model = mode === "document"
-      ? "claude-sonnet-4-5"
-      : "claude-haiku-4-5-20251001";
+    // Sonnet 4.6 supports vision + documents; Haiku 4.5 for cheaper text-only mode
+    const model = mode === "document" ? "claude-sonnet-4-6" : "claude-haiku-4-5-20251001";
 
     const anthropicRes = await fetch("https://api.anthropic.com/v1/messages", {
       method: "POST",


### PR DESCRIPTION
## Summary
Previous edge function deploy used model ID `claude-sonnet-4-5` which does not exist in the Anthropic API, causing a 500 Internal Server Error. Fixed to `claude-sonnet-4-6` (the correct current Sonnet model ID). Edge function already redeployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)