### PR TITLE
fix: allow null staff_profile_id in submit_kiosk_log

### DIFF
--- a/supabase/migrations/20260520000001_fix_pin_search_path.sql
+++ b/supabase/migrations/20260520000001_fix_pin_search_path.sql
@@ -1,0 +1,249 @@
+-- ================================================================
+-- Fix: add `extensions` to search_path for PIN validation functions.
+--
+-- Problem:
+--   validate_admin_pin, validate_staff_pin, and set_admin_pin were
+--   defined with SET search_path = public only.  pgcrypto (crypt,
+--   gen_salt, digest) lives in the `extensions` schema on this
+--   Supabase project, so any call to these functions threw
+--   "function crypt(text,text) does not exist", which surfaced as
+--   "Connection error. Check your network and try again." at the kiosk.
+--
+--   setup_new_organization (20260508000001) was already correctly
+--   written with SET search_path = public, extensions — this migration
+--   brings the remaining PIN functions into line with that pattern.
+-- ================================================================
+
+-- ── 1. validate_admin_pin ─────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.validate_admin_pin(p_pin text, p_location_id uuid)
+RETURNS TABLE (
+  id              uuid,
+  organization_id uuid,
+  name            text,
+  email           text,
+  role            text,
+  location_ids    uuid[],
+  permissions     jsonb
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  v_recent_failures INT;
+  v_matched         BOOLEAN := false;
+  v_row             RECORD;
+BEGIN
+  -- Clean up stale attempts (> 1 hour) for this location
+  DELETE FROM pin_attempts
+  WHERE location_id = p_location_id
+    AND attempted_at < now() - INTERVAL '1 hour';
+
+  -- Count failed attempts in the last 5 minutes
+  SELECT COUNT(*) INTO v_recent_failures
+  FROM pin_attempts
+  WHERE location_id = p_location_id
+    AND pin_type    = 'admin'
+    AND succeeded   = false
+    AND attempted_at > now() - INTERVAL '5 minutes';
+
+  IF v_recent_failures >= 10 THEN
+    RAISE EXCEPTION 'Too many PIN attempts. Please wait before trying again.'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  IF auth.role() = 'authenticated' THEN
+    SELECT
+      tm.id,
+      tm.organization_id,
+      tm.name,
+      tm.email,
+      tm.role,
+      tm.location_ids,
+      tm.permissions
+    INTO v_row
+    FROM public.locations target
+    JOIN public.team_members tm
+      ON tm.organization_id = target.organization_id
+   WHERE target.id = p_location_id
+     AND target.organization_id = public.current_org_id()
+     AND tm.pin IS NOT NULL
+     AND crypt(p_pin, tm.pin) = tm.pin
+     AND (
+       tm.role = 'Owner'
+       OR p_location_id = ANY(COALESCE(tm.location_ids, ARRAY[]::uuid[]))
+     )
+   ORDER BY (tm.role = 'Owner') DESC, tm.created_at ASC
+   LIMIT 1;
+  ELSE
+    SELECT
+      tm.id,
+      tm.organization_id,
+      tm.name,
+      tm.email,
+      tm.role,
+      tm.location_ids,
+      tm.permissions
+    INTO v_row
+    FROM public.locations target
+    JOIN public.team_members tm
+      ON tm.organization_id = target.organization_id
+   WHERE target.id = p_location_id
+     AND tm.pin IS NOT NULL
+     AND crypt(p_pin, tm.pin) = tm.pin
+     AND (
+       tm.role = 'Owner'
+       OR p_location_id = ANY(COALESCE(tm.location_ids, ARRAY[]::uuid[]))
+     )
+   ORDER BY (tm.role = 'Owner') DESC, tm.created_at ASC
+   LIMIT 1;
+  END IF;
+
+  v_matched := (v_row IS NOT NULL AND v_row.id IS NOT NULL);
+
+  INSERT INTO pin_attempts (location_id, pin_type, succeeded)
+  VALUES (p_location_id, 'admin', v_matched);
+
+  IF v_matched THEN
+    RETURN QUERY
+      SELECT
+        v_row.id,
+        v_row.organization_id,
+        v_row.name,
+        v_row.email,
+        v_row.role,
+        v_row.location_ids,
+        v_row.permissions;
+  END IF;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.validate_admin_pin(text, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.validate_admin_pin(text, uuid) TO anon, authenticated;
+
+-- ── 2. validate_staff_pin ─────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.validate_staff_pin(p_pin text, p_location_id uuid)
+RETURNS TABLE (
+  id              uuid,
+  first_name      text,
+  last_name       text,
+  role            text,
+  organization_id uuid
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  v_recent_failures INT;
+  v_matched         BOOLEAN := false;
+  v_row             RECORD;
+BEGIN
+  DELETE FROM pin_attempts
+  WHERE location_id = p_location_id
+    AND attempted_at < now() - INTERVAL '1 hour';
+
+  SELECT COUNT(*) INTO v_recent_failures
+  FROM pin_attempts
+  WHERE location_id = p_location_id
+    AND pin_type    = 'staff'
+    AND succeeded   = false
+    AND attempted_at > now() - INTERVAL '5 minutes';
+
+  IF v_recent_failures >= 10 THEN
+    RAISE EXCEPTION 'Too many PIN attempts. Please wait before trying again.'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT
+    sp.id,
+    sp.first_name,
+    sp.last_name,
+    sp.role,
+    sp.organization_id
+  INTO v_row
+  FROM public.staff_profiles sp
+  WHERE sp.pin = encode(digest(p_pin, 'sha256'), 'hex')
+    AND (sp.location_id = p_location_id OR sp.location_id IS NULL)
+    AND sp.status = 'active'
+  ORDER BY
+    CASE WHEN sp.location_id = p_location_id THEN 0 ELSE 1 END
+  LIMIT 1;
+
+  v_matched := (v_row IS NOT NULL AND v_row.id IS NOT NULL);
+
+  INSERT INTO pin_attempts (location_id, pin_type, succeeded)
+  VALUES (p_location_id, 'staff', v_matched);
+
+  IF v_matched THEN
+    RETURN QUERY
+      SELECT
+        v_row.id,
+        v_row.first_name,
+        v_row.last_name,
+        v_row.role,
+        v_row.organization_id;
+  END IF;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.validate_staff_pin(text, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.validate_staff_pin(text, uuid) TO anon, authenticated;
+
+-- ── 3. set_admin_pin ──────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.set_admin_pin(
+  p_member_id uuid,
+  p_raw_pin   text
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  v_org_id uuid;
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  IF auth.uid() <> p_member_id THEN
+    RAISE EXCEPTION 'You may only update your own PIN';
+  END IF;
+
+  IF length(trim(p_raw_pin)) < 4 THEN
+    RAISE EXCEPTION 'PIN must be at least 4 digits';
+  END IF;
+
+  SELECT organization_id INTO v_org_id
+  FROM public.team_members
+  WHERE id = p_member_id;
+
+  IF v_org_id IS NULL THEN
+    RAISE EXCEPTION 'Team member not found';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM public.team_members tm
+    WHERE tm.organization_id = v_org_id
+      AND tm.id <> p_member_id
+      AND tm.pin IS NOT NULL
+      AND crypt(p_raw_pin, tm.pin) = tm.pin
+  ) THEN
+    RAISE EXCEPTION 'Another team member is already using this PIN. Please choose a different one.';
+  END IF;
+
+  UPDATE public.team_members
+  SET
+    pin               = crypt(p_raw_pin, gen_salt('bf', 12)),
+    default_pin       = NULL,
+    pin_reset_required = false
+  WHERE id = p_member_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.set_admin_pin(uuid, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.set_admin_pin(uuid, text) TO authenticated;

--- a/supabase/migrations/20260520000002_fix_submit_kiosk_log_null_staff.sql
+++ b/supabase/migrations/20260520000002_fix_submit_kiosk_log_null_staff.sql
@@ -1,0 +1,94 @@
+-- ================================================================
+-- Fix: submit_kiosk_log staff_profile_id validation must allow NULL.
+--
+-- Problem:
+--   The validation block raised an exception whenever staff_profile_id
+--   was not found in staff_profiles.  When id = NULL the EXISTS check
+--   returns false (NULL never matches), so any submission where the
+--   kiosk user authenticated via an admin PIN (no staff profile) was
+--   immediately rejected with "staff_profile_id <NULL> not found."
+--
+--   staff_profile_id is intentionally nullable in checklist_logs —
+--   admins who enter their team-member PIN have no staff_profiles row.
+--
+-- Fix: only run the EXISTS check when p_staff_profile_id IS NOT NULL.
+-- ================================================================
+
+CREATE OR REPLACE FUNCTION public.submit_kiosk_log(
+  p_location_id        uuid,
+  p_checklist_id       uuid,
+  p_staff_profile_id   uuid,
+  p_score              numeric,
+  p_answers            jsonb,
+  p_checklist_title    text,
+  p_completed_by       text        DEFAULT '',
+  p_duration_seconds   integer     DEFAULT NULL,
+  p_started_at         timestamptz DEFAULT NULL
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  _org_id  uuid;
+  _log_id  uuid;
+BEGIN
+  SELECT organization_id INTO _org_id
+    FROM public.locations
+   WHERE id = p_location_id;
+
+  IF _org_id IS NULL THEN
+    RAISE EXCEPTION 'submit_kiosk_log: location % not found.', p_location_id;
+  END IF;
+
+  -- Only validate when a staff profile ID is actually provided
+  IF p_staff_profile_id IS NOT NULL AND NOT EXISTS (
+    SELECT 1 FROM public.staff_profiles WHERE id = p_staff_profile_id
+  ) THEN
+    RAISE EXCEPTION 'submit_kiosk_log: staff_profile_id % not found.', p_staff_profile_id;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.checklists
+     WHERE id = p_checklist_id AND organization_id = _org_id
+  ) THEN
+    RAISE EXCEPTION 'submit_kiosk_log: checklist % does not belong to organization %.', p_checklist_id, _org_id;
+  END IF;
+
+  IF p_score IS NULL OR p_score < 0 OR p_score > 100 THEN
+    RAISE EXCEPTION 'submit_kiosk_log: p_score must be between 0 and 100 (got %).', p_score;
+  END IF;
+
+  IF p_answers IS NULL THEN
+    RAISE EXCEPTION 'submit_kiosk_log: p_answers must not be null.';
+  END IF;
+
+  INSERT INTO public.checklist_logs (
+    organization_id,
+    checklist_id,
+    checklist_title,
+    completed_by,
+    staff_profile_id,
+    score,
+    answers,
+    location_id,
+    started_at
+  ) VALUES (
+    _org_id,
+    p_checklist_id,
+    p_checklist_title,
+    p_completed_by,
+    p_staff_profile_id,
+    p_score::integer,
+    p_answers,
+    p_location_id,
+    p_started_at
+  )
+  RETURNING id INTO _log_id;
+
+  RETURN _log_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.submit_kiosk_log(uuid, uuid, uuid, numeric, jsonb, text, text, integer, timestamptz) TO anon;


### PR DESCRIPTION
## Summary

- `submit_kiosk_log` validated that `staff_profile_id` exists in `staff_profiles` — but didn't skip the check when the value is `NULL`
- When a team member authenticates via their **admin PIN** (no staff profile), `p_staff_profile_id` is `NULL`; `WHERE id = NULL` returns no rows, so `NOT EXISTS` fired and threw "staff_profile_id <NULL> not found"
- Every completed checklist was queued as failed and the "Submission queued (offline/error)" banner appeared
- Fix: add `p_staff_profile_id IS NOT NULL AND` guard so the validation only runs when an ID is actually provided (`staff_profile_id` is intentionally nullable in `checklist_logs`)

## Why this wasn't visible before

The PIN search_path bug (#374) prevented authentication entirely — no one could get past the PIN screen to submit. Once PINs started working, this next failure became visible.

## Test plan

- [ ] Complete a checklist using an admin PIN — no "Submission queued" error, log appears in reporting
- [ ] Verify wrong `staff_profile_id` (real UUID but no matching row) still raises the validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)