### PR TITLE
fix: portal blocker dialog to body and add Member role

### DIFF
--- a/src/lib/admin-repository.ts
+++ b/src/lib/admin-repository.ts
@@ -1,7 +1,7 @@
 // ─── Admin Data Types & Mock Repository ─────────────────────────────────────
 // Isolated data access layer — swap to DB later without rewriting UI.
 
-export type AccountRole = "Owner" | "Manager";
+export type AccountRole = "Owner" | "Manager" | "Member";
 export type StaffStatus = "active" | "archived";
 
 export interface StaffDepartment {

--- a/src/pages/admin/SharedUI.tsx
+++ b/src/pages/admin/SharedUI.tsx
@@ -303,7 +303,11 @@ export function TeamMemberModal({
       role,
       location_ids: locationIds,
       initials: getInitials(name),
-      permissions: role === "Owner" ? { ...DEFAULT_PERMISSIONS } : perms,
+      permissions: role === "Owner"
+        ? { ...DEFAULT_PERMISSIONS }
+        : role === "Manager"
+        ? perms
+        : Object.fromEntries(Object.keys(DEFAULT_PERMISSIONS).map(k => [k, false])) as ManagerPermissions,
       ...(pin ? { rawPin: pin } : {}),
     });
     onClose();
@@ -329,7 +333,7 @@ export function TeamMemberModal({
         </FormField>
         <FormField label="Role">
           <div className="flex gap-2">
-            {(["Owner", "Manager"] as AccountRole[]).map(r => (
+            {(["Owner", "Manager", "Member"] as AccountRole[]).map(r => (
               <button
                 type="button" key={r} onClick={() => setRole(r)}
                 className={cn(

--- a/src/pages/checklists/ChecklistsTab.tsx
+++ b/src/pages/checklists/ChecklistsTab.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, lazy, Suspense } from "react";
+import { createPortal } from "react-dom";
 import { useSearchParams, useBlocker } from "react-router-dom";
 import { Plus, Search, ChevronDown, X, GripVertical, MoreVertical, FolderPlus, ClipboardList, Eye, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -260,7 +261,7 @@ export function ChecklistsTab() {
         editId={editingChecklistId || undefined}
       />
       </Suspense>
-      {blocker.state === "blocked" && (
+      {blocker.state === "blocked" && createPortal(
         <div className="fixed inset-0 z-[80] flex items-center justify-center bg-foreground/30 backdrop-blur-sm">
           <div className="bg-card rounded-2xl p-6 mx-4 max-w-sm w-full shadow-xl space-y-4">
             <h3 className="font-display text-lg text-foreground">Leave without saving?</h3>
@@ -280,7 +281,8 @@ export function ChecklistsTab() {
               </button>
             </div>
           </div>
-        </div>
+        </div>,
+        document.body
       )}
       </>
     );


### PR DESCRIPTION
## Summary
- **Discard dialog bug (recurring):** The "Leave without saving?" blocker dialog in `ChecklistsTab` was rendered inside Layout's `<main>` element, which runs an `animate-fade-in` animation using `transform: translateY(...)`. Any non-`none` CSS transform makes the element a containing block for `position: fixed` descendants — including after the animation ends (fill-mode: both keeps `translateY(0)` applied). So the dialog was fixed relative to `main`, not the viewport, and appeared above the scroll position when the user had scrolled down. Fixed by wrapping it in `createPortal(…, document.body)`, matching the pattern already used in `ChecklistBuilderModal`.
- **Member role missing:** `AccountRole` was `"Owner" | "Manager"` only. Added `"Member"` to the type, the role picker buttons, and made `handleSave` assign all-false permissions for Members.

## Test plan
- [ ] Edit a checklist, scroll down, click another tab — confirm dialog appears centred in the viewport
- [ ] Click "Keep editing" — confirm you stay in the builder
- [ ] Click "Discard changes" — confirm you navigate away cleanly
- [ ] Add team member → confirm three role options: Owner, Manager, Member
- [ ] Save a Member → confirm no permissions panel shown, member saved correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)