### PR TITLE
fix: brand mark visibility, font size, and cross-platform font loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,11 @@
     <link rel="icon" href="/olia-app-icon-16.png" type="image/png" sizes="16x16" />
     <link rel="apple-touch-icon" href="/olia-app-icon-180.png" />
 
+    <!-- Fonts — preconnect first, then stylesheet for fastest cross-browser load -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500;1,600&family=Hanken+Grotesk:wght@300;400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap" />
+
     <title>Olia</title>
     <meta name="description" content="Olia — Your daily operations, streamlined." />
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500;1,600&family=Hanken+Grotesk:wght@300;400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap');
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -9,7 +7,7 @@
    Mobile-first: 16px base. Laptop: slightly denser at 14px. Wide desktop: 18px.
    ────────────────────────────────────────────────────────────────────────── */
 html { font-size: 16px; }                        /* mobile / default        */
-@media (min-width: 768px)  { html { font-size: 14px; } } /* laptop          */
+@media (min-width: 768px)  { html { font-size: 16px; } } /* laptop          */
 @media (min-width: 1280px) { html { font-size: 18px; } } /* wide desktop    */
 
 @layer base {

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -3,8 +3,6 @@ import { Link } from "react-router-dom";
 import { DemoModal } from "@/components/landing/DemoModal";
 
 const css = `
-  @import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500;1,600&family=Hanken+Grotesk:wght@300;400;500;600;700&display=swap');
-
   .olia-landing *, .olia-landing *::before, .olia-landing *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
   .olia-landing {

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -142,9 +142,7 @@ export default function Login() {
     <div className="min-h-screen bg-background flex flex-col items-center justify-center px-6 py-12">
       <div className="w-full max-w-sm space-y-8">
         <div className="text-center">
-          <div className="w-14 h-14 rounded-2xl bg-sage flex items-center justify-center mx-auto mb-4">
-            <span className="text-white font-display text-2xl font-bold">O</span>
-          </div>
+          <img src="/brand/logo/olia-app-icon.svg" alt="Olia" className="w-14 h-14 mx-auto mb-4" />
           <h1 className="font-display text-2xl text-foreground">Sign in</h1>
           <p className="text-sm text-muted-foreground mt-1">Use the one-time code from your inbox.</p>
         </div>

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -261,9 +261,7 @@ export default function Signup() {
 
         {/* Logo */}
         <div className="text-center">
-          <div className="w-14 h-14 rounded-2xl bg-sage flex items-center justify-center mx-auto mb-4">
-            <span className="text-white font-display text-2xl font-bold">O</span>
-          </div>
+          <img src="/brand/logo/olia-app-icon.svg" alt="Olia" className="w-14 h-14 mx-auto mb-4" />
           <h1 className="font-display text-2xl text-foreground">Create your account</h1>
           <p className="text-sm text-muted-foreground mt-1">Set up Olia for your business with a one-time code</p>
         </div>

--- a/src/pages/kiosk/KioskSetupScreen.tsx
+++ b/src/pages/kiosk/KioskSetupScreen.tsx
@@ -42,9 +42,7 @@ export function KioskSetupScreen({
     <div className="min-h-screen bg-background flex flex-col items-center justify-center px-6 sm:px-8 lg:px-10">
       <div className="w-full max-w-sm">
         <div className="text-center mb-10">
-          <div className="w-16 h-16 rounded-full bg-sage flex items-center justify-center mx-auto mb-5">
-            <span className="text-white text-2xl font-bold font-display">O</span>
-          </div>
+          <img src="/brand/logo/olia-app-icon.svg" alt="Olia" className="w-16 h-16 mx-auto mb-5" />
           <h1 className="font-display text-3xl italic text-foreground tracking-tight">Olia Kiosk</h1>
           <p className="section-label mt-2 tracking-widest">Select a location to launch</p>
         </div>


### PR DESCRIPTION
## What broke and why

After the brand kit PR, three issues remained:

**1. O-letter placeholders not replaced** — Login, Signup, and KioskSetupScreen all had a dark navy circle/square with a hand-typed "O". Only the Kiosk grid screen was updated in the previous PR.

**2. Font size regression at laptop width** — Hanken Grotesk has a smaller x-height than DM Sans. At the 768px breakpoint the `html` font-size drops to 14px; the same px value renders visually smaller with the new font. Fixed by raising the laptop base from 14px → 16px.

**3. Unreliable font loading** — Fonts were loaded via `@import` inside `src/index.css`. This is less reliable than `<link>` tags (browser can block it, CSS @import has lower priority, WebViews/Capacitor can miss it). Moved to preconnect + `<link rel="stylesheet">` in `index.html` so fonts load at the earliest possible moment, cross-browser and cross-platform.

## Changes
- `index.html` — preconnect hints + `<link rel="stylesheet">` for Google Fonts
- `src/index.css` — remove `@import` (now redundant)
- `src/pages/Landing.tsx` — remove `@import` (now redundant)
- `src/pages/Login.tsx` — `olia-app-icon.svg` replaces O placeholder
- `src/pages/Signup.tsx` — `olia-app-icon.svg` replaces O placeholder
- `src/pages/kiosk/KioskSetupScreen.tsx` — `olia-app-icon.svg` replaces O placeholder

## Test plan
- [ ] Login page shows brand mark icon (not letter O)
- [ ] Signup page shows brand mark icon
- [ ] Kiosk setup screen shows brand mark icon
- [ ] Body text at laptop width (1024px) renders at 16px base — not smaller than mobile
- [ ] No font flash or missing fonts on hard refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)