### PR TITLE
Set up custom domain oliahq.com

### DIFF
--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+oliahq.com

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,12 +3,9 @@ import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import { componentTagger } from "lovable-tagger";
 
-const repoName = process.env.GITHUB_REPOSITORY?.split("/")[1];
-const productionBasePath = process.env.VITE_BASE_PATH ?? (repoName ? `/${repoName}/` : "/");
-
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
-  base: mode === "production" ? productionBasePath : "/",
+  base: "/",
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- Add `public/CNAME` with `oliahq.com` so GitHub Pages preserves the custom domain on every deploy
- Simplify `vite.config.ts` base to `"/"` — with a custom domain the app lives at the root, not `/olia-your-daily-operations/`

## Test plan
- [ ] Merge and confirm GitHub Actions deploy succeeds
- [ ] In repo Settings → Pages, set custom domain to `oliahq.com` and enforce HTTPS
- [ ] Verify `https://oliahq.com` loads the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)