### PR TITLE
fix: custom domain oliahq.com + replace Lovable favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,10 @@
          including the notch / Dynamic Island / home indicator on iOS -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
 
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <link rel="icon" href="/favicon.ico" sizes="any" />
+    <link rel="apple-touch-icon" href="/brand/logo/olia-app-icon.svg" />
+
     <title>Olia</title>
     <meta name="description" content="Olia — Your daily operations, streamlined." />
 

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+oliahq.com

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,14 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="faviconStroke" x1="10" y1="51" x2="55" y2="14" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#B05DFF"/>
+      <stop offset="0.5" stop-color="#7A68FF"/>
+      <stop offset="1" stop-color="#4AA8FF"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="16" fill="#050608"/>
+  <circle cx="32" cy="32" r="20" stroke="url(#faviconStroke)" stroke-width="2.6"/>
+  <circle cx="32" cy="32" r="15" stroke="url(#faviconStroke)" stroke-width="2.6" opacity="0.9"/>
+  <circle cx="32" cy="32" r="10" stroke="#FFFFFF" stroke-width="2.6"/>
+</svg>
+

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,12 +3,9 @@ import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import { componentTagger } from "lovable-tagger";
 
-const repoName = process.env.GITHUB_REPOSITORY?.split("/")[1];
-const productionBasePath = process.env.VITE_BASE_PATH ?? (repoName ? `/${repoName}/` : "/");
-
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
-  base: mode === "production" ? productionBasePath : "/",
+  base: "/",
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary

- **Custom domain** — sets up oliahq.com (CNAME already in place)
- **Favicon** — replaces the default Lovable heart with the Olia brand mark (`olia-favicon.svg`: dark rounded square with concentric gradient rings). Adds proper `<link rel="icon">` tags for SVG (modern browsers), ICO fallback, and `apple-touch-icon`.

## Test plan

- [ ] oliahq.com shows the Olia mark in the browser tab (not the Lovable heart)
- [ ] iOS "Add to Home Screen" uses the correct app icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)