### PR TITLE
fix: split team_members policy to prevent self-delete org cascade

### DIFF
--- a/supabase/migrations/20260506000001_fix_team_members_self_read.sql
+++ b/supabase/migrations/20260506000001_fix_team_members_self_read.sql
@@ -1,0 +1,43 @@
+-- ================================================================
+-- Allow a user to always read their own team_members row directly,
+-- independent of current_org_id().
+--
+-- The old policy: USING (organization_id = current_org_id())
+-- requires current_org_id() to resolve correctly before the row is
+-- visible. If current_org_id() returns NULL for any reason (e.g. a
+-- brief window during auth, connection pool timing), the user cannot
+-- read their own row and fetchTeamMember falls through to the new-
+-- org setup path, which fails as a duplicate and surfaces as a
+-- setup error screen.
+--
+-- The fix splits the single FOR ALL policy into per-operation
+-- policies so that:
+--   SELECT/UPDATE — id = auth.uid() acts as a fallback when
+--     current_org_id() is NULL, preserving the auth-window fix.
+--   INSERT        — always requires a valid org context.
+--   DELETE        — always requires a valid org context; no self-
+--     delete bypass. Without this restriction a user could delete
+--     their own row while current_org_id() is NULL, triggering the
+--     cleanup_org_when_last_member_removed trigger and cascade-
+--     deleting the entire organisation.
+-- ================================================================
+
+DROP POLICY IF EXISTS "team_members_all" ON team_members;
+
+-- SELECT: own row is always visible; org rows visible when org resolves.
+CREATE POLICY "team_members_select" ON team_members FOR SELECT
+  USING (id = auth.uid() OR organization_id = current_org_id());
+
+-- INSERT: org context must resolve — no inserting into a null org.
+CREATE POLICY "team_members_insert" ON team_members FOR INSERT
+  WITH CHECK (organization_id = current_org_id());
+
+-- UPDATE: can target own row or any org row; new value must stay in org.
+CREATE POLICY "team_members_update" ON team_members FOR UPDATE
+  USING (id = auth.uid() OR organization_id = current_org_id())
+  WITH CHECK (organization_id = current_org_id());
+
+-- DELETE: org context required — prevents accidental org cascade-delete
+-- when current_org_id() is NULL during an edge-case session.
+CREATE POLICY "team_members_delete" ON team_members FOR DELETE
+  USING (organization_id = current_org_id());


### PR DESCRIPTION
## Summary

The `team_members_all` RLS policy used `FOR ALL` with `USING (id = auth.uid() OR organization_id = current_org_id())`. The `id = auth.uid()` branch was added to fix an auth-window race condition where `current_org_id()` briefly returns NULL, preventing a user from reading their own row. However, because `FOR ALL` applies the same USING clause to DELETE, a user in a broken session context (where `current_org_id()` is NULL) could delete their own `team_members` row — triggering the `cleanup_org_when_last_member_removed` trigger, which cascade-deletes the entire organisation if they were the last member.

**Fix:** split into four per-operation policies:

| Operation | USING | WITH CHECK |
|-----------|-------|------------|
| SELECT | `id = auth.uid() OR organization_id = current_org_id()` | — |
| INSERT | — | `organization_id = current_org_id()` |
| UPDATE | `id = auth.uid() OR organization_id = current_org_id()` | `organization_id = current_org_id()` |
| DELETE | `organization_id = current_org_id()` | — |

SELECT and UPDATE retain the `auth.uid()` fallback for the auth-window fix. INSERT and DELETE require a resolved org context — no bypass.

## Test plan

- [ ] Newly signed-up user can read their own `team_members` row immediately after signup (auth-window fix still works)
- [ ] User cannot delete their own `team_members` row when `current_org_id()` would return NULL
- [ ] Normal member deletion by an owner still works (org context is present)
- [ ] Deleting the last member of an org still triggers the org cleanup cascade when called with a valid org context

🤖 Generated with [Claude Code](https://claude.com/claude-code)