### PR TITLE
fix: patch checklist cache on save to fix location revert

### DIFF
--- a/src/hooks/useChecklists.ts
+++ b/src/hooks/useChecklists.ts
@@ -130,7 +130,19 @@ export function useSaveChecklist() {
       if (error) throw error;
       return data;
     },
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["checklists"] }),
+    onSuccess: (_, variables) => {
+      // Immediately patch the cache so the list reflects the new field values
+      // (e.g. location_ids) before the background refetch completes.
+      // Without this, opening the edit modal immediately after saving reads
+      // stale cache data and shows "All locations" even though the save succeeded.
+      if (variables.id) {
+        qc.setQueriesData<ChecklistItem[]>(
+          { queryKey: ["checklists"] },
+          (old) => old?.map((c) => c.id === variables.id ? { ...c, ...variables } : c),
+        );
+      }
+      qc.invalidateQueries({ queryKey: ["checklists"] });
+    },
   });
 }
 


### PR DESCRIPTION
## Summary

- After a successful checklist save, `invalidateQueries` triggers an async background refetch but doesn't block the modal from closing
- If the user reopened the edit modal before the refetch completed (~200–500ms), they'd read stale `location_ids: null` from cache and see "All locations" — even though the DB was correct
- Fix: `setQueriesData` immediately patches the affected checklist in cache on every successful edit, so the correct `location_ids` is visible the instant the list view appears; `invalidateQueries` still runs for an authoritative server sync

## Test plan

- [ ] Edit a checklist, set it to a specific location, save
- [ ] Immediately reopen the same checklist — location should show the saved value (not "All locations")
- [ ] All 308 checklist tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)