### PR TITLE
fix: demo modal UI + email sender

### DIFF
--- a/src/components/landing/DemoModal.tsx
+++ b/src/components/landing/DemoModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from "react";
-import { X, CalendarDays, CheckCircle2 } from "lucide-react";
+import { CheckCircle2 } from "lucide-react";
 import { supabase } from "@/lib/supabase";
 
 interface Props {
@@ -10,10 +10,10 @@ interface Props {
 type State = "idle" | "submitting" | "success" | "error";
 
 export function DemoModal({ open, onClose }: Props) {
-  const [name, setName]       = useState("");
-  const [email, setEmail]     = useState("");
-  const [venue, setVenue]     = useState("");
-  const [state, setState]     = useState<State>("idle");
+  const [name, setName]         = useState("");
+  const [email, setEmail]       = useState("");
+  const [venue, setVenue]       = useState("");
+  const [state, setState]       = useState<State>("idle");
   const [errorMsg, setErrorMsg] = useState("");
   const nameRef = useRef<HTMLInputElement>(null);
 
@@ -45,7 +45,7 @@ export function DemoModal({ open, onClose }: Props) {
 
     if (error) {
       console.error("demo_requests insert:", error);
-      setErrorMsg("Something went wrong. Please email dora@oliahq.com directly.");
+      setErrorMsg("Something went wrong — please email dora@oliahq.com directly.");
       setState("error");
     } else {
       setState("success");
@@ -53,62 +53,64 @@ export function DemoModal({ open, onClose }: Props) {
   }
 
   const inputClass =
-    "w-full bg-background border border-border rounded-xl px-4 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-sage/30 focus:border-sage/50 transition-colors";
+    "w-full border border-border rounded-xl px-4 py-3 text-sm text-foreground bg-card placeholder:text-muted-foreground/60 focus:outline-none focus:ring-2 focus:ring-sage/20 focus:border-sage/40 transition-colors";
 
   return (
     <>
+      {/* Backdrop */}
       <div
-        className="fixed inset-0 z-50 bg-black/40 backdrop-blur-sm"
+        className="fixed inset-0 z-50 bg-foreground/20 backdrop-blur-sm"
         onClick={onClose}
         aria-hidden="true"
       />
+
+      {/* Sheet — slides up from bottom on mobile, centred on desktop */}
       <div
+        className="fixed inset-0 z-50 flex items-end sm:items-center sm:justify-center sm:px-4 sm:py-8"
         role="dialog"
         aria-modal="true"
         aria-labelledby="demo-modal-title"
-        className="fixed inset-0 z-50 flex items-center justify-center p-4"
       >
-        <div className="relative w-full max-w-md bg-card rounded-2xl shadow-xl border border-border p-6 sm:p-8">
-          <button
-            onClick={onClose}
-            className="absolute top-4 right-4 text-muted-foreground hover:text-foreground transition-colors"
-            aria-label="Close"
-          >
-            <X size={20} />
-          </button>
-
+        <div
+          className="w-full bg-card rounded-t-2xl sm:rounded-2xl sm:max-w-lg sm:max-h-[90vh] sm:overflow-y-auto"
+          onClick={e => e.stopPropagation()}
+        >
           {state === "success" ? (
-            <div className="text-center py-4">
-              <CheckCircle2 size={48} className="mx-auto mb-4" style={{ color: "hsl(var(--sage))" }} />
-              <h2 className="font-display text-2xl text-foreground mb-2">You're on the list</h2>
-              <p className="text-muted-foreground text-sm">
+            <div className="p-8 text-center space-y-3">
+              <div className="flex justify-center mb-2">
+                <div className="w-14 h-14 rounded-2xl bg-sage/10 flex items-center justify-center">
+                  <CheckCircle2 size={28} className="text-sage" />
+                </div>
+              </div>
+              <h2 className="font-display text-xl text-foreground">You're on the list</h2>
+              <p className="text-sm text-muted-foreground leading-relaxed">
                 Thanks, {name.split(" ")[0]}! I'll reach out within one business day.
               </p>
-              <button
-                onClick={onClose}
-                className="mt-6 inline-flex items-center justify-center font-semibold px-6 py-3 rounded-xl hover:opacity-90 transition-opacity text-white"
-                style={{ background: "hsl(var(--sage))" }}
-              >
-                Done
-              </button>
+              <div className="pt-2 space-y-2">
+                <button
+                  onClick={onClose}
+                  className="w-full py-3 rounded-xl bg-sage text-primary-foreground text-sm font-semibold hover:opacity-90 transition-opacity"
+                >
+                  Done
+                </button>
+              </div>
             </div>
           ) : (
-            <>
-              <div className="mb-6">
-                <div className="flex items-center gap-2 mb-1.5">
-                  <CalendarDays size={18} className="text-muted-foreground" />
-                  <h2 id="demo-modal-title" className="font-display text-2xl text-foreground">
-                    Book a demo
-                  </h2>
-                </div>
+            <form onSubmit={handleSubmit} className="p-6 sm:p-8 space-y-5">
+              {/* Header */}
+              <div className="space-y-1">
+                <h2 id="demo-modal-title" className="font-display text-xl text-foreground">
+                  Book a demo
+                </h2>
                 <p className="text-sm text-muted-foreground">
                   I'll reach out within one business day to find a time.
                 </p>
               </div>
 
-              <form onSubmit={handleSubmit} className="space-y-4">
-                <div>
-                  <label htmlFor="demo-name" className="block text-sm font-medium text-foreground mb-1.5">
+              {/* Fields */}
+              <div className="space-y-4">
+                <div className="space-y-1.5">
+                  <label htmlFor="demo-name" className="block text-sm font-medium text-foreground">
                     Your name
                   </label>
                   <input
@@ -117,14 +119,14 @@ export function DemoModal({ open, onClose }: Props) {
                     type="text"
                     required
                     value={name}
-                    onChange={(e) => setName(e.target.value)}
+                    onChange={e => setName(e.target.value)}
                     placeholder="Jane Smith"
                     className={inputClass}
                   />
                 </div>
 
-                <div>
-                  <label htmlFor="demo-email" className="block text-sm font-medium text-foreground mb-1.5">
+                <div className="space-y-1.5">
+                  <label htmlFor="demo-email" className="block text-sm font-medium text-foreground">
                     Work email
                   </label>
                   <input
@@ -132,41 +134,50 @@ export function DemoModal({ open, onClose }: Props) {
                     type="email"
                     required
                     value={email}
-                    onChange={(e) => setEmail(e.target.value)}
+                    onChange={e => setEmail(e.target.value)}
                     placeholder="jane@yourvenue.com"
                     className={inputClass}
                   />
                 </div>
 
-                <div>
-                  <label htmlFor="demo-venue" className="block text-sm font-medium text-foreground mb-1.5">
+                <div className="space-y-1.5">
+                  <label htmlFor="demo-venue" className="block text-sm font-medium text-foreground">
                     Venue or property name
-                    <span className="text-muted-foreground font-normal ml-1">(optional)</span>
+                    <span className="text-muted-foreground font-normal ml-1.5">(optional)</span>
                   </label>
                   <input
                     id="demo-venue"
                     type="text"
                     value={venue}
-                    onChange={(e) => setVenue(e.target.value)}
+                    onChange={e => setVenue(e.target.value)}
                     placeholder="The Grand Hotel"
                     className={inputClass}
                   />
                 </div>
+              </div>
 
-                {state === "error" && (
-                  <p className="text-sm text-destructive">{errorMsg}</p>
-                )}
+              {state === "error" && (
+                <p className="text-sm text-destructive">{errorMsg}</p>
+              )}
 
+              {/* Actions */}
+              <div className="space-y-2 pt-1">
                 <button
                   type="submit"
                   disabled={state === "submitting"}
-                  className="w-full font-semibold py-3 rounded-xl hover:opacity-90 transition-opacity disabled:opacity-60 text-white"
-                  style={{ background: "hsl(var(--sage))" }}
+                  className="w-full py-3 rounded-xl bg-sage text-primary-foreground text-sm font-semibold hover:opacity-90 transition-opacity disabled:opacity-60"
                 >
                   {state === "submitting" ? "Sending…" : "Request a demo"}
                 </button>
-              </form>
-            </>
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="w-full py-3 rounded-xl border border-border text-sm text-muted-foreground hover:bg-muted transition-colors"
+                >
+                  Cancel
+                </button>
+              </div>
+            </form>
           )}
         </div>
       </div>

--- a/supabase/functions/notify-demo-request/index.ts
+++ b/supabase/functions/notify-demo-request/index.ts
@@ -10,14 +10,15 @@
  *                     shared secret (the DB trigger sends app.alert_secret)
  *
  * Optional:
- *   DEMO_FROM_EMAIL → verified sender in Resend (default: onboarding@resend.dev)
  *   DEMO_TO_EMAIL   → where to send the notification (default: dora.angelov@gmail.com)
+ *   DEMO_FROM_EMAIL → verified sender in Resend (falls back to ALERT_FROM_EMAIL)
  */
 
 const RESEND_API_KEY  = Deno.env.get("RESEND_API_KEY");
 // Reuse ALERT_SECRET so no new DB setting is needed.
 const DEMO_SECRET     = Deno.env.get("ALERT_SECRET");
-const DEMO_FROM_EMAIL = Deno.env.get("DEMO_FROM_EMAIL") ?? "onboarding@resend.dev";
+// Fall back to ALERT_FROM_EMAIL so we always use a verified sender.
+const DEMO_FROM_EMAIL = Deno.env.get("DEMO_FROM_EMAIL") ?? Deno.env.get("ALERT_FROM_EMAIL") ?? "onboarding@resend.dev";
 const DEMO_TO_EMAIL   = Deno.env.get("DEMO_TO_EMAIL")   ?? "dora.angelov@gmail.com";
 const RESEND_ENDPOINT = "https://api.resend.com/emails";
 


### PR DESCRIPTION
## Changes

**UI:** Restyled modal to match the app's bottom-sheet pattern — slides up from bottom on mobile, centred card on desktop. White background, clean input fields, navy CTA, secondary Cancel button.

**Email:** Was falling back to `onboarding@resend.dev` (Resend sandbox — only delivers to verified addresses). Now falls back to `ALERT_FROM_EMAIL`, which is already set and working for alert emails.

## Test plan
- [ ] Open demo modal — check it looks like the app's modals
- [ ] Submit form — confirm email arrives at dora.angelov@gmail.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)