### PR TITLE
fix: update supabase/setup-cli to v2 to restore deployments

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Supabase CLI
-        uses: supabase/setup-cli@v1
+        uses: supabase/setup-cli@v2
         with:
           version: latest
 


### PR DESCRIPTION
The supabase/setup-cli@v1 action SHA is no longer downloadable, causing every GitHub Pages deploy to fail in ~7 seconds. Bumping to @v2 (latest: v2.1.1).