### PR TITLE
fix: use React Router Link for all landing page navigation

### DIFF
--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { Link } from "react-router-dom";
 
 const css = `
   @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,600;1,400;1,500&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500;9..40,600&display=swap');
@@ -548,9 +549,9 @@ export default function Landing() {
             <li><a href="#pricing">Pricing</a></li>
           </ul>
           <div className="ol-nav-actions">
-            <a href="/login" className="ol-signin">Sign in</a>
+            <Link to="/login" className="ol-signin">Sign in</Link>
             <a href="#" className="ol-btn-ghost">Book a demo</a>
-            <a href="/signup" className="ol-btn-solid">Get started</a>
+            <Link to="/signup" className="ol-btn-solid">Get started</Link>
           </div>
         </div>
       </nav>
@@ -562,7 +563,7 @@ export default function Landing() {
             <h1>Run every shift<br />the same way —<br /><em>every time.</em></h1>
             <p className="ol-hero-sub">Olia replaces paper checklists and WhatsApp chasing with a simple system your team actually uses.</p>
             <div className="ol-hero-ctas">
-              <a href="/signup" className="ol-btn-hero">Set up your first checklist →</a>
+              <Link to="/signup" className="ol-btn-hero">Set up your first checklist →</Link>
               <a href="#" className="ol-btn-hero-ghost">Book a demo</a>
             </div>
             <p className="ol-hero-note">Starter from €49 · per location · no per-user fees</p>
@@ -729,7 +730,7 @@ export default function Landing() {
               <ul className="ol-pfeats">
                 {["Up to 3 checklists","Compliance temperature logging","Issue reporting","Kiosk access, unlimited staff","30-day data history","Email support"].map((f) => <li key={f}><PCheck />{f}</li>)}
               </ul>
-              <a href="/signup" className="ol-pbtn ol-pbtn-outline">Start with Starter</a>
+              <Link to="/signup" className="ol-pbtn ol-pbtn-outline">Start with Starter</Link>
             </div>
             <div className="ol-pcard featured ol-fade ol-d1">
               <div className="ol-pbadge">Most popular</div>
@@ -740,7 +741,7 @@ export default function Landing() {
               <ul className="ol-pfeats">
                 {["Unlimited checklists","Full compliance suite","Issue tracking","Reporting & analytics","Multi-location dashboard (up to 10)","12-month data retention","Priority support"].map((f) => <li key={f}><PCheck />{f}</li>)}
               </ul>
-              <a href="/signup" className="ol-pbtn ol-pbtn-gold">Start with Growth</a>
+              <Link to="/signup" className="ol-pbtn ol-pbtn-gold">Start with Growth</Link>
             </div>
             <div className="ol-pcard ol-fade ol-d2">
               <div className="ol-pname">Enterprise</div>
@@ -763,7 +764,7 @@ export default function Landing() {
           <h2 className="ol-fade">Ready to stop chasing<br />your team on WhatsApp?</h2>
           <p className="ol-cta-sub ol-fade">Set up your first checklist today. Most venues are running in under an hour.</p>
           <div className="ol-cta-btns ol-fade">
-            <a href="/signup" className="ol-btn-cream">Set up your first checklist →</a>
+            <Link to="/signup" className="ol-btn-cream">Set up your first checklist →</Link>
             <a href="#" className="ol-btn-outline-light">Book a demo</a>
           </div>
           <p className="ol-cta-fine ol-fade">No long-term contract. No setup fee.</p>
@@ -781,7 +782,7 @@ export default function Landing() {
             <a href="#features">Features</a>
             <a href="#pricing">Pricing</a>
             <a href="#">Book a demo</a>
-            <a href="/login">Sign in</a>
+            <Link to="/login">Sign in</Link>
             <a href="#">Privacy</a>
             <a href="#">Terms</a>
           </div>


### PR DESCRIPTION
## Problem

All navigation links on the landing page used plain `<a href>` tags, which force a full-page reload. In a GitHub Pages SPA, those reloads hit GitHub's server, return a 404, and rely on the `404.html` redirect script to recover. For reasons that were hard to reproduce (CDN caching, browser quirks, timing), users reported these buttons doing nothing or behaving unexpectedly.

## Fix

Replace all `<a href="/login">` and `<a href="/signup">` with React Router `<Link to="...">`. This does client-side navigation — no server round-trip, no 404.html redirect needed, works instantly.

`href="#"` placeholder links (Book a demo, Contact sales, etc.) are left as plain `<a>` tags since they have no destination yet.

## Changes
- `src/pages/Landing.tsx`: add `Link` import, 7 links converted

## Test plan
- [ ] Click "Sign in" → goes to `/login` (login form)
- [ ] Click "Get started" → goes to `/signup`
- [ ] Click "Set up your first checklist →" (hero + CTA) → goes to `/signup`
- [ ] Click "Start with Starter" / "Start with Growth" (pricing) → goes to `/signup`
- [ ] Click "Sign in" (footer) → goes to `/login`
- [ ] "Book a demo" stays on page (href="#")

🤖 Generated with [Claude Code](https://claude.com/claude-code)