### PR TITLE
feat: dynamic CORS origin, per-org AI rate limiting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ Every page wraps its content in `src/components/Layout.tsx`, which provides:
 
 **`src/lib/export-utils.ts`** — PDF & CSV export helpers using jsPDF + jspdf-autotable.
 
-Infohub documents/training and some Dashboard data still live in local `useState`.
+Infohub documents/training are Supabase-backed via `useInfohubContent` (React Query → `infohub_folders` + `infohub_documents`). Some Dashboard data still lives in local `useState`.
 
 ### Key UI Patterns
 - **Bottom sheet modals:** Fixed overlay with `rounded-t-2xl`, slides up from bottom, max-height 85vh
@@ -176,9 +176,7 @@ Reusable CSS utility classes: `.status-ok/warn/error`, `.card-surface`, `.sectio
 shadcn/ui components are in `src/components/ui/` — do not edit these files manually; use the shadcn CLI to add/update them.
 
 ### What Is Not Yet Built
-- "Build with AI" and "Convert File" features in Checklists call Supabase edge functions (AI-powered)
 - Export buttons generate real PDFs/CSVs via `src/lib/export-utils.ts`
-- Infohub documents/training data is still local mock data (not Supabase-backed)
 - No real payment processing (Stripe integration is UI-only)
 
 ### TypeScript Config

--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,0 +1,22 @@
+// Shared CORS helper for AI edge functions.
+// Set CORS_ALLOWED_ORIGINS in Supabase secrets to a comma-separated list of
+// allowed origins (e.g. "https://myapp.com,capacitor://localhost").
+// Leave unset (or set to "*") to allow all origins during development.
+
+const raw = Deno.env.get("CORS_ALLOWED_ORIGINS") ?? "*";
+const ALLOWED: "*" | Set<string> =
+  raw.trim() === "*" ? "*" : new Set(raw.split(",").map((s) => s.trim()));
+
+export function corsHeaders(origin: string | null): Record<string, string> {
+  const allow =
+    ALLOWED === "*"
+      ? "*"
+      : origin && (ALLOWED as Set<string>).has(origin)
+      ? origin
+      : "null";
+  return {
+    "Access-Control-Allow-Origin": allow,
+    "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+  };
+}

--- a/supabase/functions/_shared/plan-guard.ts
+++ b/supabase/functions/_shared/plan-guard.ts
@@ -1,33 +1,33 @@
 // Shared plan enforcement for AI edge functions.
 // Returns a 403 Response if the caller's org is on the starter plan (no AI features).
-// Returns null if the caller is on growth or enterprise (allowed to proceed).
+// Returns a 429 Response if the org has exceeded its daily AI request limit.
+// Returns null if the caller is allowed to proceed.
 
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { corsHeaders } from "./cors.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
 const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY");
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
-
-const CORS_HEADERS = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
-  "Access-Control-Allow-Methods": "POST, OPTIONS",
-};
+const AI_DAILY_LIMIT = parseInt(Deno.env.get("AI_DAILY_LIMIT") ?? "100", 10);
 
 export async function enforcePaidPlan(
-  authHeader: string | null
+  authHeader: string | null,
+  origin: string | null = null
 ): Promise<Response | null> {
+  const CORS = corsHeaders(origin);
+
   if (!authHeader) {
     return new Response(
       JSON.stringify({ error: "Authentication required." }),
-      { status: 401, headers: { "Content-Type": "application/json", ...CORS_HEADERS } }
+      { status: 401, headers: { "Content-Type": "application/json", ...CORS } }
     );
   }
 
   if (!SUPABASE_URL || !SUPABASE_ANON_KEY || !SUPABASE_SERVICE_ROLE_KEY) {
     return new Response(
       JSON.stringify({ error: "Server configuration error." }),
-      { status: 500, headers: { "Content-Type": "application/json", ...CORS_HEADERS } }
+      { status: 500, headers: { "Content-Type": "application/json", ...CORS } }
     );
   }
 
@@ -44,14 +44,14 @@ export async function enforcePaidPlan(
     if (authError || !user) {
       return new Response(
         JSON.stringify({ error: "Invalid or expired token." }),
-        { status: 401, headers: { "Content-Type": "application/json", ...CORS_HEADERS } }
+        { status: 401, headers: { "Content-Type": "application/json", ...CORS } }
       );
     }
 
-    // Fetch the org plan via the service role (bypasses RLS safely).
+    // Fetch the org plan and ID via the service role (bypasses RLS safely).
     // user.id is now verified — it cannot be spoofed via a crafted JWT payload.
     const res = await fetch(
-      `${SUPABASE_URL}/rest/v1/team_members?select=organizations(plan)&id=eq.${user.id}&limit=1`,
+      `${SUPABASE_URL}/rest/v1/team_members?select=organization_id,organizations(plan)&id=eq.${user.id}&limit=1`,
       {
         headers: {
           "Authorization": `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
@@ -64,25 +64,51 @@ export async function enforcePaidPlan(
     if (!res.ok) {
       return new Response(
         JSON.stringify({ error: "Could not verify plan." }),
-        { status: 502, headers: { "Content-Type": "application/json", ...CORS_HEADERS } }
+        { status: 502, headers: { "Content-Type": "application/json", ...CORS } }
       );
     }
 
     const rows = await res.json();
+    const orgId: string | undefined = rows[0]?.organization_id;
     const plan: string = rows[0]?.organizations?.plan ?? "starter";
 
     if (plan === "starter") {
       return new Response(
         JSON.stringify({ error: "AI features require the Growth plan. Upgrade in Settings → Account." }),
-        { status: 403, headers: { "Content-Type": "application/json", ...CORS_HEADERS } }
+        { status: 403, headers: { "Content-Type": "application/json", ...CORS } }
       );
     }
 
-    return null; // caller is on growth or enterprise — allow through
+    // Rate limit: atomically increment today's request count and check the limit.
+    if (orgId) {
+      const limitRes = await fetch(
+        `${SUPABASE_URL}/rest/v1/rpc/check_and_increment_ai_usage`,
+        {
+          method: "POST",
+          headers: {
+            "Authorization": `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+            "apikey": SUPABASE_SERVICE_ROLE_KEY,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ p_org_id: orgId, p_daily_limit: AI_DAILY_LIMIT }),
+        }
+      );
+      if (limitRes.ok) {
+        const allowed = await limitRes.json();
+        if (!allowed) {
+          return new Response(
+            JSON.stringify({ error: "Daily AI request limit reached. Try again tomorrow." }),
+            { status: 429, headers: { "Content-Type": "application/json", ...CORS } }
+          );
+        }
+      }
+    }
+
+    return null; // caller is on a paid plan and within limits — allow through
   } catch {
     return new Response(
       JSON.stringify({ error: "Could not verify plan." }),
-      { status: 500, headers: { "Content-Type": "application/json", ...CORS_HEADERS } }
+      { status: 500, headers: { "Content-Type": "application/json", ...CORS } }
     );
   }
 }

--- a/supabase/functions/generate-checklist/index.ts
+++ b/supabase/functions/generate-checklist/index.ts
@@ -3,14 +3,9 @@
 // Called by BuildWithAIModal (mode: "text") and ConvertFileModal (mode: "file" | "document").
 
 import { enforcePaidPlan } from "../_shared/plan-guard.ts";
+import { corsHeaders } from "../_shared/cors.ts";
 
 const ANTHROPIC_API_KEY = Deno.env.get("ANTHROPIC_API_KEY");
-
-const CORS_HEADERS = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
-  "Access-Control-Allow-Methods": "POST, OPTIONS",
-};
 
 const SYSTEM_PROMPT = `You are a hospitality operations expert. Generate a checklist as a JSON object.
 
@@ -54,18 +49,20 @@ GENERAL:
 • Omit fields that are not needed (no "config" unless temperature, no "choices" unless multiple_choice).`;
 
 Deno.serve(async (req) => {
+  const CORS = corsHeaders(req.headers.get("origin"));
+
   // Handle CORS preflight
   if (req.method === "OPTIONS") {
-    return new Response("ok", { headers: CORS_HEADERS });
+    return new Response("ok", { headers: CORS });
   }
 
-  const planBlock = await enforcePaidPlan(req.headers.get("authorization"));
+  const planBlock = await enforcePaidPlan(req.headers.get("authorization"), req.headers.get("origin"));
   if (planBlock) return planBlock;
 
   if (!ANTHROPIC_API_KEY) {
     return new Response(
       JSON.stringify({ error: "ANTHROPIC_API_KEY is not configured" }),
-      { status: 500, headers: { "Content-Type": "application/json", ...CORS_HEADERS } }
+      { status: 500, headers: { "Content-Type": "application/json", ...CORS } }
     );
   }
 
@@ -110,7 +107,7 @@ Deno.serve(async (req) => {
     } else {
       return new Response(
         JSON.stringify({ error: "Provide either prompt (text mode) or content/fileBase64 (file/document mode)" }),
-        { status: 400, headers: { "Content-Type": "application/json", ...CORS_HEADERS } }
+        { status: 400, headers: { "Content-Type": "application/json", ...CORS } }
       );
     }
 
@@ -138,7 +135,7 @@ Deno.serve(async (req) => {
       // letting the actual Anthropic error reach the frontend.
       return new Response(
         JSON.stringify({ error: `Anthropic ${anthropicRes.status}: ${err}` }),
-        { headers: { "Content-Type": "application/json", ...CORS_HEADERS } }
+        { headers: { "Content-Type": "application/json", ...CORS } }
       );
     }
 
@@ -160,14 +157,14 @@ Deno.serve(async (req) => {
     }
 
     return new Response(JSON.stringify(parsed), {
-      headers: { "Content-Type": "application/json", ...CORS_HEADERS },
+      headers: { "Content-Type": "application/json", ...CORS },
     });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : "Internal error";
     // Return 200 so Supabase puts the body in data (not fnError), letting the real error reach the frontend
     return new Response(
       JSON.stringify({ error: message }),
-      { headers: { "Content-Type": "application/json", ...CORS_HEADERS } }
+      { headers: { "Content-Type": "application/json", ...CORS } }
     );
   }
 });

--- a/supabase/functions/generate-training/index.ts
+++ b/supabase/functions/generate-training/index.ts
@@ -3,14 +3,9 @@
 
 import { buildTrainingPrompt, parseTrainingModule, type TrainingCategory } from "./training.ts";
 import { enforcePaidPlan } from "../_shared/plan-guard.ts";
+import { corsHeaders } from "../_shared/cors.ts";
 
 const ANTHROPIC_API_KEY = Deno.env.get("ANTHROPIC_API_KEY");
-
-const CORS_HEADERS = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
-  "Access-Control-Allow-Methods": "POST, OPTIONS",
-};
 
 const SYSTEM_PROMPT = `You are a hospitality training specialist. Generate a practical training module as JSON.
 
@@ -31,18 +26,20 @@ Rules:
 - duration should be realistic, such as 5 min or 8 min`;
 
 Deno.serve(async (req) => {
+  const CORS = corsHeaders(req.headers.get("origin"));
+
   if (req.method === "OPTIONS") {
-    return new Response("ok", { headers: CORS_HEADERS });
+    return new Response("ok", { headers: CORS });
   }
 
   if (!ANTHROPIC_API_KEY) {
     return new Response(
       JSON.stringify({ error: "ANTHROPIC_API_KEY is not configured" }),
-      { status: 500, headers: { "Content-Type": "application/json", ...CORS_HEADERS } }
+      { status: 500, headers: { "Content-Type": "application/json", ...CORS } }
     );
   }
 
-  const planBlock = await enforcePaidPlan(req.headers.get("authorization"));
+  const planBlock = await enforcePaidPlan(req.headers.get("authorization"), req.headers.get("origin"));
   if (planBlock) return planBlock;
 
   try {
@@ -55,7 +52,7 @@ Deno.serve(async (req) => {
     if (!prompt || !prompt.trim()) {
       return new Response(
         JSON.stringify({ error: "Provide a prompt" }),
-        { status: 400, headers: { "Content-Type": "application/json", ...CORS_HEADERS } }
+        { status: 400, headers: { "Content-Type": "application/json", ...CORS } }
       );
     }
 
@@ -80,7 +77,7 @@ Deno.serve(async (req) => {
       const err = await anthropicRes.text();
       return new Response(
         JSON.stringify({ error: `Anthropic API error (${anthropicRes.status}): ${err}` }),
-        { status: 502, headers: { "Content-Type": "application/json", ...CORS_HEADERS } }
+        { status: 502, headers: { "Content-Type": "application/json", ...CORS } }
       );
     }
 
@@ -89,13 +86,13 @@ Deno.serve(async (req) => {
     const parsed = parseTrainingModule(rawText);
 
     return new Response(JSON.stringify(parsed), {
-      headers: { "Content-Type": "application/json", ...CORS_HEADERS },
+      headers: { "Content-Type": "application/json", ...CORS },
     });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : "Internal error";
     return new Response(
       JSON.stringify({ error: message }),
-      { status: 500, headers: { "Content-Type": "application/json", ...CORS_HEADERS } }
+      { status: 500, headers: { "Content-Type": "application/json", ...CORS } }
     );
   }
 });

--- a/supabase/functions/infohub-ai-tools/index.ts
+++ b/supabase/functions/infohub-ai-tools/index.ts
@@ -2,14 +2,9 @@
 // Generates Infohub study outputs from document/training content.
 
 import { enforcePaidPlan } from "../_shared/plan-guard.ts";
+import { corsHeaders } from "../_shared/cors.ts";
 
 const ANTHROPIC_API_KEY = Deno.env.get("ANTHROPIC_API_KEY");
-
-const CORS_HEADERS = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
-  "Access-Control-Allow-Methods": "POST, OPTIONS",
-};
 
 const SHARED_PROMPT = `You are an expert hospitality trainer helping staff learn Infohub content.
 Return only valid JSON, no markdown, no code fences, no explanation.`;
@@ -86,18 +81,20 @@ function parseJson(text: string) {
 }
 
 Deno.serve(async (req) => {
+  const CORS = corsHeaders(req.headers.get("origin"));
+
   if (req.method === "OPTIONS") {
-    return new Response("ok", { headers: CORS_HEADERS });
+    return new Response("ok", { headers: CORS });
   }
 
   if (!ANTHROPIC_API_KEY) {
     return new Response(
       JSON.stringify({ error: "ANTHROPIC_API_KEY is not configured" }),
-      { status: 500, headers: { "Content-Type": "application/json", ...CORS_HEADERS } }
+      { status: 500, headers: { "Content-Type": "application/json", ...CORS } }
     );
   }
 
-  const planBlock = await enforcePaidPlan(req.headers.get("authorization"));
+  const planBlock = await enforcePaidPlan(req.headers.get("authorization"), req.headers.get("origin"));
   if (planBlock) return planBlock;
 
   try {
@@ -109,7 +106,7 @@ Deno.serve(async (req) => {
     if (!action || !title || !content) {
       return new Response(
         JSON.stringify({ error: "Provide action, title, and content" }),
-        { status: 400, headers: { "Content-Type": "application/json", ...CORS_HEADERS } }
+        { status: 400, headers: { "Content-Type": "application/json", ...CORS } }
       );
     }
 
@@ -132,7 +129,7 @@ Deno.serve(async (req) => {
       const err = await anthropicRes.text();
       return new Response(
         JSON.stringify({ error: `Anthropic API error (${anthropicRes.status}): ${err}` }),
-        { status: 502, headers: { "Content-Type": "application/json", ...CORS_HEADERS } }
+        { status: 502, headers: { "Content-Type": "application/json", ...CORS } }
       );
     }
 
@@ -141,13 +138,13 @@ Deno.serve(async (req) => {
     const parsed = parseJson(rawText);
 
     return new Response(JSON.stringify(parsed), {
-      headers: { "Content-Type": "application/json", ...CORS_HEADERS },
+      headers: { "Content-Type": "application/json", ...CORS },
     });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : "Internal error";
     return new Response(
       JSON.stringify({ error: message }),
-      { status: 500, headers: { "Content-Type": "application/json", ...CORS_HEADERS } }
+      { status: 500, headers: { "Content-Type": "application/json", ...CORS } }
     );
   }
 });

--- a/supabase/functions/invite-team-member/index.ts
+++ b/supabase/functions/invite-team-member/index.ts
@@ -16,6 +16,7 @@
  */
 
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2?target=denonext";
+import { corsHeaders } from "../_shared/cors.ts";
 
 const SUPABASE_URL              = Deno.env.get("SUPABASE_URL")!;
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
@@ -23,26 +24,22 @@ const RESEND_API_KEY            = Deno.env.get("RESEND_API_KEY");
 const INVITE_FROM_EMAIL         = Deno.env.get("INVITE_FROM_EMAIL") ?? "onboarding@resend.dev";
 const RESEND_ENDPOINT           = "https://api.resend.com/emails";
 
-const CORS_HEADERS = {
-  "Access-Control-Allow-Origin":  "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
-  "Access-Control-Allow-Methods": "POST, OPTIONS",
-};
-
-const ok  = (body: unknown) =>
-  new Response(JSON.stringify(body), {
-    status: 200,
-    headers: { "Content-Type": "application/json", ...CORS_HEADERS },
-  });
-
-const err = (message: string) =>
-  new Response(JSON.stringify({ error: message }), {
-    status: 200,
-    headers: { "Content-Type": "application/json", ...CORS_HEADERS },
-  });
-
 Deno.serve(async (req: Request): Promise<Response> => {
-  if (req.method === "OPTIONS") return new Response("ok", { headers: CORS_HEADERS });
+  const CORS = corsHeaders(req.headers.get("origin"));
+
+  const ok  = (body: unknown) =>
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "Content-Type": "application/json", ...CORS },
+    });
+
+  const err = (message: string) =>
+    new Response(JSON.stringify({ error: message }), {
+      status: 200,
+      headers: { "Content-Type": "application/json", ...CORS },
+    });
+
+  if (req.method === "OPTIONS") return new Response("ok", { headers: CORS });
   if (req.method !== "POST")    return err("Method not allowed");
 
   // ── Authenticate caller ─────────────────────────────────────────────

--- a/supabase/migrations/20260521000003_ai_usage_rate_limit.sql
+++ b/supabase/migrations/20260521000003_ai_usage_rate_limit.sql
@@ -1,0 +1,50 @@
+-- ================================================================
+-- Per-org daily AI request tracking for rate limiting.
+--
+-- The plan-guard edge function calls check_and_increment_ai_usage
+-- via the service role on every AI request. The function atomically
+-- increments today's count and returns false once the daily limit
+-- is exceeded, causing the edge function to return 429.
+--
+-- Default limit: 100 requests per org per day (configurable via the
+-- AI_DAILY_LIMIT secret on the edge function environment).
+-- ================================================================
+
+CREATE TABLE public.ai_usage (
+  organization_id uuid    NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  usage_date      date    NOT NULL DEFAULT CURRENT_DATE,
+  request_count   integer NOT NULL DEFAULT 0,
+  PRIMARY KEY (organization_id, usage_date)
+);
+
+-- Accessible only via service_role (plan-guard). No client policies needed.
+ALTER TABLE public.ai_usage ENABLE ROW LEVEL SECURITY;
+
+-- Atomically upsert today's row and return whether the org is still
+-- within its daily limit. Increments before checking so the counter
+-- is always accurate; at most one request may slip past the exact limit
+-- under concurrent load, which is acceptable for a daily soft cap.
+CREATE OR REPLACE FUNCTION public.check_and_increment_ai_usage(
+  p_org_id      uuid,
+  p_daily_limit integer DEFAULT 100
+)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_count integer;
+BEGIN
+  INSERT INTO public.ai_usage (organization_id, usage_date, request_count)
+  VALUES (p_org_id, CURRENT_DATE, 1)
+  ON CONFLICT (organization_id, usage_date)
+  DO UPDATE SET request_count = ai_usage.request_count + 1
+  RETURNING request_count INTO v_count;
+
+  RETURN v_count <= p_daily_limit;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.check_and_increment_ai_usage(uuid, integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.check_and_increment_ai_usage(uuid, integer) TO service_role;


### PR DESCRIPTION
## Summary

- **Dynamic CORS** — new `_shared/cors.ts` helper reads `CORS_ALLOWED_ORIGINS` from Supabase secrets (comma-separated, e.g. `https://myapp.com,capacitor://localhost`). Falls back to `*` when unset (dev default). All four edge functions now send the correct `Access-Control-Allow-Origin` per request instead of a blanket wildcard.

- **Per-org AI rate limiting** — `ai_usage` table + `check_and_increment_ai_usage` RPC atomically upserts today's request count. `plan-guard.ts` calls it after the plan check and returns **429** when the org exceeds the daily limit. Configurable via `AI_DAILY_LIMIT` secret (default: 100 requests/org/day). The organisation ID is now fetched alongside the plan in a single query.

- **CLAUDE.md** — removed two stale entries: Infohub has been Supabase-backed since `useInfohubContent` was written; "Build with AI / Convert File not built" is no longer true.

## Setup required after merge

Set these secrets in Supabase Dashboard → Settings → Edge Functions:
| Secret | Value |
|---|---|
| `CORS_ALLOWED_ORIGINS` | Your production domain(s), e.g. `https://dorabuilds.github.io,capacitor://localhost` |
| `AI_DAILY_LIMIT` | Optional override, default `100` |

## Test plan

- [ ] OPTIONS preflight from an allowed origin returns `Access-Control-Allow-Origin: <origin>`
- [ ] OPTIONS preflight from an unknown origin returns `Access-Control-Allow-Origin: null`
- [ ] AI request from a Growth-plan org succeeds under the daily limit
- [ ] 101st AI request from the same org on the same day returns 429
- [ ] Counter resets the next calendar day
- [ ] Starter-plan orgs still get 403 before hitting the rate limit check

🤖 Generated with [Claude Code](https://claude.com/claude-code)