### PR TITLE
fix: remove pin_plaintext — stop storing kiosk PIN in plaintext

### DIFF
--- a/src/hooks/useTeamMembers.ts
+++ b/src/hooks/useTeamMembers.ts
@@ -11,7 +11,7 @@ export function useTeamMembers() {
     queryFn: async () => {
       const { data, error } = await supabase
         .from("team_members")
-        .select("id, organization_id, name, email, role, location_ids, permissions, pin_reset_required, last_seen_at, pin_plaintext")
+        .select("id, organization_id, name, email, role, location_ids, permissions, pin_reset_required, last_seen_at")
         .order("name");
       if (error) throw error;
       return ((data ?? []) as any[])

--- a/src/pages/admin/AccountTab.tsx
+++ b/src/pages/admin/AccountTab.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import {
-  MapPin, Plus, Pencil, Trash2, Check, X, ChevronDown, ChevronUp, Eye, EyeOff, MailCheck, Send,
+  MapPin, Plus, Pencil, Trash2, Check, X, ChevronDown, ChevronUp, MailCheck, Send,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { supabase } from "@/lib/supabase";
@@ -88,8 +88,7 @@ export function AccountTab({
   const [profileName, setProfileName] = useState(authUserName ?? currentAccount?.name ?? "");
   const [profileEmail, setProfileEmail] = useState(authUserEmail ?? currentAccount?.email ?? "");
   const [pin, setPin] = useState("");
-  const [showNewPin, setShowNewPin] = useState(false);
-  const [showCurrentPin, setShowCurrentPin] = useState(false);
+
   const [showAddDepartment, setShowAddDepartment] = useState(false);
   const [profileSaving, setProfileSaving] = useState(false);
   const [pinSaving, setPinSaving] = useState(false);
@@ -319,29 +318,7 @@ export function AccountTab({
                 Default PIN is <span className="font-semibold">{DEFAULT_ADMIN_PIN}</span>. Change it before using kiosk mode.
               </div>
             )}
-            {/* Current PIN */}
-            <div className="space-y-1">
-              <span className="text-xs text-muted-foreground font-medium">Current PIN</span>
-              <div className="relative">
-                <input
-                  readOnly
-                  type={showCurrentPin && currentAccount?.pin_plaintext ? "text" : "password"}
-                  value={currentAccount?.pin_plaintext ?? "1234"}
-                  className="w-full border border-border rounded-xl px-3 py-2.5 pr-9 text-sm bg-muted/50 text-muted-foreground tracking-[0.3em] cursor-default select-none"
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowCurrentPin(v => !v)}
-                  className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-                >
-                  {showCurrentPin ? <EyeOff size={14} /> : <Eye size={14} />}
-                </button>
-              </div>
-              {!currentAccount?.pin_plaintext && (
-                <p className="text-xs text-muted-foreground">Set a new PIN below to enable viewing.</p>
-              )}
-            </div>
-            {/* New PIN */}
+            {/* PIN */}
             <div className="space-y-1">
               <span className="text-xs text-muted-foreground font-medium">New PIN</span>
               <div className="relative">

--- a/supabase/migrations/20260521000002_remove_pin_plaintext.sql
+++ b/supabase/migrations/20260521000002_remove_pin_plaintext.sql
@@ -1,0 +1,42 @@
+-- ================================================================
+-- Remove pin_plaintext column.
+--
+-- pin_plaintext stored the raw 4-digit PIN alongside its bcrypt hash
+-- so the Account tab could display "Current PIN" to the owner.
+-- Any authenticated org member could read all team_members rows via
+-- the existing RLS policy, making every member's PIN visible to
+-- everyone else in the org.
+--
+-- The "Current PIN" display is removed from the UI. Owners can still
+-- set a new PIN at any time; the kiosk PIN reset flow is unaffected.
+-- pin_uniqueness_hash (added in 20260521000001) continues to provide
+-- O(1) per-org duplicate detection without exposing plaintext.
+-- ================================================================
+
+-- ── 1. Drop the column ────────────────────────────────────────────
+ALTER TABLE public.team_members
+  DROP COLUMN IF EXISTS pin_plaintext;
+
+-- ── 2. Remove pin_plaintext from the trigger ──────────────────────
+CREATE OR REPLACE FUNCTION public.hash_team_member_pin()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+BEGIN
+  IF NEW.pin IS NOT NULL AND (
+    NEW.pin NOT LIKE '$2a$%' AND
+    NEW.pin NOT LIKE '$2b$%' AND
+    NEW.pin NOT LIKE '$2x$%' AND
+    NEW.pin NOT LIKE '$2y$%'
+  ) THEN
+    NEW.pin_uniqueness_hash := encode(
+      digest(NEW.organization_id::text || NEW.pin, 'sha256'),
+      'hex'
+    );
+    NEW.pin := crypt(NEW.pin, gen_salt('bf', 12));
+  END IF;
+  RETURN NEW;
+END;
+$$;


### PR DESCRIPTION
## Summary

`pin_plaintext` stored the raw 4-digit kiosk PIN alongside its bcrypt hash so the Account tab could show the owner their "Current PIN". The `team_members_all` RLS policy lets any authenticated org member read all rows in their org, meaning every member's PIN was readable by everyone else.

**Changes:**

- **Migration `20260521000002`** — `DROP COLUMN pin_plaintext`; update `hash_team_member_pin` trigger to stop capturing it
- **`useTeamMembers.ts`** — remove `pin_plaintext` from the SELECT query
- **`AccountTab.tsx`** — remove the "Current PIN" display block, `Eye`/`EyeOff` imports, and the two now-dead `showCurrentPin`/`showNewPin` state variables

The "Set new PIN" field and the "Default PIN is 1234, change it" banner are unchanged. `pin_uniqueness_hash` (PR #406) continues to provide O(1) per-org duplicate detection without storing plaintext.

## Test plan

- [ ] Account tab → Security section shows only the "New PIN" input and save button (no "Current PIN" field)
- [ ] Setting a new PIN still works and authenticates at the kiosk
- [ ] No `pin_plaintext` column in `team_members` after migration
- [ ] `pin_reset_required = true` banner still shows for accounts that haven't set a custom PIN

🤖 Generated with [Claude Code](https://claude.com/claude-code)