### PR TITLE
fix: 404 redirect loop on direct navigation to /login and other routes

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -6,25 +6,17 @@
     <title>Olia</title>
     <script>
       (function () {
-        var pathname = window.location.pathname;
-        var firstRouteSlash = pathname.indexOf("/", 1);
-        var basePath = firstRouteSlash === -1 ? pathname.replace(/\/$/, "") : pathname.slice(0, firstRouteSlash);
-        var route = firstRouteSlash === -1 ? "/" : pathname.slice(firstRouteSlash);
+        var path = window.location.pathname;
         var search = window.location.search || "";
         var hash = window.location.hash || "";
-        var searchParams = new URLSearchParams(search);
 
-        if (route === "/") {
-          window.location.replace(basePath + "/");
+        // Already carrying a ?p= param — just go to root so the app can read it
+        if (new URLSearchParams(search).get("p") !== null) {
+          window.location.replace("/" + search + hash);
           return;
         }
 
-        if (searchParams.get("p") !== null) {
-          window.location.replace(basePath + "/" + search + hash);
-          return;
-        }
-
-        window.location.replace(basePath + "/?p=" + encodeURIComponent(route + search + hash));
+        window.location.replace("/?p=" + encodeURIComponent(path + search + hash));
       })();
     </script>
   </head>


### PR DESCRIPTION
## Problem

Navigating directly to `oliahq.com/login` (or any deep link) returns a 404 and never recovers.

**Root cause:** The `404.html` redirect script had sub-path detection logic designed for `username.github.io/repo/` deployments. With a custom domain at root, visiting `/login` caused the script to misidentify `/login` as the base path and `/` as the route — triggering a redirect back to `/login/`, which is another 404, creating an infinite loop.

## Fix

Simplified `public/404.html` to always redirect `/?p=<encoded-path>`. The existing `restoreGitHubPagesRoute` in `main.tsx` already handles decoding this correctly — no other changes needed.

**Before:**
- `/login` → 404.html → detects basePath=`/login`, route=`/` → redirects to `/login/` → 404 → loop

**After:**
- `/login` → 404.html → redirects to `/?p=%2Flogin` → `index.html` loads → React restores path → `/login` renders ✓

## Test plan
- [ ] Navigate directly to `oliahq.com/login` — should show the login page
- [ ] Navigate directly to `oliahq.com/dashboard` — should redirect to login (protected route)
- [ ] Navigate directly to `oliahq.com/signup` — should show signup page
- [ ] Refresh the page on any deep route — should stay on that route

🤖 Generated with [Claude Code](https://claude.com/claude-code)