### PR TITLE
feat: Book a demo form → Supabase lead capture + email notification

### DIFF
--- a/src/components/landing/DemoModal.tsx
+++ b/src/components/landing/DemoModal.tsx
@@ -1,0 +1,175 @@
+import { useState, useEffect, useRef } from "react";
+import { X, CalendarDays, CheckCircle2 } from "lucide-react";
+import { supabase } from "@/lib/supabase";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+type State = "idle" | "submitting" | "success" | "error";
+
+export function DemoModal({ open, onClose }: Props) {
+  const [name, setName]       = useState("");
+  const [email, setEmail]     = useState("");
+  const [venue, setVenue]     = useState("");
+  const [state, setState]     = useState<State>("idle");
+  const [errorMsg, setErrorMsg] = useState("");
+  const nameRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (open) setTimeout(() => nameRef.current?.focus(), 50);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) {
+      setState("idle");
+      setName("");
+      setEmail("");
+      setVenue("");
+      setErrorMsg("");
+    }
+  }, [open]);
+
+  if (!open) return null;
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setState("submitting");
+
+    const { error } = await supabase.from("demo_requests").insert({
+      name:       name.trim(),
+      email:      email.trim(),
+      venue_name: venue.trim() || null,
+    });
+
+    if (error) {
+      console.error("demo_requests insert:", error);
+      setErrorMsg("Something went wrong. Please email dora@oliahq.com directly.");
+      setState("error");
+    } else {
+      setState("success");
+    }
+  }
+
+  const inputClass =
+    "w-full bg-background border border-border rounded-xl px-4 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-sage/30 focus:border-sage/50 transition-colors";
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 z-50 bg-black/40 backdrop-blur-sm"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="demo-modal-title"
+        className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      >
+        <div className="relative w-full max-w-md bg-card rounded-2xl shadow-xl border border-border p-6 sm:p-8">
+          <button
+            onClick={onClose}
+            className="absolute top-4 right-4 text-muted-foreground hover:text-foreground transition-colors"
+            aria-label="Close"
+          >
+            <X size={20} />
+          </button>
+
+          {state === "success" ? (
+            <div className="text-center py-4">
+              <CheckCircle2 size={48} className="mx-auto mb-4" style={{ color: "hsl(var(--sage))" }} />
+              <h2 className="font-display text-2xl text-foreground mb-2">You're on the list</h2>
+              <p className="text-muted-foreground text-sm">
+                Thanks, {name.split(" ")[0]}! I'll reach out within one business day.
+              </p>
+              <button
+                onClick={onClose}
+                className="mt-6 inline-flex items-center justify-center font-semibold px-6 py-3 rounded-xl hover:opacity-90 transition-opacity text-white"
+                style={{ background: "hsl(var(--sage))" }}
+              >
+                Done
+              </button>
+            </div>
+          ) : (
+            <>
+              <div className="mb-6">
+                <div className="flex items-center gap-2 mb-1.5">
+                  <CalendarDays size={18} className="text-muted-foreground" />
+                  <h2 id="demo-modal-title" className="font-display text-2xl text-foreground">
+                    Book a demo
+                  </h2>
+                </div>
+                <p className="text-sm text-muted-foreground">
+                  I'll reach out within one business day to find a time.
+                </p>
+              </div>
+
+              <form onSubmit={handleSubmit} className="space-y-4">
+                <div>
+                  <label htmlFor="demo-name" className="block text-sm font-medium text-foreground mb-1.5">
+                    Your name
+                  </label>
+                  <input
+                    ref={nameRef}
+                    id="demo-name"
+                    type="text"
+                    required
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    placeholder="Jane Smith"
+                    className={inputClass}
+                  />
+                </div>
+
+                <div>
+                  <label htmlFor="demo-email" className="block text-sm font-medium text-foreground mb-1.5">
+                    Work email
+                  </label>
+                  <input
+                    id="demo-email"
+                    type="email"
+                    required
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    placeholder="jane@yourvenue.com"
+                    className={inputClass}
+                  />
+                </div>
+
+                <div>
+                  <label htmlFor="demo-venue" className="block text-sm font-medium text-foreground mb-1.5">
+                    Venue or property name
+                    <span className="text-muted-foreground font-normal ml-1">(optional)</span>
+                  </label>
+                  <input
+                    id="demo-venue"
+                    type="text"
+                    value={venue}
+                    onChange={(e) => setVenue(e.target.value)}
+                    placeholder="The Grand Hotel"
+                    className={inputClass}
+                  />
+                </div>
+
+                {state === "error" && (
+                  <p className="text-sm text-destructive">{errorMsg}</p>
+                )}
+
+                <button
+                  type="submit"
+                  disabled={state === "submitting"}
+                  className="w-full font-semibold py-3 rounded-xl hover:opacity-90 transition-opacity disabled:opacity-60 text-white"
+                  style={{ background: "hsl(var(--sage))" }}
+                >
+                  {state === "submitting" ? "Sending…" : "Request a demo"}
+                </button>
+              </form>
+            </>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/landing/FinalCtaSection.tsx
+++ b/src/components/landing/FinalCtaSection.tsx
@@ -1,7 +1,7 @@
 import { Link } from "react-router-dom";
 import { ArrowRight, CalendarDays } from "lucide-react";
 
-export function FinalCtaSection() {
+export function FinalCtaSection({ onBookDemo }: { onBookDemo?: () => void }) {
   return (
     <section className="py-20 sm:py-28" style={{ background: "hsl(var(--sage))" }}>
       <div className="max-w-3xl mx-auto px-4 sm:px-6 text-center">
@@ -25,13 +25,13 @@ export function FinalCtaSection() {
             Set up your first checklist
             <ArrowRight size={16} />
           </Link>
-          <a
-            href="mailto:hello@useolia.com?subject=Demo request"
+          <button
+            onClick={onBookDemo}
             className="w-full sm:w-auto inline-flex items-center justify-center gap-2 border border-white/25 text-white font-medium text-base px-7 py-3.5 rounded-2xl hover:bg-white/10 transition-colors"
           >
             <CalendarDays size={16} className="opacity-70" />
             Book a demo
-          </a>
+          </button>
         </div>
 
         {/* Trust trio */}

--- a/src/components/landing/HeroSection.tsx
+++ b/src/components/landing/HeroSection.tsx
@@ -2,7 +2,7 @@ import { Link } from "react-router-dom";
 import { ArrowRight, CalendarDays } from "lucide-react";
 import { KioskMock } from "./KioskMock";
 
-export function HeroSection() {
+export function HeroSection({ onBookDemo }: { onBookDemo?: () => void }) {
   return (
     <section className="bg-background overflow-hidden">
       <div className="max-w-6xl mx-auto px-4 sm:px-6 pt-16 pb-20 lg:pt-24 lg:pb-28">
@@ -35,13 +35,13 @@ export function HeroSection() {
                 Set up your first checklist
                 <ArrowRight size={16} />
               </Link>
-              <a
-                href="mailto:hello@useolia.com?subject=Demo request"
+              <button
+                onClick={onBookDemo}
                 className="w-full sm:w-auto inline-flex items-center justify-center gap-2 bg-card border border-border text-foreground text-base font-medium px-6 py-3.5 rounded-2xl hover:bg-background transition-colors"
               >
                 <CalendarDays size={16} className="text-muted-foreground" />
                 Book a demo
-              </a>
+              </button>
             </div>
 
             {/* Trust line */}

--- a/src/components/landing/LandingFooter.tsx
+++ b/src/components/landing/LandingFooter.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
 
-export function LandingFooter() {
+export function LandingFooter({ onBookDemo }: { onBookDemo?: () => void }) {
   return (
     <footer className="border-t border-border bg-background">
       <div className="max-w-6xl mx-auto px-4 sm:px-6 py-12">
@@ -20,12 +20,12 @@ export function LandingFooter() {
             <a href="#pricing" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
               Pricing
             </a>
-            <a
-              href="mailto:hello@useolia.com?subject=Demo request"
+            <button
+              onClick={onBookDemo}
               className="text-sm text-muted-foreground hover:text-foreground transition-colors"
             >
               Book a demo
-            </a>
+            </button>
             <a
               href="mailto:hello@useolia.com"
               className="text-sm text-muted-foreground hover:text-foreground transition-colors"

--- a/src/components/landing/LandingNav.tsx
+++ b/src/components/landing/LandingNav.tsx
@@ -1,7 +1,7 @@
 import { Link } from "react-router-dom";
 import { ArrowRight } from "lucide-react";
 
-export function LandingNav() {
+export function LandingNav({ onBookDemo }: { onBookDemo?: () => void }) {
   return (
     <header className="sticky top-0 z-50 bg-background/95 backdrop-blur-sm border-b border-border">
       <div className="max-w-6xl mx-auto px-4 sm:px-6 h-16 flex items-center justify-between gap-4">
@@ -43,12 +43,12 @@ export function LandingNav() {
           >
             Sign in
           </Link>
-          <a
-            href="mailto:hello@useolia.com?subject=Demo request"
+          <button
+            onClick={onBookDemo}
             className="hidden sm:inline-flex text-sm font-medium text-muted-foreground hover:text-foreground transition-colors px-3 py-2 rounded-lg"
           >
             Book a demo
-          </a>
+          </button>
           <Link
             to="/signup"
             className="inline-flex items-center gap-1.5 text-sm font-semibold bg-sage text-white px-4 py-2.5 rounded-xl hover:opacity-90 transition-opacity"

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
+import { DemoModal } from "@/components/landing/DemoModal";
 
 const css = `
   @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,600;1,400;1,500&family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500;9..40,600&display=swap');
@@ -500,6 +501,8 @@ const KIOSK_TASKS = [
 export default function Landing() {
   const navRef = useRef<HTMLElement>(null);
   const [completed, setCompleted] = useState(0);
+  const [demoOpen, setDemoOpen] = useState(false);
+  const openDemo = (e: React.MouseEvent) => { e.preventDefault(); setDemoOpen(true); };
   const total = KIOSK_TASKS.length;
 
   useEffect(() => {
@@ -550,7 +553,7 @@ export default function Landing() {
           </ul>
           <div className="ol-nav-actions">
             <Link to="/login" className="ol-signin">Sign in</Link>
-            <a href="#" className="ol-btn-ghost">Book a demo</a>
+            <a href="#" className="ol-btn-ghost" onClick={openDemo}>Book a demo</a>
             <Link to="/signup" className="ol-btn-solid">Get started</Link>
           </div>
         </div>
@@ -564,7 +567,7 @@ export default function Landing() {
             <p className="ol-hero-sub">Olia replaces paper checklists and WhatsApp chasing with a simple system your team actually uses.</p>
             <div className="ol-hero-ctas">
               <Link to="/signup" className="ol-btn-hero">Set up your first checklist →</Link>
-              <a href="#" className="ol-btn-hero-ghost">Book a demo</a>
+              <a href="#" className="ol-btn-hero-ghost" onClick={openDemo}>Book a demo</a>
             </div>
             <p className="ol-hero-note">Starter from €49 · per location · no per-user fees</p>
           </div>
@@ -765,7 +768,7 @@ export default function Landing() {
           <p className="ol-cta-sub ol-fade">Set up your first checklist today. Most venues are running in under an hour.</p>
           <div className="ol-cta-btns ol-fade">
             <Link to="/signup" className="ol-btn-cream">Set up your first checklist →</Link>
-            <a href="#" className="ol-btn-outline-light">Book a demo</a>
+            <a href="#" className="ol-btn-outline-light" onClick={openDemo}>Book a demo</a>
           </div>
           <p className="ol-cta-fine ol-fade">No long-term contract. No setup fee.</p>
         </div>
@@ -781,7 +784,7 @@ export default function Landing() {
             <a href="#how">How it works</a>
             <a href="#features">Features</a>
             <a href="#pricing">Pricing</a>
-            <a href="#">Book a demo</a>
+            <a href="#" onClick={openDemo}>Book a demo</a>
             <Link to="/login">Sign in</Link>
             <a href="#">Privacy</a>
             <a href="#">Terms</a>
@@ -789,6 +792,7 @@ export default function Landing() {
           <p className="ol-footer-copy">© 2026 Olia. All rights reserved.</p>
         </div>
       </footer>
+      <DemoModal open={demoOpen} onClose={() => setDemoOpen(false)} />
     </div>
   );
 }

--- a/supabase/functions/notify-demo-request/index.ts
+++ b/supabase/functions/notify-demo-request/index.ts
@@ -1,0 +1,111 @@
+/**
+ * notify-demo-request
+ *
+ * Called by the Postgres trigger `trg_notify_demo_request` via pg_net
+ * whenever a new row is inserted into public.demo_requests.
+ *
+ * Required secrets — all already set, nothing new to add:
+ *   RESEND_API_KEY  → already set from send-alert-email
+ *   ALERT_SECRET    → already set from send-alert-email; reused here as the
+ *                     shared secret (the DB trigger sends app.alert_secret)
+ *
+ * Optional:
+ *   DEMO_FROM_EMAIL → verified sender in Resend (default: onboarding@resend.dev)
+ *   DEMO_TO_EMAIL   → where to send the notification (default: dora.angelov@gmail.com)
+ */
+
+const RESEND_API_KEY  = Deno.env.get("RESEND_API_KEY");
+// Reuse ALERT_SECRET so no new DB setting is needed.
+const DEMO_SECRET     = Deno.env.get("ALERT_SECRET");
+const DEMO_FROM_EMAIL = Deno.env.get("DEMO_FROM_EMAIL") ?? "onboarding@resend.dev";
+const DEMO_TO_EMAIL   = Deno.env.get("DEMO_TO_EMAIL")   ?? "dora.angelov@gmail.com";
+const RESEND_ENDPOINT = "https://api.resend.com/emails";
+
+interface DemoRequest {
+  id: string;
+  name: string;
+  email: string;
+  venue_name?: string | null;
+  created_at: string;
+}
+
+Deno.serve(async (req: Request): Promise<Response> => {
+  if (req.method !== "POST") {
+    return json({ error: "Method not allowed" }, 405);
+  }
+
+  if (!DEMO_SECRET) {
+    console.error("notify-demo-request: ALERT_SECRET not configured");
+    return json({ error: "Server misconfiguration" }, 500);
+  }
+
+  const incomingSecret = req.headers.get("x-demo-secret");
+  if (!incomingSecret || incomingSecret !== DEMO_SECRET) {
+    return json({ error: "Unauthorized" }, 401);
+  }
+
+  let demo: DemoRequest;
+  try {
+    demo = await req.json();
+  } catch {
+    return json({ error: "Invalid JSON body" }, 400);
+  }
+
+  if (!RESEND_API_KEY) {
+    console.error("notify-demo-request: RESEND_API_KEY not configured");
+    return json({ error: "Server misconfiguration" }, 500);
+  }
+
+  const esc = (s: string) =>
+    s.replace(/&/g, "&amp;")
+     .replace(/</g, "&lt;")
+     .replace(/>/g, "&gt;")
+     .replace(/"/g, "&quot;")
+     .replace(/'/g, "&#39;");
+
+  const safeName  = esc(demo.name);
+  const safeEmail = esc(demo.email);
+  const safeVenue = demo.venue_name ? esc(demo.venue_name) : null;
+
+  const venue = safeVenue ? ` (${safeVenue})` : "";
+  const subject = `Demo request: ${safeName}${venue}`;
+  const html = `
+    <p><strong>Name:</strong> ${safeName}</p>
+    <p><strong>Email:</strong> <a href="mailto:${safeEmail}">${safeEmail}</a></p>
+    ${safeVenue ? `<p><strong>Venue:</strong> ${safeVenue}</p>` : ""}
+    <p><strong>Submitted:</strong> ${new Date(demo.created_at).toLocaleString("en-GB", { timeZone: "Europe/London" })}</p>
+    <hr />
+    <p style="color:#666;font-size:12px;">View all requests in <a href="https://supabase.com/dashboard">Supabase Dashboard</a> → Table Editor → demo_requests</p>
+  `;
+
+  const res = await fetch(RESEND_ENDPOINT, {
+    method:  "POST",
+    headers: {
+      "Authorization": `Bearer ${RESEND_API_KEY}`,
+      "Content-Type":  "application/json",
+    },
+    body: JSON.stringify({
+      from:    DEMO_FROM_EMAIL,
+      to:      [DEMO_TO_EMAIL],
+      subject,
+      html,
+    }),
+  });
+
+  const body = await res.json().catch(() => ({}));
+
+  if (!res.ok) {
+    console.error(`notify-demo-request: Resend error ${res.status}`, JSON.stringify(body));
+    return json({ error: "Resend API error", detail: body }, 502);
+  }
+
+  console.log(`notify-demo-request: sent → ${DEMO_TO_EMAIL}, resend_id=${body?.id}`);
+  return json({ sent: true, resend_id: body?.id }, 200);
+});
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/supabase/migrations/20260608000001_demo_requests.sql
+++ b/supabase/migrations/20260608000001_demo_requests.sql
@@ -1,0 +1,88 @@
+-- ================================================================
+-- Demo request capture + email notification pipeline
+-- ================================================================
+-- Landing page visitor submits form → inserts into demo_requests
+-- → pg_net trigger → notify-demo-request edge function → Resend → Dora
+--
+-- REQUIRED ONE-TIME SETUP (run in SQL Editor before deploying):
+--
+--   ALTER DATABASE postgres
+--     SET app.supabase_url = 'https://YOUR_REF.supabase.co';
+--   ALTER DATABASE postgres
+--     SET app.demo_secret = 'YOUR_RANDOM_SECRET';
+--
+--   app.supabase_url  → already set if send-alert-email is working
+--   app.demo_secret   → any random string, e.g. "olia-demo-2026-xK9m"
+--                       Store the same value as DEMO_SECRET in Edge Function secrets.
+-- ================================================================
+
+CREATE TABLE IF NOT EXISTS public.demo_requests (
+  id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  name        text        NOT NULL,
+  email       text        NOT NULL,
+  venue_name  text,
+  created_at  timestamptz DEFAULT now()
+);
+
+ALTER TABLE public.demo_requests ENABLE ROW LEVEL SECURITY;
+
+-- Allow unauthenticated landing page visitors to insert
+CREATE POLICY "anon can insert demo requests"
+  ON public.demo_requests
+  FOR INSERT
+  TO anon
+  WITH CHECK (true);
+
+-- Trigger function: fires after each INSERT → pg_net → edge function
+CREATE OR REPLACE FUNCTION public.notify_demo_request_on_insert()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  _url    text;
+  _secret text;
+BEGIN
+  _url    := current_setting('app.supabase_url', true);
+  _secret := current_setting('app.demo_secret', true);
+
+  IF _url IS NULL OR _url = '' THEN
+    RAISE WARNING 'notify_demo_request: app.supabase_url not set.';
+    RETURN NEW;
+  END IF;
+
+  IF _secret IS NULL OR _secret = '' THEN
+    RAISE WARNING 'notify_demo_request: app.demo_secret not set.';
+    RETURN NEW;
+  END IF;
+
+  PERFORM extensions.net.http_post(
+    url     := _url || '/functions/v1/notify-demo-request',
+    headers := jsonb_build_object(
+                 'Content-Type',  'application/json',
+                 'x-demo-secret', _secret
+               ),
+    body    := jsonb_build_object(
+                 'id',         NEW.id,
+                 'name',       NEW.name,
+                 'email',      NEW.email,
+                 'venue_name', NEW.venue_name,
+                 'created_at', NEW.created_at
+               )::text,
+    timeout_milliseconds := 5000
+  );
+
+  RETURN NEW;
+EXCEPTION WHEN OTHERS THEN
+  RAISE WARNING 'notify_demo_request: pg_net call failed: %', SQLERRM;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_notify_demo_request ON public.demo_requests;
+
+CREATE TRIGGER trg_notify_demo_request
+  AFTER INSERT ON public.demo_requests
+  FOR EACH ROW
+  EXECUTE FUNCTION public.notify_demo_request_on_insert();

--- a/supabase/migrations/20260608000002_demo_trigger_use_alert_secret.sql
+++ b/supabase/migrations/20260608000002_demo_trigger_use_alert_secret.sql
@@ -1,0 +1,49 @@
+-- Replace the demo request trigger function to reuse app.alert_secret
+-- (already set on the DB for the send-alert-email pipeline).
+-- The edge function verifies against ALERT_SECRET, which is already
+-- stored as an edge function secret.
+CREATE OR REPLACE FUNCTION public.notify_demo_request_on_insert()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  _url    text;
+  _secret text;
+BEGIN
+  _url    := current_setting('app.supabase_url', true);
+  _secret := current_setting('app.alert_secret', true);
+
+  IF _url IS NULL OR _url = '' THEN
+    RAISE WARNING 'notify_demo_request: app.supabase_url not set.';
+    RETURN NEW;
+  END IF;
+
+  IF _secret IS NULL OR _secret = '' THEN
+    RAISE WARNING 'notify_demo_request: app.alert_secret not set.';
+    RETURN NEW;
+  END IF;
+
+  PERFORM extensions.net.http_post(
+    url     := _url || '/functions/v1/notify-demo-request',
+    headers := jsonb_build_object(
+                 'Content-Type',  'application/json',
+                 'x-demo-secret', _secret
+               ),
+    body    := jsonb_build_object(
+                 'id',         NEW.id,
+                 'name',       NEW.name,
+                 'email',      NEW.email,
+                 'venue_name', NEW.venue_name,
+                 'created_at', NEW.created_at
+               )::text,
+    timeout_milliseconds := 5000
+  );
+
+  RETURN NEW;
+EXCEPTION WHEN OTHERS THEN
+  RAISE WARNING 'notify_demo_request: pg_net call failed: %', SQLERRM;
+  RETURN NEW;
+END;
+$$;


### PR DESCRIPTION
## Summary

- Replaces all four `mailto:` demo buttons with a modal form (name, email, venue)
- Submits to a new `demo_requests` Supabase table (already migrated + live)
- pg_net trigger fires on each insert → `notify-demo-request` edge function (already deployed) → Resend → dora.angelov@gmail.com
- Reuses existing `ALERT_SECRET` and `app.alert_secret` — no new secrets needed
- HTML-escapes all user input before interpolating into the email body

## Test plan

- [ ] Click "Book a demo" on the landing page — modal opens
- [ ] Submit with name + email — success state shows, email arrives at dora.angelov@gmail.com
- [ ] Submit with venue name filled in — venue appears in the email
- [ ] Check Supabase Table Editor → demo_requests for the row

🤖 Generated with [Claude Code](https://claude.com/claude-code)