### PR TITLE
security: harden notify-demo-request auth

### DIFF
--- a/supabase/functions/notify-demo-request/index.ts
+++ b/supabase/functions/notify-demo-request/index.ts
@@ -1,16 +1,25 @@
 /**
  * notify-demo-request
  *
- * Called directly from the DemoModal component after a successful insert.
- * Auth: verifies the request carries a valid Supabase JWT (anon or user session).
+ * Called directly from DemoModal after a successful insert into demo_requests.
  *
- * Required secrets — all already set:
- *   RESEND_API_KEY    → from send-alert-email setup
- *   SUPABASE_ANON_KEY → auto-available in all edge functions
+ * Auth model: verifies the submitted email was actually inserted into
+ * demo_requests within the last 60 seconds using the service role key.
+ * This prevents the public endpoint from being used to send arbitrary emails —
+ * a caller must first successfully insert a real row (subject to RLS), and
+ * then call this function before the 60-second window closes.
+ *
+ * Also enforces per-email rate limiting (1 notification per 24 h) and
+ * field length caps to prevent abuse.
+ *
+ * Required secrets — all auto-available in Supabase edge functions:
+ *   RESEND_API_KEY          → set from send-alert-email setup
+ *   SUPABASE_URL            → auto-injected
+ *   SUPABASE_SERVICE_ROLE_KEY → auto-injected
  *
  * Optional:
- *   DEMO_TO_EMAIL     → notification recipient (default: dora.angelov@gmail.com)
- *   DEMO_FROM_EMAIL   → verified Resend sender (falls back to ALERT_FROM_EMAIL)
+ *   DEMO_TO_EMAIL   → notification recipient (default: dora.angelov@gmail.com)
+ *   DEMO_FROM_EMAIL → verified Resend sender (falls back to ALERT_FROM_EMAIL)
  */
 
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
@@ -20,6 +29,10 @@ const DEMO_FROM_EMAIL = Deno.env.get("DEMO_FROM_EMAIL") ?? Deno.env.get("ALERT_F
 const DEMO_TO_EMAIL   = Deno.env.get("DEMO_TO_EMAIL")   ?? "dora.angelov@gmail.com";
 const RESEND_ENDPOINT = "https://api.resend.com/emails";
 
+const MAX_NAME  = 120;
+const MAX_EMAIL = 254;
+const MAX_VENUE = 200;
+
 interface DemoRequest {
   name: string;
   email: string;
@@ -28,48 +41,67 @@ interface DemoRequest {
 
 Deno.serve(async (req: Request): Promise<Response> => {
   if (req.method === "OPTIONS") {
-    return new Response(null, {
-      headers: {
-        "Access-Control-Allow-Origin":  "*",
-        "Access-Control-Allow-Headers": "authorization, content-type",
-      },
-    });
+    return new Response(null, { headers: cors() });
   }
-
   if (req.method !== "POST") {
     return json({ error: "Method not allowed" }, 405);
   }
 
-  // Verify the caller has a valid Supabase JWT (anon or authenticated session).
-  const authHeader = req.headers.get("Authorization");
-  if (!authHeader?.startsWith("Bearer ")) {
-    return json({ error: "Unauthorized" }, 401);
+  let body: DemoRequest;
+  try {
+    body = await req.json();
+  } catch {
+    return json({ error: "Invalid JSON" }, 400);
   }
 
+  // Field presence + length caps
+  const name  = String(body.name  ?? "").trim().slice(0, MAX_NAME);
+  const email = String(body.email ?? "").trim().slice(0, MAX_EMAIL).toLowerCase();
+  const venue = body.venue_name ? String(body.venue_name).trim().slice(0, MAX_VENUE) : null;
+
+  if (!name || !email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    return json({ error: "Invalid fields" }, 400);
+  }
+
+  // Use the service role to verify a real insert happened for this email
+  // within the last 60 seconds, and that no notification was sent in 24 h.
   const supabase = createClient(
     Deno.env.get("SUPABASE_URL") ?? "",
-    Deno.env.get("SUPABASE_ANON_KEY") ?? "",
-    { global: { headers: { Authorization: authHeader } } },
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
   );
 
-  const { error: authError } = await supabase.auth.getUser();
-  // anon JWTs return an auth error ("not authenticated") but are still valid tokens.
-  // We just need the JWT to be a real Supabase-issued token, not arbitrary garbage.
-  // Re-verify by checking the token decodes correctly against the anon key.
-  // Simplest: if getUser() errors with "invalid JWT" it's forged; "not authenticated" is fine.
-  if (authError && authError.message.toLowerCase().includes("invalid")) {
-    return json({ error: "Unauthorized" }, 401);
+  const since60s  = new Date(Date.now() - 60_000).toISOString();
+  const since24h  = new Date(Date.now() - 86_400_000).toISOString();
+
+  const { data: rows, error: dbError } = await supabase
+    .from("demo_requests")
+    .select("id, created_at")
+    .eq("email", email)
+    .gte("created_at", since60s)
+    .order("created_at", { ascending: false })
+    .limit(1);
+
+  if (dbError) {
+    console.error("notify-demo-request: db check failed", dbError);
+    return json({ error: "Server error" }, 500);
   }
 
-  let demo: DemoRequest;
-  try {
-    demo = await req.json();
-  } catch {
-    return json({ error: "Invalid JSON body" }, 400);
+  // No matching insert in the last 60 s → this call wasn't triggered by the form
+  if (!rows || rows.length === 0) {
+    return json({ error: "No recent submission found" }, 403);
   }
 
-  if (!demo.name || !demo.email) {
-    return json({ error: "Missing required fields" }, 400);
+  // Rate limit: has a notification already gone out for this email in the last 24 h?
+  const { count } = await supabase
+    .from("demo_requests")
+    .select("id", { count: "exact", head: true })
+    .eq("email", email)
+    .gte("created_at", since24h);
+
+  if ((count ?? 0) > 1) {
+    // More than one submission from this email today — silently accept but skip email
+    console.log(`notify-demo-request: rate-limited ${email}`);
+    return json({ sent: false, reason: "rate_limited" }, 200);
   }
 
   if (!RESEND_API_KEY) {
@@ -84,12 +116,11 @@ Deno.serve(async (req: Request): Promise<Response> => {
      .replace(/"/g, "&quot;")
      .replace(/'/g, "&#39;");
 
-  const safeName  = esc(demo.name);
-  const safeEmail = esc(demo.email);
-  const safeVenue = demo.venue_name ? esc(demo.venue_name) : null;
+  const safeName  = esc(name);
+  const safeEmail = esc(email);
+  const safeVenue = venue ? esc(venue) : null;
 
-  const venue   = safeVenue ? ` (${safeVenue})` : "";
-  const subject = `Demo request: ${safeName}${venue}`;
+  const subject = `Demo request: ${safeName}${safeVenue ? ` (${safeVenue})` : ""}`;
   const html = `
     <p><strong>Name:</strong> ${safeName}</p>
     <p><strong>Email:</strong> <a href="mailto:${safeEmail}">${safeEmail}</a></p>
@@ -100,16 +131,8 @@ Deno.serve(async (req: Request): Promise<Response> => {
 
   const res = await fetch(RESEND_ENDPOINT, {
     method:  "POST",
-    headers: {
-      "Authorization": `Bearer ${RESEND_API_KEY}`,
-      "Content-Type":  "application/json",
-    },
-    body: JSON.stringify({
-      from: DEMO_FROM_EMAIL,
-      to:   [DEMO_TO_EMAIL],
-      subject,
-      html,
-    }),
+    headers: { "Authorization": `Bearer ${RESEND_API_KEY}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ from: DEMO_FROM_EMAIL, to: [DEMO_TO_EMAIL], subject, html }),
   });
 
   const resBody = await res.json().catch(() => ({}));
@@ -123,12 +146,16 @@ Deno.serve(async (req: Request): Promise<Response> => {
   return json({ sent: true, resend_id: resBody?.id }, 200);
 });
 
+function cors() {
+  return {
+    "Access-Control-Allow-Origin":  "*",
+    "Access-Control-Allow-Headers": "content-type",
+  };
+}
+
 function json(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,
-    headers: {
-      "Content-Type":                 "application/json",
-      "Access-Control-Allow-Origin":  "*",
-    },
+    headers: { "Content-Type": "application/json", ...cors() },
   });
 }


### PR DESCRIPTION
## Problem
The anon JWT is public (it's in the JS bundle), so validating it offered no real protection — anyone could call the endpoint and trigger arbitrary emails to dora.angelov@gmail.com.

## Fix
Replaced the anon JWT check with a server-side verification using the service role key:
- Confirms the submitted email was actually inserted into `demo_requests` within the last 60 seconds (ties the function call to a real form submission)
- Per-email rate limiting: only 1 notification per 24 h
- Field length caps + email format validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)