### PR TITLE
fix: pass location_ids to builder when opening via checklist row tap

### DIFF
--- a/src/pages/checklists/ChecklistsTab.tsx
+++ b/src/pages/checklists/ChecklistsTab.tsx
@@ -386,6 +386,7 @@ export function ChecklistsTab() {
                 setEditingChecklistId(cl.id);
                 setPrefillTitle(cl.title);
                 setPrefillSections(cl.sections);
+                setPrefillLocationIds(cl.location_ids ?? (cl.location_id ? [cl.location_id] : null));
                 setShowBuilder(true);
               }}
                 className="flex-1 flex items-center gap-3 px-4 py-3.5 text-left hover:bg-muted/30 transition-colors">


### PR DESCRIPTION
## Summary

- The main checklist row click opened the builder with `editingChecklistId`, `prefillTitle`, and `prefillSections` set — but never called `setPrefillLocationIds`
- So `initialLocationIds` was always `undefined`, causing `locationMode` to initialise as `"all"` and the location picker to show "All locations" every time, regardless of what was saved
- The 3-dot menu → Edit path already called `setPrefillLocationIds` correctly; this fix brings the direct row tap in line with it
- One line added: `setPrefillLocationIds(cl.location_ids ?? (cl.location_id ? [cl.location_id] : null))`

## Test plan

- [ ] Save a checklist with a specific location
- [ ] Tap the checklist row directly (not the 3-dot menu) — location should now show correctly on reopen
- [ ] Also verify via 3-dot → Edit still works correctly
- [ ] All 7 ChecklistsTab tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)