### PR TITLE
feat: add brand mark to app header/sidebar and centre kiosk logo

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -42,7 +42,9 @@ export function Layout({ children, title, subtitle, headerRight, headerLeft }: L
           <div className={cn(shellWidthClass, "flex items-center justify-between gap-2 px-4 py-3 sm:px-6 lg:px-8 xl:px-10")}>
             {headerLeft ? (
               <div className="flex items-center gap-2 shrink-0">{headerLeft}</div>
-            ) : <div className="w-8" />}
+            ) : (
+              <img src="/brand/logo/olia-mark-navy.svg" alt="Olia" className="w-8 h-8 shrink-0" />
+            )}
             <div className="flex-1 min-w-0 text-center">
               <h1 className="font-display text-lg text-foreground leading-tight truncate">{title}</h1>
               {subtitle && (

--- a/src/components/SidebarNav.tsx
+++ b/src/components/SidebarNav.tsx
@@ -11,7 +11,11 @@ export function SidebarNav() {
   return (
     <aside className="hidden md:flex md:w-[224px] md:shrink-0 pt-5 pb-8">
       <div className="w-full h-fit rounded-[28px] border border-border bg-card/92 p-3 shadow-[0_18px_50px_rgba(15,23,42,0.06)] backdrop-blur-sm">
-        <p className="px-3 pb-2 text-[11px] font-semibold uppercase tracking-[0.24em] text-muted-foreground">
+        <div className="flex items-center gap-2.5 px-3 pt-1 pb-3 mb-1 border-b border-border/60">
+          <img src="/brand/logo/olia-mark-navy.svg" alt="" className="w-7 h-7 shrink-0" />
+          <span className="font-display italic text-[17px] font-semibold text-foreground tracking-tight leading-none">Olia</span>
+        </div>
+        <p className="px-3 pt-2 pb-2 text-[11px] font-semibold uppercase tracking-[0.24em] text-muted-foreground">
           Navigate
         </p>
         <nav aria-label="Primary" className="space-y-1">

--- a/src/pages/Kiosk.tsx
+++ b/src/pages/Kiosk.tsx
@@ -685,28 +685,34 @@ export default function Kiosk() {
   return (
     <div className="min-h-screen bg-background w-full min-[900px]:max-w-none mx-auto flex flex-col">
       {/* Top bar */}
-      <div className="px-5 pt-7 pb-4 flex items-center justify-between border-b border-border">
-        <div className="flex items-center gap-2">
-          <img src="/brand/logo/olia-mark-navy.svg" alt="Olia" className="w-7 h-7 shrink-0" />
+      <div className="px-5 pt-6 pb-4 grid grid-cols-3 items-center border-b border-border">
+        {/* Left: current status */}
+        <div>
+          <p className="text-xs text-muted-foreground uppercase tracking-widest">Current Status</p>
+          <p className="text-sm font-semibold text-foreground">{dateStr} · {timeStr}</p>
+        </div>
+
+        {/* Center: brand mark + name */}
+        <div className="flex items-center justify-center gap-2.5">
+          <img src="/brand/logo/olia-mark-navy.svg" alt="Olia" className="w-10 h-10 shrink-0" />
           <div>
             <p className="text-xs font-bold text-foreground uppercase tracking-widest leading-none">Olia</p>
-            {/* Issue 9: Show location name prominently */}
             <p className="text-xs text-sage uppercase tracking-wide leading-none mt-0.5 font-semibold">
               {locationName || "Kiosk"}
             </p>
           </div>
         </div>
-        <div className="text-right">
-          <p className="text-xs text-muted-foreground uppercase tracking-widest">Current Status</p>
-          <p className="text-sm font-semibold text-foreground">{dateStr} · {timeStr}</p>
+
+        {/* Right: admin */}
+        <div className="flex justify-end">
+          <button
+            id="admin-btn"
+            onClick={handleAdminButtonClick}
+            className="text-xs font-semibold text-muted-foreground border border-border rounded-full px-3 py-1.5 hover:bg-muted transition-colors shrink-0"
+          >
+            Admin
+          </button>
         </div>
-        <button
-          id="admin-btn"
-          onClick={handleAdminButtonClick}
-          className="text-xs font-semibold text-muted-foreground border border-border rounded-full px-3 py-1.5 hover:bg-muted transition-colors ml-2 shrink-0"
-        >
-          Admin
-        </button>
       </div>
 
       {/* Agenda heading */}


### PR DESCRIPTION
## Changes

**App view (admin/checklists/dashboard)**
- `Layout.tsx`: The `w-8` spacer on the left of every page header is replaced with `olia-mark-navy.svg` — the mark now appears on every authenticated page
- `SidebarNav.tsx`: Olia mark + italic "Olia" wordmark added above the "Navigate" label so the sidebar has a clear brand anchor

**Kiosk grid top bar** (as requested)
- Restructured from `flex justify-between` → `grid grid-cols-3` so the centre column is mathematically centred regardless of left/right content widths
- **Centre**: mark (`w-10`, up from `w-7` for screen-distance visibility) + "OLIA" / location name
- **Left**: Current Status + date/time (was on the right)
- **Right**: Admin button (unchanged position)

## Test plan
- [ ] Authenticated app pages show the Olia mark in the top-left of the header
- [ ] Sidebar shows mark + "Olia" wordmark above nav links
- [ ] Kiosk grid top bar: logo centred, current status on left, Admin on right
- [ ] Mark is clearly visible at kiosk screen distance

🤖 Generated with [Claude Code](https://claude.com/claude-code)