### PR TITLE
fix: remove duplicate mark from Layout header

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -42,9 +42,7 @@ export function Layout({ children, title, subtitle, headerRight, headerLeft }: L
           <div className={cn(shellWidthClass, "flex items-center justify-between gap-2 px-4 py-3 sm:px-6 lg:px-8 xl:px-10")}>
             {headerLeft ? (
               <div className="flex items-center gap-2 shrink-0">{headerLeft}</div>
-            ) : (
-              <img src="/brand/logo/olia-mark-navy.svg" alt="Olia" className="w-8 h-8 shrink-0" />
-            )}
+            ) : <div className="w-8" />}
             <div className="flex-1 min-w-0 text-center">
               <h1 className="font-display text-lg text-foreground leading-tight truncate">{title}</h1>
               {subtitle && (


### PR DESCRIPTION
The sidebar already shows the Olia mark + wordmark. The standalone mark in the top-left header slot was redundant and visually confusing at close proximity. Restoring the w-8 spacer so the header stays balanced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)