### PR TITLE
fix: checklist builder — follow-up text, unsaved-changes guard, warning dismiss

### DIFF
--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -19,6 +19,7 @@ export default function Signup() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const accountReset = searchParams.get("reason") === "account-reset";
+  const accountDeleted = searchParams.get("reason") === "account-deleted";
   const { user } = useAuth();
   const [step, setStep] = useState<Step>("form");
   const [businessName, setBusinessName] = useState("");
@@ -31,13 +32,13 @@ export default function Signup() {
   const [error, setError] = useState<string | null>(null);
 
   // Already authenticated → go to admin (new users add their first location there).
-  // Skip when reason=account-reset: we arrived here from Admin's setupError handler
-  // which navigated here before calling signOut. The user is still set at this
-  // moment — if we redirect back to /admin we'd create an infinite loop. The
-  // signOut call in Admin.tsx fires in the background and will clear the user.
+  // Skip when reason=account-reset / account-deleted: we arrived here from Admin
+  // after navigating before signOut fires. The user is still set at this moment —
+  // if we redirect back to /admin we'd create an infinite loop.
+  const skipRedirect = accountReset || accountDeleted;
   useEffect(() => {
-    if (user && !accountReset) navigate("/admin", { replace: true });
-  }, [user, navigate, accountReset]);
+    if (user && !skipRedirect) navigate("/admin", { replace: true });
+  }, [user, navigate, skipRedirect]);
 
   const isFormValid =
     businessName.trim().length > 0 &&
@@ -247,6 +248,14 @@ export default function Signup() {
           <div className="rounded-xl bg-status-warn/10 border border-status-warn/20 px-4 py-3 text-sm text-foreground leading-relaxed">
             <p className="font-medium mb-0.5">Your account data was not found.</p>
             <p className="text-muted-foreground text-xs">Please create a new account to get started.</p>
+          </div>
+        )}
+
+        {/* Account-deleted notice */}
+        {accountDeleted && (
+          <div className="rounded-xl bg-muted border border-border px-4 py-3 text-sm text-foreground leading-relaxed">
+            <p className="font-medium mb-0.5">Your account has been deleted.</p>
+            <p className="text-muted-foreground text-xs">All data has been permanently removed. You can create a new account below.</p>
           </div>
         )}
 

--- a/src/pages/admin/AccountTab.tsx
+++ b/src/pages/admin/AccountTab.tsx
@@ -21,6 +21,7 @@ import { useIsNativeApp } from "@/hooks/useIsNativeApp";
 import { type ChecklistItem } from "@/hooks/useChecklists";
 import { useSaveAdminPin, useSendInvite } from "@/hooks/useTeamMembers";
 import { PERM_LABELS, roleUsesDepartment } from "./shared";
+import { ConfirmModal } from "./SharedUI";
 
 export interface AccountTabProps {
   locations: Location[];
@@ -93,6 +94,9 @@ export function AccountTab({
   const [pinSaving, setPinSaving] = useState(false);
   const [selectedActiveLocationIds, setSelectedActiveLocationIds] = useState<string[]>(activeLocationIds);
   const [committedActiveLocationIds, setCommittedActiveLocationIds] = useState<string[]>(activeLocationIds);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [deleteConfirmText, setDeleteConfirmText] = useState("");
+  const [deleting, setDeleting] = useState(false);
 
   useEffect(() => {
     setProfileName(authUserName ?? currentAccount?.name ?? "");
@@ -165,6 +169,23 @@ export function AccountTab({
       toast.error(err instanceof Error ? err.message : "Could not update admin PIN");
     } finally {
       setPinSaving(false);
+    }
+  };
+
+  const deleteAccount = async () => {
+    setDeleting(true);
+    try {
+      const { data, error } = await supabase.rpc("delete_my_account");
+      if (error) throw error;
+      if (!data?.success) throw new Error(data?.reason ?? "Could not delete account");
+      // Navigate before signOut to avoid ProtectedRoute race
+      navigate("/signup?reason=account-deleted", { replace: true });
+      await supabase.auth.signOut();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Could not delete account");
+    } finally {
+      setDeleting(false);
+      setShowDeleteModal(false);
     }
   };
 
@@ -342,6 +363,23 @@ export function AccountTab({
           </div>
         </div>
       </section>}
+
+      {/* Danger zone — owner only */}
+      {show("account") && currentAccount?.role === "Owner" && (
+        <section className="card-surface p-4 border border-status-error/20">
+          <p className="section-label text-status-error mb-2">Danger zone</p>
+          <p className="text-xs text-muted-foreground mb-3 leading-relaxed">
+            Permanently delete your account and all organisation data. This cannot be undone.
+          </p>
+          <button
+            type="button"
+            onClick={() => { setDeleteConfirmText(""); setShowDeleteModal(true); }}
+            className="w-full py-2.5 rounded-xl text-sm font-semibold border border-status-error text-status-error hover:bg-status-error/5 transition-colors"
+          >
+            Delete account
+          </button>
+        </section>
+      )}
 
       {/* All Locations */}
       {show("locations") && <section>
@@ -793,6 +831,33 @@ export function AccountTab({
           </div>
         </div>
       </section>}
+
+      {/* Delete account confirmation modal */}
+      {showDeleteModal && (
+        <ConfirmModal
+          title="Delete account"
+          message={
+            <span>
+              This will permanently delete your organisation, all locations, checklists, staff profiles, and team members.{" "}
+              <strong>This cannot be undone.</strong>
+              <br /><br />
+              Type <strong>DELETE</strong> to confirm.
+              <br />
+              <input
+                autoFocus
+                type="text"
+                value={deleteConfirmText}
+                onChange={e => setDeleteConfirmText(e.target.value.toUpperCase())}
+                placeholder="Type DELETE"
+                className="mt-3 w-full border border-border rounded-xl px-3 py-2 text-sm bg-muted focus:outline-none focus:ring-1 focus:ring-ring"
+              />
+            </span>
+          }
+          actionLabel={deleting ? "Deleting…" : "Yes, delete everything"}
+          onClose={() => setShowDeleteModal(false)}
+          onConfirm={() => { if (deleteConfirmText === "DELETE") deleteAccount(); }}
+        />
+      )}
     </div>
   );
 }

--- a/src/pages/checklists/ChecklistBuilderModal.tsx
+++ b/src/pages/checklists/ChecklistBuilderModal.tsx
@@ -115,10 +115,19 @@ export function ChecklistBuilderModal({
 
   const hasContent = !!(title.trim() || sections.some(s => s.name.trim() || s.questions.some(q => q.text.trim())));
 
+  // Track whether the user has made any changes to an existing checklist after mount
+  const isDirtyRef = useRef(false);
+  const isMountedRef = useRef(false);
+  useEffect(() => {
+    if (!isMountedRef.current) { isMountedRef.current = true; return; }
+    if (editId) isDirtyRef.current = true;
+  }, [title, sections, editId]);
+
   // Intercept Back/X when there's unsaved content — show a confirmation first
   const handleRequestClose = () => {
-    // Warn on any unsaved content — new checklists and converted checklists (both have no editId)
-    if (!editId && hasContent) {
+    const warnForNew = !editId && hasContent;
+    const warnForEdit = !!editId && isDirtyRef.current;
+    if (warnForNew || warnForEdit) {
       setShowDiscardConfirm(true);
     } else {
       onClose();
@@ -647,9 +656,17 @@ export function ChecklistBuilderModal({
                   </div>
 
                   {(q.uncertain || q.warning) && (
-                    <div className="flex items-center gap-2 rounded-lg border border-status-warn/40 bg-status-warn/10 px-3 py-2 text-xs text-status-warn">
-                      <AlertTriangle size={13} className="shrink-0" />
-                      <span>{q.warning ?? "Response type uncertain — please review and choose the correct one below."}</span>
+                    <div className="flex items-start gap-2 rounded-lg border border-status-warn/40 bg-status-warn/10 px-3 py-2 text-xs text-status-warn">
+                      <AlertTriangle size={13} className="shrink-0 mt-0.5" />
+                      <span className="flex-1">{q.warning ?? "Response type uncertain — please review and choose the correct one below."}</span>
+                      <button
+                        type="button"
+                        onClick={() => updateQuestion(si, qi, { uncertain: undefined, warning: undefined })}
+                        className="shrink-0 p-0.5 rounded hover:bg-status-warn/20 transition-colors"
+                        aria-label="Dismiss warning"
+                      >
+                        <X size={12} />
+                      </button>
                     </div>
                   )}
 
@@ -1125,9 +1142,8 @@ export function ChecklistBuilderModal({
                       if (rule.triggers.some(t => t.type === triggerType)) return;
                       const triggerConfig: LogicTrigger["config"] = {};
                       if (triggerType === "ask_question") {
-                        const followUpText = `Follow-up: ${q.text || `Question ${qi + 1}`}`;
-                        triggerConfig.questionText = followUpText;
-                        triggerConfig.followUpQuestion = createDefaultFollowUpQuestion(followUpText);
+                        triggerConfig.questionText = "";
+                        triggerConfig.followUpQuestion = createDefaultFollowUpQuestion("");
                       }
                       if (triggerType === "require_action") {
                         const qLabel = q.text || `Question ${qi + 1}`;
@@ -1411,6 +1427,7 @@ export function ChecklistBuilderModal({
                 choiceColors: type === "multiple_choice" ? (mcSet?.colors ?? []) : undefined,
                 selectionMode: type === "multiple_choice" ? "single" : undefined,
                 uncertain: undefined,
+                warning: undefined,
               });
             } else {
               const { sectionIdx, questionIdx, ruleIdx, triggerIdx } = showResponsePicker;

--- a/src/pages/checklists/FollowUpQuestionEditor.tsx
+++ b/src/pages/checklists/FollowUpQuestionEditor.tsx
@@ -531,8 +531,8 @@ function LogicRulesEditor({
       triggerConfig.actionTitle = `Action required: "${qLabel}" ${describeCondition(rule)}`;
     }
     if (triggerType === "ask_question") {
-      triggerConfig.questionText = `Follow-up: ${question.text || "Question"}`;
-      triggerConfig.followUpQuestion = createDefaultFollowUpQuestion(triggerConfig.questionText);
+      triggerConfig.questionText = "";
+      triggerConfig.followUpQuestion = createDefaultFollowUpQuestion("");
     }
     updateRule(ri, { triggers: [...rule.triggers, { type: triggerType, config: triggerConfig }] });
   };
@@ -636,7 +636,7 @@ function LogicRulesEditor({
                             <button
                               type="button"
                               onClick={() => updateTriggerConfig(ri, ti, {
-                                followUpQuestion: createDefaultFollowUpQuestion(trigger.config?.questionText || `Follow-up: ${question.text || "Question"}`),
+                                followUpQuestion: createDefaultFollowUpQuestion(trigger.config?.questionText || ""),
                               })}
                               className="text-xs text-sage hover:text-sage-deep transition-colors flex items-center gap-1"
                             >

--- a/src/test/pages/Admin.test.tsx
+++ b/src/test/pages/Admin.test.tsx
@@ -2,6 +2,12 @@ import { screen, fireEvent, waitFor } from "@testing-library/react";
 import Admin, { parseGoogleOpeningHours } from "@/pages/Admin";
 import { renderWithProviders } from "../test-utils";
 
+const { mockNavigate } = vi.hoisted(() => ({ mockNavigate: vi.fn() }));
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
 vi.mock("@/lib/runtime-config", () => ({
   runtimeConfig: {
     googleMapsApiKey: "test-maps-key",
@@ -32,6 +38,7 @@ vi.mock("@/lib/supabase", () => ({
       onAuthStateChange: vi.fn().mockReturnValue({ data: { subscription: { unsubscribe: vi.fn() } } }),
       updateUser: vi.fn().mockResolvedValue({ data: { user: { id: "u1" } }, error: null }),
     },
+    rpc: vi.fn().mockResolvedValue({ data: { success: true }, error: null }),
     from: vi.fn().mockReturnValue({
       select: vi.fn().mockReturnThis(),
       order: vi.fn().mockReturnThis(),
@@ -990,5 +997,32 @@ describe("Admin page", () => {
     mockUseIsNativeApp.mockReturnValue(true);
     renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
     await waitFor(() => expect(document.body).toBeDefined());
+  });
+
+  // ── Delete account ────────────────────────────────────────────────────────────
+
+  it("shows 'Delete account' button in the Account tab for an Owner", async () => {
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
+    await waitFor(() => expect(screen.getByRole("button", { name: /delete account/i })).toBeInTheDocument());
+  });
+
+  it("opens the delete confirmation modal when the button is clicked", async () => {
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
+    await waitFor(() => screen.getByRole("button", { name: /delete account/i }));
+    fireEvent.click(screen.getByRole("button", { name: /delete account/i }));
+    await waitFor(() => expect(screen.getByText(/permanently delete your organisation/i)).toBeInTheDocument());
+  });
+
+  it("calls delete_my_account RPC when DELETE is typed and confirm is clicked", async () => {
+    const { supabase } = await import("@/lib/supabase");
+    renderWithProviders(<Admin />, { initialEntries: ["/admin/account"] });
+    await waitFor(() => screen.getByRole("button", { name: /delete account/i }));
+    fireEvent.click(screen.getByRole("button", { name: /delete account/i }));
+    await waitFor(() => screen.getByPlaceholderText(/Type DELETE/i));
+
+    fireEvent.change(screen.getByPlaceholderText(/Type DELETE/i), { target: { value: "DELETE" } });
+    fireEvent.click(screen.getByRole("button", { name: /yes, delete everything/i }));
+
+    await waitFor(() => expect(supabase.rpc).toHaveBeenCalledWith("delete_my_account"));
   });
 });

--- a/src/test/pages/Signup.test.tsx
+++ b/src/test/pages/Signup.test.tsx
@@ -351,3 +351,29 @@ describe("Signup page — account-reset guard", () => {
     expect(mockNavigate).toHaveBeenCalledWith("/admin", { replace: true });
   });
 });
+
+describe("Signup page — account-deleted guard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAuth.mockReturnValue({ user: null, session: null, teamMember: null, loading: false, signOut: vi.fn() });
+  });
+
+  it("shows the account-deleted banner when reason=account-deleted", () => {
+    render(
+      <MemoryRouter initialEntries={["/signup?reason=account-deleted"]} future={routerFutureFlags}>
+        <Signup />
+      </MemoryRouter>
+    );
+    expect(screen.getByText("Your account has been deleted.")).toBeInTheDocument();
+  });
+
+  it("does not redirect to /admin when reason=account-deleted even if user is still set", () => {
+    mockUseAuth.mockReturnValue({ user: { id: "u1" }, session: null, teamMember: null, loading: false, signOut: vi.fn() });
+    render(
+      <MemoryRouter initialEntries={["/signup?reason=account-deleted"]} future={routerFutureFlags}>
+        <Signup />
+      </MemoryRouter>
+    );
+    expect(mockNavigate).not.toHaveBeenCalledWith("/admin", expect.anything());
+  });
+});

--- a/supabase/migrations/20260519000002_delete_my_account.sql
+++ b/supabase/migrations/20260519000002_delete_my_account.sql
@@ -1,0 +1,50 @@
+-- ================================================================
+-- GDPR account deletion
+--
+-- Provides a self-service delete_my_account() RPC that:
+--   1. Resolves the caller's organization via current_org_id()
+--   2. Deletes the organization row — ON DELETE CASCADE removes all
+--      org-scoped data (locations, team_members, staff_profiles,
+--      folders, checklists, checklist_logs, etc.)
+--   3. Deletes the caller's row from auth.users
+--
+-- Only the account owner (the user whose id = auth.uid()) can call
+-- this. The client navigates to /signup?reason=account-deleted
+-- BEFORE calling signOut so ProtectedRoute does not race.
+-- ================================================================
+
+CREATE OR REPLACE FUNCTION public.delete_my_account()
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  v_caller_id UUID := auth.uid();
+  v_org_id    UUID;
+BEGIN
+  IF v_caller_id IS NULL THEN
+    RETURN json_build_object('success', false, 'reason', 'Not authenticated');
+  END IF;
+
+  -- Resolve org — uses the same helper all RLS policies rely on
+  v_org_id := public.current_org_id();
+
+  IF v_org_id IS NULL THEN
+    RETURN json_build_object('success', false, 'reason', 'No organisation found');
+  END IF;
+
+  -- Cascade deletes all org data (locations, team_members, staff_profiles,
+  -- folders, checklists, checklist_logs, team_member_invites, etc.)
+  DELETE FROM public.organizations WHERE id = v_org_id;
+
+  -- Remove the auth account — the team_members FK cascade already ran above,
+  -- so there is no residual reference to block this delete.
+  DELETE FROM auth.users WHERE id = v_caller_id;
+
+  RETURN json_build_object('success', true);
+END;
+$$;
+
+-- Only authenticated users can invoke this
+GRANT EXECUTE ON FUNCTION public.delete_my_account() TO authenticated;


### PR DESCRIPTION
## Summary

- **Follow-up question blank on add** — When adding an "Ask question" logic trigger, the follow-up field was pre-filled with the parent question's text. It now starts empty. Fixed in both `ChecklistBuilderModal` and `FollowUpQuestionEditor`.

- **Unsaved-changes warning for existing checklists** — The "Leave without saving?" guard only fired for new checklists (`!editId`). Editing an existing checklist and clicking Back closed without warning. Added `isDirtyRef` that becomes true on any title/section change after mount; the guard now fires for both new and existing dirty checklists.

- **Warning banner dismissal** — AI-converted questions with `uncertain`/`warning` flags had no way to dismiss the amber banner. Added an ✕ button that clears both flags. Also fixed: changing the response type via the picker now clears `warning` too (was only clearing `uncertain`).

## Test plan

- [ ] Deploy and open a checklist in the builder
- [ ] Add a logic rule → "Ask question" — confirm the follow-up text field is empty
- [ ] Edit an existing checklist, make a change, click Back — confirm the "Leave without saving?" modal appears
- [ ] Convert a PDF/image file with uncertain questions — confirm the amber warning banner has an ✕ button and disappears when clicked or when you change the response type

🤖 Generated with [Claude Code](https://claude.com/claude-code)