### PR TITLE
feat: add component-level design tokens (buttons, cards, badges, sheets, form labels)

### DIFF
--- a/src/components/UpgradePrompt.tsx
+++ b/src/components/UpgradePrompt.tsx
@@ -30,7 +30,8 @@ export function UpgradePrompt({
           </div>
           <button
             onClick={onClose}
-            className="p-1.5 rounded-full hover:bg-muted transition-colors"
+            className="btn-icon"
+            aria-label="Close"
           >
             <X size={18} className="text-muted-foreground" />
           </button>

--- a/src/index.css
+++ b/src/index.css
@@ -35,6 +35,7 @@ html { font-size: 16px; }                        /* mobile / default        */
        Maps 1:1 to Tailwind's numeric scale: --space-4 = p-4 = 16px
        ──────────────────────────────────────────────────────────────────── */
     --space-1:   4px;    /* icon gaps, tight insets                   */
+    --space-1-5: 6px;    /* icon button padding (p-1.5)               */
     --space-2:   8px;    /* list item gaps, small chips               */
     --space-3:  12px;    /* compact inner padding                     */
     --space-4:  16px;    /* standard card padding, section content    */
@@ -164,21 +165,14 @@ html { font-size: 16px; }                        /* mobile / default        */
 }
 
 @layer components {
-  /* Status badge helpers */
-  .status-ok {
-    background-color: hsl(var(--status-ok-bg));
-    color: hsl(var(--status-ok));
-  }
-  .status-warn {
-    background-color: hsl(var(--status-warn-bg));
-    color: hsl(var(--status-warn));
-  }
-  .status-error {
-    background-color: hsl(var(--status-error-bg));
-    color: hsl(var(--status-error));
-  }
+  /* ── Status helpers ──────────────────────────────────────────────────────── */
+  .status-ok   { background-color: hsl(var(--status-ok-bg));   color: hsl(var(--status-ok)); }
+  .status-warn { background-color: hsl(var(--status-warn-bg)); color: hsl(var(--status-warn)); }
+  .status-error{ background-color: hsl(var(--status-error-bg));color: hsl(var(--status-error)); }
 
-  /* Card elevation */
+  /* ── Cards ───────────────────────────────────────────────────────────────── */
+
+  /* Elevated card — border + shadow, no padding (add p-* in JSX) */
   .card-surface {
     background-color: hsl(var(--card));
     border: 1px solid hsl(var(--border));
@@ -186,7 +180,173 @@ html { font-size: 16px; }                        /* mobile / default        */
     box-shadow: var(--shadow-card);
   }
 
-  /* Section label */
+  /* Card with standard inset padding */
+  .card {
+    background-color: hsl(var(--card));
+    border: 1px solid hsl(var(--border));
+    border-radius: var(--radius);
+    box-shadow: var(--shadow-card);
+    padding: var(--space-card-inset);
+  }
+
+  /* Nested section inside a card — tinted background, tighter radius */
+  .card-inset {
+    background-color: hsl(var(--background));
+    border: 1px solid hsl(var(--border));
+    border-radius: calc(var(--radius) - 2px);
+    padding: var(--space-3);
+  }
+
+  /* ── Buttons ─────────────────────────────────────────────────────────────── */
+
+  /* Base — layout, reset, transitions. Always pair with a variant. */
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
+    border-radius: var(--radius);
+    font-family: var(--font-body);
+    font-size: var(--text-body-sm);
+    font-weight: 500;
+    white-space: nowrap;
+    cursor: pointer;
+    transition-property: color, background-color, border-color, opacity, box-shadow;
+    transition-duration: var(--duration-fast);
+    transition-timing-function: var(--ease-out);
+  }
+  .btn:disabled { opacity: 0.5; pointer-events: none; }
+
+  /* Sizes — compose with variant */
+  .btn-sm { padding: var(--space-1) var(--space-3);  font-size: var(--text-caption); }
+  .btn-md { padding: var(--space-2) var(--space-4); }           /* default */
+  .btn-lg { padding: var(--space-3) var(--space-5);  font-size: var(--text-body); }
+  .btn-full { width: 100%; }
+
+  /* Variants */
+  .btn-primary {
+    background-color: hsl(var(--sage));
+    color: hsl(var(--primary-foreground));
+  }
+  .btn-primary:hover { background-color: hsl(var(--sage-deep)); }
+  .btn-primary:active { transform: scale(0.98); }
+
+  .btn-secondary {
+    background-color: hsl(var(--card));
+    color: hsl(var(--foreground));
+    border: 1px solid hsl(var(--border));
+  }
+  .btn-secondary:hover { background-color: hsl(var(--muted)); }
+
+  .btn-ghost { color: hsl(var(--foreground)); }
+  .btn-ghost:hover { background-color: hsl(var(--muted)); }
+
+  .btn-danger {
+    background-color: hsl(var(--status-error));
+    color: hsl(0 0% 100%);
+  }
+  .btn-danger:hover { opacity: 0.9; }
+
+  .btn-outline {
+    border: 1px solid hsl(var(--sage) / 0.4);
+    color: hsl(var(--sage));
+  }
+  .btn-outline:hover { background-color: hsl(var(--sage-light)); }
+
+  /* Icon-only button — circle touch target, no label */
+  .btn-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--space-1-5);  /* 6px — matches Tailwind p-1.5, safe swap */
+    border-radius: 9999px;
+    transition-property: background-color, color;
+    transition-duration: var(--duration-fast);
+    transition-timing-function: var(--ease-out);
+    cursor: pointer;
+  }
+  .btn-icon:hover { background-color: hsl(var(--muted)); }
+
+  /* ── Badges ──────────────────────────────────────────────────────────────── */
+
+  /* Base — always pair with a color variant */
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    border-radius: 9999px;
+    padding: 2px var(--space-2);
+    font-family: var(--font-body);
+    font-size: var(--text-caption);
+    font-weight: 500;
+    white-space: nowrap;
+  }
+
+  .badge-primary { background-color: hsl(var(--sage-light));       color: hsl(var(--sage)); }
+  .badge-muted   { background-color: hsl(var(--muted));            color: hsl(var(--muted-foreground)); }
+  .badge-ok      { background-color: hsl(var(--status-ok-bg));     color: hsl(var(--status-ok)); }
+  .badge-warn    { background-color: hsl(var(--status-warn-bg));   color: hsl(var(--status-warn)); }
+  .badge-error   { background-color: hsl(var(--status-error-bg));  color: hsl(var(--status-error)); }
+
+  /* ── Bottom sheet / modal ────────────────────────────────────────────────── */
+
+  /* Backdrop — set z-index via Tailwind (z-[60]/z-[70] etc.) in JSX */
+  .sheet-overlay {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    background-color: hsl(var(--foreground) / 0.2);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+    animation: fade-in var(--duration-base) var(--ease-out) both;
+    padding-bottom: 4rem;  /* clears bottom nav on mobile */
+  }
+
+  /* Slide-up panel */
+  .sheet-panel {
+    background-color: hsl(var(--card));
+    width: 100%;
+    max-width: 32rem;
+    border-radius: calc(var(--radius) + 8px) calc(var(--radius) + 8px) 0 0;
+    padding: var(--space-5);
+    max-height: 85vh;
+    overflow-y: auto;
+    box-shadow: var(--shadow-lg);
+    animation: fade-in var(--duration-base) var(--ease-out) both;
+  }
+
+  /* On wider screens: centre the panel and round all corners */
+  @media (min-width: 640px) {
+    .sheet-overlay { align-items: center; padding: var(--space-8); }
+    .sheet-panel   { border-radius: calc(var(--radius) + 8px); max-height: 90vh; }
+  }
+
+  /* ── Form elements ───────────────────────────────────────────────────────── */
+
+  .form-label {
+    display: block;
+    font-family: var(--font-body);
+    font-size: var(--text-body-sm);
+    font-weight: 500;
+    color: hsl(var(--foreground));
+    margin-bottom: var(--space-1);
+  }
+
+  .form-hint {
+    font-size: var(--text-caption);
+    color: hsl(var(--muted-foreground));
+    margin-top: var(--space-1);
+  }
+
+  .form-error {
+    font-size: var(--text-caption);
+    color: hsl(var(--status-error));
+    margin-top: var(--space-1);
+  }
+
+  /* ── Section label ───────────────────────────────────────────────────────── */
   .section-label {
     font-family: var(--font-body);
     font-size: var(--text-caption);
@@ -196,7 +356,7 @@ html { font-size: 16px; }                        /* mobile / default        */
     color: hsl(var(--muted-foreground));
   }
 
-  /* Score ring helpers */
+  /* ── Score ring ──────────────────────────────────────────────────────────── */
   .score-ring {
     border-radius: 50%;
     display: flex;
@@ -206,21 +366,8 @@ html { font-size: 16px; }                        /* mobile / default        */
   }
 
   /* ── Safe area utilities (Capacitor / iOS notch / Android edge-to-edge) ── */
+  .safe-area-pb { padding-bottom: env(safe-area-inset-bottom, 0px); }
+  .safe-area-pt { padding-top:    env(safe-area-inset-top,    0px); }
 
-  /* Bottom nav sits above the home indicator */
-  .safe-area-pb {
-    padding-bottom: env(safe-area-inset-bottom, 0px);
-  }
-
-  /* Top content respects status bar height */
-  .safe-area-pt {
-    padding-top: env(safe-area-inset-top, 0px);
-  }
-
-  /* Full-bleed page wrapper fills behind status bar + home indicator */
-  #root {
-    /* Prevents content from being obscured by iOS home indicator or
-       Android gesture nav bar when running in Capacitor */
-    min-height: 100dvh;
-  }
+  #root { min-height: 100dvh; }
 }

--- a/src/pages/Infohub.tsx
+++ b/src/pages/Infohub.tsx
@@ -415,7 +415,7 @@ export default function Infohub() {
                       </div>
                       <button
                         onClick={e => { e.stopPropagation(); setOpenMenuId(openMenuId === folder.id ? null : folder.id); }}
-                        className="p-1.5 rounded-full hover:bg-muted transition-colors shrink-0"
+                        className="btn-icon shrink-0"
                       >
                         <MoreVertical size={16} className="text-muted-foreground" />
                       </button>
@@ -467,7 +467,7 @@ export default function Infohub() {
                       </button>
                       <button
                         onClick={e => { e.stopPropagation(); setOpenMenuId(openMenuId === doc.id ? null : doc.id); }}
-                        className="p-1.5 rounded-full hover:bg-muted transition-colors shrink-0"
+                        className="btn-icon shrink-0"
                       >
                         <MoreVertical size={16} className="text-muted-foreground" />
                       </button>
@@ -573,7 +573,7 @@ export default function Infohub() {
                       </div>
                       <button
                         onClick={e => { e.stopPropagation(); setOpenMenuId(openMenuId === folder.id ? null : folder.id); }}
-                        className="p-1.5 rounded-full hover:bg-muted transition-colors shrink-0"
+                        className="btn-icon shrink-0"
                       >
                         <MoreVertical size={16} className="text-muted-foreground" />
                       </button>
@@ -627,7 +627,7 @@ export default function Infohub() {
                       )}
                       <button
                         onClick={e => { e.stopPropagation(); setOpenMenuId(openMenuId === doc.id ? null : doc.id); }}
-                        className="p-1.5 rounded-full hover:bg-muted transition-colors shrink-0"
+                        className="btn-icon shrink-0"
                       >
                         <MoreVertical size={16} className="text-muted-foreground" />
                       </button>

--- a/src/pages/Maintenance.tsx
+++ b/src/pages/Maintenance.tsx
@@ -86,7 +86,7 @@ function NewTaskModal({ onClose, onAdd }: {
       <div className="bg-card w-full max-w-lg rounded-t-2xl p-5 pb-8 space-y-4 animate-fade-in">
         <div className="flex items-center justify-between">
           <h2 className="font-display text-lg text-foreground">New maintenance task</h2>
-          <button onClick={onClose} className="p-1.5 rounded-full hover:bg-muted transition-colors">
+          <button onClick={onClose} className="btn-icon">
             <X size={18} className="text-muted-foreground" />
           </button>
         </div>

--- a/src/pages/Notifications.tsx
+++ b/src/pages/Notifications.tsx
@@ -76,7 +76,7 @@ export default function Notifications() {
                   </div>
                   <button
                     onClick={() => clearOne(alert.id)}
-                    className="p-1.5 rounded-full hover:bg-muted transition-colors shrink-0"
+                    className="btn-icon shrink-0"
                     aria-label="Dismiss alert"
                   >
                     <X size={14} className="text-muted-foreground" />

--- a/src/pages/Training.tsx
+++ b/src/pages/Training.tsx
@@ -163,7 +163,7 @@ function ModuleDetail({
     <div className="min-h-screen bg-background flex flex-col w-full min-[900px]:max-w-[1120px] xl:max-w-[1040px] mx-auto">
       <header className="sticky top-0 z-40 bg-background/95 backdrop-blur-sm border-b border-border px-5 py-4">
         <div className="flex items-center gap-3">
-          <button onClick={onBack} className="p-1.5 rounded-full hover:bg-muted transition-colors">
+          <button onClick={onBack} className="btn-icon">
             <ChevronLeft size={20} className="text-muted-foreground" />
           </button>
           <div className="flex-1 min-w-0">

--- a/src/pages/TrainingAIModal.tsx
+++ b/src/pages/TrainingAIModal.tsx
@@ -48,7 +48,7 @@ export function TrainingAIModal({
             Build training with AI
             <Sparkles size={16} className="text-lavender" />
           </h2>
-          <button onClick={onClose} className="p-1.5 rounded-full hover:bg-muted transition-colors">
+          <button onClick={onClose} className="btn-icon">
             <X size={18} className="text-muted-foreground" />
           </button>
         </div>

--- a/src/pages/admin/SharedUI.tsx
+++ b/src/pages/admin/SharedUI.tsx
@@ -48,7 +48,7 @@ export function ModalHeader({ title, onClose }: { title: string; onClose: () => 
   return (
     <div className="flex items-center justify-between">
       <h2 className="font-display text-lg text-foreground">{title}</h2>
-      <button onClick={onClose} className="p-1.5 rounded-full hover:bg-muted transition-colors">
+      <button onClick={onClose} className="btn-icon">
         <X size={18} className="text-muted-foreground" />
       </button>
     </div>

--- a/src/pages/checklists/BuildWithAIModal.tsx
+++ b/src/pages/checklists/BuildWithAIModal.tsx
@@ -40,7 +40,7 @@ export function BuildWithAIModal({ onClose, onGenerate }: { onClose: () => void;
             Build with AI
             <Sparkles size={16} className="text-lavender" />
           </h2>
-          <button onClick={onClose} className="p-1.5 rounded-full hover:bg-muted transition-colors">
+          <button onClick={onClose} className="btn-icon">
             <X size={18} className="text-muted-foreground" />
           </button>
         </div>

--- a/src/pages/checklists/ChecklistBuilderModal.tsx
+++ b/src/pages/checklists/ChecklistBuilderModal.tsx
@@ -369,7 +369,7 @@ export function ChecklistBuilderModal({
         {asPage ? (
           <div className="w-16" />
         ) : (
-          <button onClick={handleRequestClose} className="p-1.5 rounded-full hover:bg-muted transition-colors">
+          <button onClick={handleRequestClose} className="btn-icon">
             <X size={18} className="text-muted-foreground" />
           </button>
         )}

--- a/src/pages/checklists/ChecklistsTab.tsx
+++ b/src/pages/checklists/ChecklistsTab.tsx
@@ -461,7 +461,7 @@ export function ChecklistsTab() {
           <div className="bg-card w-full max-w-lg rounded-t-2xl p-5 pb-20 space-y-4 animate-fade-in">
             <div className="flex items-center justify-between">
               <h2 className="font-display text-lg text-foreground">New folder</h2>
-              <button onClick={() => setShowNewFolder(false)} className="p-1.5 rounded-full hover:bg-muted transition-colors">
+              <button onClick={() => setShowNewFolder(false)} className="btn-icon">
                 <X size={18} className="text-muted-foreground" />
               </button>
             </div>
@@ -533,7 +533,7 @@ export function ChecklistsTab() {
           <div className="bg-card w-full max-w-lg rounded-t-2xl p-5 pb-20 space-y-4 animate-fade-in">
             <div className="flex items-center justify-between">
               <h2 className="font-display text-lg text-foreground">Rename folder</h2>
-              <button onClick={() => setRenameTarget(null)} className="p-1.5 rounded-full hover:bg-muted transition-colors">
+              <button onClick={() => setRenameTarget(null)} className="btn-icon">
                 <X size={18} className="text-muted-foreground" />
               </button>
             </div>

--- a/src/pages/checklists/CreateMenuSheet.tsx
+++ b/src/pages/checklists/CreateMenuSheet.tsx
@@ -19,7 +19,7 @@ export function CreateMenuSheet({ onClose, onBuildOwn, onConvertFile, onBuildAI,
       <div className="bg-card w-full max-w-md rounded-3xl border border-border p-5 pb-6 space-y-1 shadow-2xl animate-fade-in">
         <div className="flex items-center justify-between mb-3">
           <h2 className="font-display text-lg text-foreground">Create new</h2>
-          <button onClick={onClose} className="p-1.5 rounded-full hover:bg-muted transition-colors">
+          <button onClick={onClose} className="btn-icon">
             <X size={18} className="text-muted-foreground" />
           </button>
         </div>

--- a/src/pages/checklists/LogDetailModal.tsx
+++ b/src/pages/checklists/LogDetailModal.tsx
@@ -62,7 +62,7 @@ export function LogDetailModal({ log, onClose }: { log: LogEntry; onClose: () =>
               className="flex items-center gap-1.5 text-xs font-medium text-sage px-3 py-1.5 rounded-full border border-sage/40 hover:bg-sage-light transition-colors">
               <FileText size={12} /> Export PDF
             </button>
-            <button onClick={onClose} className="p-1.5 rounded-full hover:bg-muted transition-colors">
+            <button onClick={onClose} className="btn-icon">
               <X size={18} className="text-muted-foreground" />
             </button>
           </div>

--- a/src/pages/checklists/MoveToFolderSheet.tsx
+++ b/src/pages/checklists/MoveToFolderSheet.tsx
@@ -18,7 +18,7 @@ export function MoveToFolderSheet({ folders, currentFolderId, onMove, onClose }:
       <div className="bg-card w-full max-w-lg rounded-t-2xl p-5 pb-20 space-y-4 animate-fade-in max-h-[85vh] overflow-y-auto sm:max-w-2xl sm:rounded-2xl sm:max-h-[90vh]">
         <div className="flex items-center justify-between">
           <h2 className="font-display text-lg text-foreground">Move to folder</h2>
-          <button onClick={onClose} className="p-1.5 rounded-full hover:bg-muted transition-colors">
+          <button onClick={onClose} className="btn-icon">
             <X size={18} className="text-muted-foreground" />
           </button>
         </div>

--- a/src/pages/checklists/ResponseTypePicker.tsx
+++ b/src/pages/checklists/ResponseTypePicker.tsx
@@ -58,7 +58,7 @@ export function ResponseTypePicker({ onSelect, onClose, anchorRect }: {
       >
         <div className="flex items-center justify-between px-5 pt-5 pb-3 border-b border-border shrink-0">
           <h2 className="font-display text-lg text-foreground">Type of response</h2>
-          <button onClick={onClose} className="p-1.5 rounded-full hover:bg-muted transition-colors">
+          <button onClick={onClose} className="btn-icon">
             <X size={18} className="text-muted-foreground" />
           </button>
         </div>

--- a/src/pages/infohub/InfohubDocumentViews.tsx
+++ b/src/pages/infohub/InfohubDocumentViews.tsx
@@ -42,7 +42,7 @@ export function LibraryDocDetail({
     <div className="min-h-screen bg-background flex flex-col w-full min-[900px]:max-w-[1120px] xl:max-w-[1040px] mx-auto">
       <header className="sticky top-0 z-40 bg-background/95 backdrop-blur-sm border-b border-border px-5 py-4">
         <div className="flex items-center gap-3">
-          <button onClick={isEditing ? () => setIsEditing(false) : onBack} className="p-1.5 rounded-full hover:bg-muted transition-colors">
+          <button onClick={isEditing ? () => setIsEditing(false) : onBack} className="btn-icon">
             <ChevronLeft size={20} className="text-muted-foreground" />
           </button>
           <div className="flex-1 min-w-0">
@@ -194,7 +194,7 @@ export function TrainingDocDetail({
     <div className="min-h-screen bg-background flex flex-col w-full min-[900px]:max-w-[1120px] xl:max-w-[1040px] mx-auto">
       <header className="sticky top-0 z-40 bg-background/95 backdrop-blur-sm border-b border-border px-5 py-4">
         <div className="flex items-center gap-3">
-          <button onClick={onBack} className="p-1.5 rounded-full hover:bg-muted transition-colors">
+          <button onClick={onBack} className="btn-icon">
             <ChevronLeft size={20} className="text-muted-foreground" />
           </button>
           <div className="flex-1 min-w-0">

--- a/src/pages/infohub/InfohubShared.tsx
+++ b/src/pages/infohub/InfohubShared.tsx
@@ -86,7 +86,7 @@ export function MoveToFolderSheet({
       <div className="space-y-3">
         <div className="flex items-center justify-between mb-1">
           <h3 className="font-display text-base text-foreground">Move to folder</h3>
-          <button onClick={onClose} className="p-1.5 rounded-full hover:bg-muted transition-colors">
+          <button onClick={onClose} className="btn-icon">
             <X size={18} className="text-muted-foreground" />
           </button>
         </div>
@@ -195,7 +195,7 @@ export function CreateFolderModal({
       <div className="space-y-4">
         <div className="flex items-center justify-between">
           <h3 className="font-display text-base text-foreground">New folder</h3>
-          <button onClick={onClose} className="p-1.5 rounded-full hover:bg-muted transition-colors">
+          <button onClick={onClose} className="btn-icon">
             <X size={18} className="text-muted-foreground" />
           </button>
         </div>
@@ -236,7 +236,7 @@ export function RenameFolderModal({
       <div className="space-y-4">
         <div className="flex items-center justify-between">
           <h3 className="font-display text-base text-foreground">Rename folder</h3>
-          <button onClick={onClose} className="p-1.5 rounded-full hover:bg-muted transition-colors">
+          <button onClick={onClose} className="btn-icon">
             <X size={18} className="text-muted-foreground" />
           </button>
         </div>
@@ -281,7 +281,7 @@ export function CreateDocModal({
       <div className="space-y-4">
         <div className="flex items-center justify-between">
           <h3 className="font-display text-base text-foreground">New document</h3>
-          <button onClick={onClose} className="p-1.5 rounded-full hover:bg-muted transition-colors">
+          <button onClick={onClose} className="btn-icon">
             <X size={18} className="text-muted-foreground" />
           </button>
         </div>
@@ -331,7 +331,7 @@ export function PlusMenu({ onClose, onAction }: { onClose: () => void; onAction:
       <div className="space-y-1">
         <div className="flex items-center justify-between mb-3">
           <h3 className="font-display text-base text-foreground">Create new</h3>
-          <button onClick={onClose} className="p-1.5 rounded-full hover:bg-muted transition-colors">
+          <button onClick={onClose} className="btn-icon">
             <X size={18} className="text-muted-foreground" />
           </button>
         </div>
@@ -404,7 +404,7 @@ export function ManageAccessModal({
             <h3 className="font-display text-base text-foreground">Manage access</h3>
             <p className="text-xs text-muted-foreground mt-1">{target.name}</p>
           </div>
-          <button onClick={onClose} className="p-1.5 rounded-full hover:bg-muted transition-colors">
+          <button onClick={onClose} className="btn-icon">
             <X size={18} className="text-muted-foreground" />
           </button>
         </div>
@@ -553,7 +553,7 @@ export function AIActionsSheet({
             <Sparkles size={16} className="text-lavender-deep" />
             <h3 className="font-display text-base text-foreground">AI Tools</h3>
           </div>
-          <button onClick={onClose} className="p-1.5 rounded-full hover:bg-muted transition-colors">
+          <button onClick={onClose} className="btn-icon">
             <X size={18} className="text-muted-foreground" />
           </button>
         </div>
@@ -696,7 +696,7 @@ export function SearchOverlay({
           onChange={(e) => setQuery(e.target.value)}
           className="flex-1 text-sm bg-transparent focus:outline-none"
         />
-        <button onClick={onClose} className="p-1.5 rounded-full hover:bg-muted transition-colors">
+        <button onClick={onClose} className="btn-icon">
           <X size={18} className="text-muted-foreground" />
         </button>
       </header>

--- a/src/pages/kiosk/PinEntryModal.tsx
+++ b/src/pages/kiosk/PinEntryModal.tsx
@@ -201,7 +201,7 @@ export function AdminLoginModal({ onClose, kioskLocationId }: { onClose: () => v
       <div className="bg-card w-full max-w-sm mx-4 rounded-2xl p-6 space-y-5 animate-fade-in">
         <div className="flex items-center justify-between">
           <h2 className="font-display text-lg text-foreground">Admin PIN</h2>
-          <button onClick={onClose} className="p-1.5 rounded-full hover:bg-muted transition-colors">
+          <button onClick={onClose} className="btn-icon">
             <X size={18} className="text-muted-foreground" />
           </button>
         </div>

--- a/src/test/components/UpgradePrompt.test.tsx
+++ b/src/test/components/UpgradePrompt.test.tsx
@@ -71,9 +71,8 @@ describe("UpgradePrompt", () => {
     renderWithProviders(
       <UpgradePrompt feature="AI checklist builder" onClose={onClose} />
     );
-    const closeBtn = document.querySelector("button[class*='rounded-full']");
-    expect(closeBtn).not.toBeNull();
-    fireEvent.click(closeBtn!);
+    const closeBtn = screen.getByRole("button", { name: "Close" });
+    fireEvent.click(closeBtn);
     expect(onClose).toHaveBeenCalled();
   });
 

--- a/src/test/pages/Infohub.test.tsx
+++ b/src/test/pages/Infohub.test.tsx
@@ -316,9 +316,9 @@ describe("Infohub page", () => {
         const docRow = moduleTitle.closest("div[class*='cursor-pointer']") as HTMLElement;
         if (docRow) {
           fireEvent.click(docRow);
-          // Find back button (ChevronLeft)
+          // Find back button — first button in header containing a chevron-left SVG
           const backBtn = screen.getAllByRole("button").find(btn =>
-            btn.className.includes("rounded-full") && btn.querySelector("svg")
+            btn.querySelector("svg.lucide-chevron-left")
           );
           if (backBtn) {
             fireEvent.click(backBtn);


### PR DESCRIPTION
## Summary

Third chapter of Olia's design system — component tokens that wire the primitive layer (color, spacing, radius, motion) into reusable CSS classes. One token change in `src/index.css` now updates every instance automatically.

**New component classes**

| Class | Wired tokens | Usage |
|---|---|---|
| `.btn` + `.btn-{primary,secondary,ghost,danger,outline}` | `--sage`, `--radius`, `--duration-fast`, `--ease-out` | All button variants |
| `.btn-{sm,md,lg,full}` | `--space-*` | Size modifiers |
| `.btn-icon` | `--space-1-5` (6px), `--duration-fast` | Icon-only touch targets |
| `.card` / `.card-inset` | `--space-card-inset`, `--shadow-card`, `--radius` | Card surfaces with padding |
| `.badge` + `.badge-{primary,muted,ok,warn,error}` | `--text-caption`, status tokens | Status / type chips |
| `.sheet-overlay` / `.sheet-panel` | `--foreground`, `--shadow-lg`, `--duration-base` | Bottom sheet pattern |
| `.form-{label,hint,error}` | `--text-body-sm`, `--text-caption`, `--space-1` | Form field text |

**Migrations applied**
- `p-1.5 rounded-full hover:bg-muted transition-colors` → `.btn-icon` in 17 files (24 occurrences)
- `aria-label="Close"` added to UpgradePrompt X button (accessibility improvement)

**Test fixes**
- `UpgradePrompt`: `getByRole("button", { name: "Close" })` instead of CSS class inspection
- `Infohub`: `svg.lucide-chevron-left` selector to find back button (was fragile `className.includes("rounded-full")`)

## Test plan
- [x] All 1239 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)