### PR TITLE
fix: modal CSS bleed + match app design exactly

### DIFF
--- a/src/components/landing/DemoModal.tsx
+++ b/src/components/landing/DemoModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from "react";
-import { CheckCircle2 } from "lucide-react";
+import { X, CheckCircle2 } from "lucide-react";
 import { supabase } from "@/lib/supabase";
 
 interface Props {
@@ -8,6 +8,8 @@ interface Props {
 }
 
 type State = "idle" | "submitting" | "success" | "error";
+
+const inputCls = "w-full border border-border rounded-xl px-4 py-3 text-sm bg-muted focus:outline-none focus:ring-1 focus:ring-ring";
 
 export function DemoModal({ open, onClose }: Props) {
   const [name, setName]         = useState("");
@@ -52,135 +54,114 @@ export function DemoModal({ open, onClose }: Props) {
     }
   }
 
-  const inputClass =
-    "w-full border border-border rounded-xl px-4 py-3 text-sm text-foreground bg-card placeholder:text-muted-foreground/60 focus:outline-none focus:ring-2 focus:ring-sage/20 focus:border-sage/40 transition-colors";
-
   return (
-    <>
-      {/* Backdrop */}
-      <div
-        className="fixed inset-0 z-50 bg-foreground/20 backdrop-blur-sm"
-        onClick={onClose}
-        aria-hidden="true"
-      />
+    <div
+      className="fixed inset-0 z-[60] flex items-end justify-center bg-foreground/20 backdrop-blur-sm sm:items-center sm:px-4 sm:py-8"
+      onClick={e => { if (e.target === e.currentTarget) onClose(); }}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="demo-modal-title"
+    >
+      <div className="bg-card w-full max-w-lg rounded-t-2xl p-5 pb-8 space-y-4 max-h-[85vh] overflow-y-auto sm:max-w-lg sm:rounded-2xl sm:max-h-[90vh] sm:shadow-2xl">
 
-      {/* Sheet — slides up from bottom on mobile, centred on desktop */}
-      <div
-        className="fixed inset-0 z-50 flex items-end sm:items-center sm:justify-center sm:px-4 sm:py-8"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="demo-modal-title"
-      >
-        <div
-          className="w-full bg-card rounded-t-2xl sm:rounded-2xl sm:max-w-lg sm:max-h-[90vh] sm:overflow-y-auto"
-          onClick={e => e.stopPropagation()}
-        >
-          {state === "success" ? (
-            <div className="p-8 text-center space-y-3">
-              <div className="flex justify-center mb-2">
-                <div className="w-14 h-14 rounded-2xl bg-sage/10 flex items-center justify-center">
-                  <CheckCircle2 size={28} className="text-sage" />
+        {state === "success" ? (
+          <>
+            <div className="flex items-center justify-between">
+              <h2 id="demo-modal-title" className="font-display text-lg text-foreground">Book a demo</h2>
+              <button onClick={onClose} className="btn-icon">
+                <X size={18} className="text-muted-foreground" />
+              </button>
+            </div>
+            <div className="py-4 text-center space-y-3">
+              <div className="flex justify-center">
+                <div className="w-12 h-12 rounded-2xl bg-sage/10 flex items-center justify-center">
+                  <CheckCircle2 size={22} className="text-sage" />
                 </div>
               </div>
-              <h2 className="font-display text-xl text-foreground">You're on the list</h2>
-              <p className="text-sm text-muted-foreground leading-relaxed">
+              <p className="text-sm font-medium text-foreground">You're on the list</p>
+              <p className="text-sm text-muted-foreground">
                 Thanks, {name.split(" ")[0]}! I'll reach out within one business day.
               </p>
-              <div className="pt-2 space-y-2">
-                <button
-                  onClick={onClose}
-                  className="w-full py-3 rounded-xl bg-sage text-primary-foreground text-sm font-semibold hover:opacity-90 transition-opacity"
-                >
-                  Done
-                </button>
-              </div>
             </div>
-          ) : (
-            <form onSubmit={handleSubmit} className="p-6 sm:p-8 space-y-5">
-              {/* Header */}
-              <div className="space-y-1">
-                <h2 id="demo-modal-title" className="font-display text-xl text-foreground">
-                  Book a demo
-                </h2>
-                <p className="text-sm text-muted-foreground">
-                  I'll reach out within one business day to find a time.
-                </p>
-              </div>
+            <button
+              onClick={onClose}
+              className="w-full py-3 rounded-xl text-sm font-medium bg-sage text-primary-foreground hover:bg-sage-deep transition-colors"
+            >
+              Done
+            </button>
+          </>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="flex items-center justify-between">
+              <h2 id="demo-modal-title" className="font-display text-lg text-foreground">Book a demo</h2>
+              <button type="button" onClick={onClose} className="btn-icon">
+                <X size={18} className="text-muted-foreground" />
+              </button>
+            </div>
 
-              {/* Fields */}
-              <div className="space-y-4">
-                <div className="space-y-1.5">
-                  <label htmlFor="demo-name" className="block text-sm font-medium text-foreground">
-                    Your name
-                  </label>
-                  <input
-                    ref={nameRef}
-                    id="demo-name"
-                    type="text"
-                    required
-                    value={name}
-                    onChange={e => setName(e.target.value)}
-                    placeholder="Jane Smith"
-                    className={inputClass}
-                  />
-                </div>
+            <p className="text-sm text-muted-foreground -mt-1">
+              I'll reach out within one business day to find a time.
+            </p>
 
-                <div className="space-y-1.5">
-                  <label htmlFor="demo-email" className="block text-sm font-medium text-foreground">
-                    Work email
-                  </label>
-                  <input
-                    id="demo-email"
-                    type="email"
-                    required
-                    value={email}
-                    onChange={e => setEmail(e.target.value)}
-                    placeholder="jane@yourvenue.com"
-                    className={inputClass}
-                  />
-                </div>
+            <div>
+              <label htmlFor="demo-name" className="text-xs text-muted-foreground mb-1 block">
+                Your name (required)
+              </label>
+              <input
+                ref={nameRef}
+                id="demo-name"
+                type="text"
+                required
+                value={name}
+                onChange={e => setName(e.target.value)}
+                placeholder="Jane Smith"
+                className={inputCls}
+              />
+            </div>
 
-                <div className="space-y-1.5">
-                  <label htmlFor="demo-venue" className="block text-sm font-medium text-foreground">
-                    Venue or property name
-                    <span className="text-muted-foreground font-normal ml-1.5">(optional)</span>
-                  </label>
-                  <input
-                    id="demo-venue"
-                    type="text"
-                    value={venue}
-                    onChange={e => setVenue(e.target.value)}
-                    placeholder="The Grand Hotel"
-                    className={inputClass}
-                  />
-                </div>
-              </div>
+            <div>
+              <label htmlFor="demo-email" className="text-xs text-muted-foreground mb-1 block">
+                Work email (required)
+              </label>
+              <input
+                id="demo-email"
+                type="email"
+                required
+                value={email}
+                onChange={e => setEmail(e.target.value)}
+                placeholder="jane@yourvenue.com"
+                className={inputCls}
+              />
+            </div>
 
-              {state === "error" && (
-                <p className="text-sm text-destructive">{errorMsg}</p>
-              )}
+            <div>
+              <label htmlFor="demo-venue" className="text-xs text-muted-foreground mb-1 block">
+                Venue or property name (optional)
+              </label>
+              <input
+                id="demo-venue"
+                type="text"
+                value={venue}
+                onChange={e => setVenue(e.target.value)}
+                placeholder="The Grand Hotel"
+                className={inputCls}
+              />
+            </div>
 
-              {/* Actions */}
-              <div className="space-y-2 pt-1">
-                <button
-                  type="submit"
-                  disabled={state === "submitting"}
-                  className="w-full py-3 rounded-xl bg-sage text-primary-foreground text-sm font-semibold hover:opacity-90 transition-opacity disabled:opacity-60"
-                >
-                  {state === "submitting" ? "Sending…" : "Request a demo"}
-                </button>
-                <button
-                  type="button"
-                  onClick={onClose}
-                  className="w-full py-3 rounded-xl border border-border text-sm text-muted-foreground hover:bg-muted transition-colors"
-                >
-                  Cancel
-                </button>
-              </div>
-            </form>
-          )}
-        </div>
+            {state === "error" && (
+              <p className="text-sm text-destructive">{errorMsg}</p>
+            )}
+
+            <button
+              type="submit"
+              disabled={state === "submitting"}
+              className="w-full py-3 rounded-xl text-sm font-medium bg-sage text-primary-foreground hover:bg-sage-deep transition-colors disabled:opacity-60"
+            >
+              {state === "submitting" ? "Sending…" : "Request a demo"}
+            </button>
+          </form>
+        )}
       </div>
-    </>
+    </div>
   );
 }

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -540,6 +540,7 @@ export default function Landing() {
   }, []);
 
   return (
+    <>
     <div className="olia-landing">
       <style>{css}</style>
 
@@ -792,7 +793,8 @@ export default function Landing() {
           <p className="ol-footer-copy">© 2026 Olia. All rights reserved.</p>
         </div>
       </footer>
-      <DemoModal open={demoOpen} onClose={() => setDemoOpen(false)} />
     </div>
+    <DemoModal open={demoOpen} onClose={() => setDemoOpen(false)} />
+    </>
   );
 }


### PR DESCRIPTION
## Root cause

`<DemoModal>` was rendered inside `<div className="olia-landing">`. The landing page CSS contains `.olia-landing h2 { font-family: 'Playfair Display' }`, which overrode the modal title with the large serif font.

## Fix

- Moved `<DemoModal>` outside `.olia-landing` (wrapped return in a Fragment) so it renders in clean app CSS context
- Rebuilt modal to exactly match `BottomSheet` + `ModalHeader` + `inputCls` from `SharedUI.tsx` — same structure as the Edit Location modal in Image #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)