### PR TITLE
chore: commit pending migrations (sort order, org cleanup, permission gaps)

### DIFF
--- a/supabase/migrations/20260503000003_folder_sort_order.sql
+++ b/supabase/migrations/20260503000003_folder_sort_order.sql
@@ -1,0 +1,14 @@
+-- Add sort_order to folders so drag-to-reorder persists across sessions.
+
+ALTER TABLE folders ADD COLUMN IF NOT EXISTS sort_order integer NOT NULL DEFAULT 0;
+
+-- Backfill existing rows: preserve current alphabetical order within each parent.
+WITH ranked AS (
+  SELECT id,
+         ROW_NUMBER() OVER (
+           PARTITION BY COALESCE(parent_id::text, '__root__')
+           ORDER BY name
+         ) - 1 AS rn
+  FROM folders
+)
+UPDATE folders SET sort_order = ranked.rn FROM ranked WHERE folders.id = ranked.id;

--- a/supabase/migrations/20260503000004_cleanup_org_on_last_member_removed.sql
+++ b/supabase/migrations/20260503000004_cleanup_org_on_last_member_removed.sql
@@ -1,0 +1,31 @@
+-- When the last team_member of an org is deleted (e.g. because the auth user
+-- was removed via the Supabase dashboard), automatically delete the organisation
+-- too. This cascades to locations, checklists, staff_profiles, and all other
+-- org-scoped tables via their existing ON DELETE CASCADE foreign keys.
+--
+-- Without this trigger, deleting an auth user only cascade-deletes the
+-- team_members row; the organisations row and all its data become orphaned
+-- and will reappear for anyone who re-registers with the same email.
+
+CREATE OR REPLACE FUNCTION public.cleanup_org_when_last_member_removed()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM public.team_members WHERE organization_id = OLD.organization_id
+  ) THEN
+    DELETE FROM public.organizations WHERE id = OLD.organization_id;
+  END IF;
+  RETURN OLD;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_cleanup_org_after_member_removed ON public.team_members;
+
+CREATE TRIGGER trg_cleanup_org_after_member_removed
+  AFTER DELETE ON public.team_members
+  FOR EACH ROW
+  EXECUTE FUNCTION public.cleanup_org_when_last_member_removed();

--- a/supabase/migrations/20260503000005_server_side_permission_gaps.sql
+++ b/supabase/migrations/20260503000005_server_side_permission_gaps.sql
@@ -1,0 +1,120 @@
+-- ================================================================
+-- Close remaining server-side permission and plan-limit gaps.
+--
+-- What was already enforced (20260312000002_server_permissions.sql):
+--   - staff_profiles write/update/delete: has_permission('manage_staff_profiles')
+--   - locations insert: check_plan_limit maxLocations
+--   - checklists insert: check_plan_limit maxChecklists
+--
+-- What this migration adds:
+--   1. checklists insert/update/delete: has_permission('create_edit_checklists')
+--   2. folders all writes: has_permission('create_edit_checklists')
+--   3. locations update: has_permission('edit_location_details')
+--   4. alerts writes: has_permission('manage_alerts')
+--   5. staff_profiles insert: check_plan_limit maxStaff (was missing alongside permission check)
+-- ================================================================
+
+-- ── 1. Checklists — add permission check to writes ────────────────────────────
+
+DROP POLICY IF EXISTS "checklists_insert_within_limit" ON checklists;
+DROP POLICY IF EXISTS "checklists_update" ON checklists;
+DROP POLICY IF EXISTS "checklists_delete" ON checklists;
+
+CREATE POLICY "checklists_insert" ON checklists FOR INSERT
+  WITH CHECK (
+    organization_id = current_org_id()
+    AND has_permission('create_edit_checklists')
+    AND check_plan_limit(organization_id, 'checklists', 'maxChecklists')
+  );
+
+CREATE POLICY "checklists_update" ON checklists FOR UPDATE
+  USING (
+    organization_id = current_org_id()
+    AND has_permission('create_edit_checklists')
+  );
+
+CREATE POLICY "checklists_delete" ON checklists FOR DELETE
+  USING (
+    organization_id = current_org_id()
+    AND has_permission('create_edit_checklists')
+  );
+
+-- ── 2. Folders — add permission check to writes ───────────────────────────────
+-- The original "folders_all" policy (for all using org_id) is replaced with
+-- separate read vs write policies.
+
+DROP POLICY IF EXISTS "folders_all" ON folders;
+
+CREATE POLICY "folders_select" ON folders FOR SELECT
+  USING (organization_id = current_org_id());
+
+CREATE POLICY "folders_insert" ON folders FOR INSERT
+  WITH CHECK (
+    organization_id = current_org_id()
+    AND has_permission('create_edit_checklists')
+  );
+
+CREATE POLICY "folders_update" ON folders FOR UPDATE
+  USING (
+    organization_id = current_org_id()
+    AND has_permission('create_edit_checklists')
+  );
+
+CREATE POLICY "folders_delete" ON folders FOR DELETE
+  USING (
+    organization_id = current_org_id()
+    AND has_permission('create_edit_checklists')
+  );
+
+-- ── 3. Locations update — add permission check ────────────────────────────────
+-- The current policy (from 20260408000001) checks plan editability but not
+-- the user's permission to edit location details.
+
+DROP POLICY IF EXISTS "locations_update" ON locations;
+
+CREATE POLICY "locations_update" ON locations FOR UPDATE
+  USING (
+    organization_id = current_org_id()
+    AND has_permission('edit_location_details')
+    AND location_is_plan_editable(id)
+  );
+
+-- ── 4. Alerts — split into read vs write, add permission check on writes ──────
+-- The original "alerts_all" policy allows any team member to do everything.
+-- Managers have manage_alerts: false by default, so they should not be able
+-- to create, edit or delete alerts — only read them.
+
+DROP POLICY IF EXISTS "alerts_all" ON alerts;
+
+CREATE POLICY "alerts_select" ON alerts FOR SELECT
+  USING (organization_id = current_org_id());
+
+CREATE POLICY "alerts_insert" ON alerts FOR INSERT
+  WITH CHECK (
+    organization_id = current_org_id()
+    AND has_permission('manage_alerts')
+  );
+
+CREATE POLICY "alerts_update" ON alerts FOR UPDATE
+  USING (
+    organization_id = current_org_id()
+    AND has_permission('manage_alerts')
+  );
+
+CREATE POLICY "alerts_delete" ON alerts FOR DELETE
+  USING (
+    organization_id = current_org_id()
+    AND has_permission('manage_alerts')
+  );
+
+-- ── 5. Staff profiles insert — add missing plan limit check ───────────────────
+-- The existing policy had the permission check but not the staff count limit.
+
+DROP POLICY IF EXISTS "staff_profiles_insert_permitted" ON staff_profiles;
+
+CREATE POLICY "staff_profiles_insert" ON staff_profiles FOR INSERT
+  WITH CHECK (
+    organization_id = current_org_id()
+    AND has_permission('manage_staff_profiles')
+    AND check_plan_limit(organization_id, 'staff_profiles', 'maxStaff')
+  );


### PR DESCRIPTION
## Summary

Three migrations that were sitting untracked — reviewed and confirmed clean during the security audit.

- **20260503000003** — adds `sort_order` to `folders` for persistent drag-to-reorder; backfills existing rows in alphabetical order
- **20260503000004** — trigger to cascade-delete an org when its last `team_member` is removed, preventing orphaned org data if a user is deleted via the Supabase dashboard
- **20260503000005** — closes server-side RLS permission gaps: checklist/folder writes require `create_edit_checklists`, location updates require `edit_location_details`, alert writes require `manage_alerts`, staff profile inserts enforce the `maxStaff` plan limit

## Test plan

- [ ] Drag-to-reorder folders persists across sessions
- [ ] Deleting the last member of an org via the dashboard cascades to delete the org and all its data
- [ ] Manager without `create_edit_checklists` permission cannot create, edit, or delete checklists or folders
- [ ] Manager without `manage_alerts` permission cannot create, edit, or delete alerts
- [ ] Staff profile insert is blocked when the org is at its plan staff limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)