### PR TITLE
feat: add spacing, elevation, and motion tokens to design system

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -31,6 +31,51 @@ html { font-size: 16px; }                        /* mobile / default        */
     --leading-tight: 1.2;    /* headings                              */
     --leading-body:  1.5;    /* body — WCAG 2.1 §1.4.12 minimum      */
 
+    /* ── Spacing — 4px base grid (px so layout stays stable across viewports)
+       Maps 1:1 to Tailwind's numeric scale: --space-4 = p-4 = 16px
+       ──────────────────────────────────────────────────────────────────── */
+    --space-1:   4px;    /* icon gaps, tight insets                   */
+    --space-2:   8px;    /* list item gaps, small chips               */
+    --space-3:  12px;    /* compact inner padding                     */
+    --space-4:  16px;    /* standard card padding, section content    */
+    --space-5:  20px;    /* comfortable button padding                */
+    --space-6:  24px;    /* card padding relaxed, between cards       */
+    --space-8:  32px;    /* section gaps, large card padding          */
+    --space-10: 40px;    /* page section dividers                     */
+    --space-12: 48px;    /* major layout gaps                         */
+    --space-16: 64px;    /* hero / full-bleed sections                */
+
+    /* Semantic aliases */
+    --space-card-inset:  var(--space-4);   /* inner padding for cards  */
+    --space-section-gap: var(--space-6);   /* vertical between sections */
+    --space-page-inset:  var(--space-4);   /* page horizontal padding   */
+
+    /* ── Elevation — four levels using espresso base hsl(17 30% 9%)
+       Level 0: flat (no shadow)  →  Level 3: modal / bottom sheet
+       ──────────────────────────────────────────────────────────────────── */
+    --shadow-sm:    0 1px 3px 0 hsl(17 30% 9% / 0.06),
+                    0 1px 2px -1px hsl(17 30% 9% / 0.04);   /* level 1 — subtle lift    */
+    --shadow-card:  0 2px 8px 0 hsl(17 30% 9% / 0.06);     /* level 2 — cards          */
+    --shadow-md:    0 4px 12px 0 hsl(17 30% 9% / 0.07),
+                    0 2px 6px -2px hsl(17 30% 9% / 0.05);   /* level 3 — popovers       */
+    --shadow-lg:    0 8px 24px 0 hsl(17 30% 9% / 0.10),
+                    0 4px 12px -2px hsl(17 30% 9% / 0.08);  /* level 4 — modals, sheets */
+    --shadow-inset: inset 0 1px 3px 0 hsl(17 30% 9% / 0.08); /* inputs, pressed states */
+
+    /* ── Motion — duration + easing tokens
+       Use var(--duration-*) + var(--ease-*) in transition/animation declarations.
+       ──────────────────────────────────────────────────────────────────── */
+    --duration-instant:  50ms;   /* state toggles (checked, active)   */
+    --duration-fast:    150ms;   /* hover effects, tooltips           */
+    --duration-base:    250ms;   /* default — page fade-in, drawers   */
+    --duration-slow:    400ms;   /* sheet slide-up, complex reveals   */
+    --duration-slower:  600ms;   /* onboarding, splash animations     */
+
+    --ease-out:    cubic-bezier(0.0, 0.0, 0.2, 1);    /* decelerate — entering        */
+    --ease-in:     cubic-bezier(0.4, 0.0, 1.0, 1.0);  /* accelerate — leaving         */
+    --ease-inout:  cubic-bezier(0.4, 0.0, 0.2, 1.0);  /* symmetric — repositioning   */
+    --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1); /* slight bounce — playful UX  */
+
     /* Olia Brand Colors — all HSL */
     --sage:            219 46% 19%;   /* midnight blue #1A2A47 */
     --sage-deep:       219 52% 13%;   /* hover/active */
@@ -91,11 +136,6 @@ html { font-size: 16px; }                        /* mobile / default        */
     /* Typography */
     --font-display: 'DM Serif Display', Georgia, serif;
     --font-body: 'DM Sans', system-ui, sans-serif;
-
-    /* Shadows — espresso hue */
-    --shadow-sm: 0 1px 3px 0 hsl(17 30% 9% / 0.06), 0 1px 2px -1px hsl(17 30% 9% / 0.04);
-    --shadow-md: 0 4px 12px 0 hsl(17 30% 9% / 0.07), 0 2px 6px -2px hsl(17 30% 9% / 0.05);
-    --shadow-card: 0 2px 8px 0 hsl(17 30% 9% / 0.06);
   }
 }
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -97,9 +97,24 @@ export default {
         "2xl": "calc(var(--radius) + 8px)",
       },
       boxShadow: {
-        sm: "var(--shadow-sm)",
-        md: "var(--shadow-md)",
-        card: "var(--shadow-card)",
+        sm:    "var(--shadow-sm)",
+        card:  "var(--shadow-card)",
+        md:    "var(--shadow-md)",
+        lg:    "var(--shadow-lg)",       // modals, bottom sheets
+        inset: "var(--shadow-inset)",    // inputs, pressed states
+      },
+      transitionDuration: {
+        instant: "var(--duration-instant)",  // 50ms
+        fast:    "var(--duration-fast)",     // 150ms
+        base:    "var(--duration-base)",     // 250ms
+        slow:    "var(--duration-slow)",     // 400ms
+        slower:  "var(--duration-slower)",   // 600ms
+      },
+      transitionTimingFunction: {
+        "ease-out":    "var(--ease-out)",
+        "ease-in":     "var(--ease-in)",
+        "ease-inout":  "var(--ease-inout)",
+        "ease-spring": "var(--ease-spring)",
       },
       keyframes: {
         "fade-in": {
@@ -116,9 +131,9 @@ export default {
         },
       },
       animation: {
-        "fade-in": "fade-in 0.25s ease-out both",
+        "fade-in":       "fade-in var(--duration-base) var(--ease-out) both",
         "accordion-down": "accordion-down 0.2s ease-out",
-        "accordion-up": "accordion-up 0.2s ease-out",
+        "accordion-up":   "accordion-up 0.2s ease-out",
       },
     },
   },


### PR DESCRIPTION
## Summary

Second chapter of Olia's design system — spacing, elevation, and motion.

**Spacing** (`px`-based so gaps stay stable as `html` font-size shifts across viewports)

| Token | Value | Usage |
|---|---|---|
| `--space-1` | 4px | Icon gaps, tight insets |
| `--space-2` | 8px | List item gaps, small chips |
| `--space-3` | 12px | Compact inner padding |
| `--space-4` | 16px | Standard card padding |
| `--space-6` | 24px | Card padding relaxed, between cards |
| `--space-8` | 32px | Section gaps |
| `--space-12` | 48px | Major layout gaps |
| `--space-16` | 64px | Hero / full-bleed sections |
| `--space-card-inset` | → space-4 | Semantic alias |
| `--space-section-gap` | → space-6 | Semantic alias |
| `--space-page-inset` | → space-4 | Semantic alias |

**Elevation** (4 levels on espresso base)

| Level | Token | Usage |
|---|---|---|
| 1 | `--shadow-sm` | Subtle lift |
| 2 | `--shadow-card` | Cards |
| 3 | `--shadow-md` | Popovers, dropdowns |
| 4 | `--shadow-lg` ✨ | Modals, bottom sheets |
| — | `--shadow-inset` ✨ | Inputs, pressed states |

**Motion**

| Token | Value | Usage |
|---|---|---|
| `--duration-instant` | 50ms | State toggles |
| `--duration-fast` | 150ms | Hover effects |
| `--duration-base` | 250ms | Default (page fade-in) |
| `--duration-slow` | 400ms | Sheet slide-up |
| `--duration-slower` | 600ms | Onboarding |
| `--ease-out` | cubic-bezier(0,0,0.2,1) | Entering |
| `--ease-in` | cubic-bezier(0.4,0,1,1) | Leaving |
| `--ease-spring` | cubic-bezier(0.34,1.56,0.64,1) | Playful bounce |

`animate-fade-in` now uses `var(--duration-base)` + `var(--ease-out)` instead of hardcoded values.

New Tailwind utilities: `shadow-lg`, `shadow-inset`, `duration-{instant,fast,base,slow,slower}`, `ease-{out,in,inout,spring}`

## Test plan
- [x] All 1239 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)