### PR TITLE
fix: staff PINs now work in kiosk

### DIFF
--- a/src/pages/kiosk/PinEntryModal.tsx
+++ b/src/pages/kiosk/PinEntryModal.tsx
@@ -17,6 +17,13 @@ export async function validateKioskAdminPin(pin: string, locationId: string) {
   });
 }
 
+export async function validateKioskStaffPin(pin: string, locationId: string) {
+  return supabase.rpc("validate_staff_pin", {
+    p_pin: pin,
+    p_location_id: locationId,
+  });
+}
+
 // ─── clearKioskLocationSelection (needed by AdminLoginModal) ──────────────────
 
 export function clearKioskLocationSelectionForModal() {
@@ -330,15 +337,16 @@ export function PinEntryModal({
       }
     }
     const { data: adminData, error: adminRpcError } = await validateKioskAdminPin(enteredPin, locationId);
-    setValidating(false);
 
     if (!adminRpcError && adminData && adminData.length > 0) {
+      setValidating(false);
       const admin = adminData[0];
       onSuccess(null, admin.name, admin.organization_id ?? "");
       return;
     }
 
     if (adminRpcError) {
+      setValidating(false);
       setPin("");
       if (adminRpcError.message?.includes("Too many PIN attempts")) {
         // Server-side rate limit hit — enforce a 5-minute lockout in the UI
@@ -349,6 +357,22 @@ export function PinEntryModal({
       } else {
         setError("Connection error. Check your network and try again.");
       }
+      return;
+    }
+
+    // Admin PIN not recognised — try staff PIN
+    const { data: staffData, error: staffRpcError } = await validateKioskStaffPin(enteredPin, locationId);
+    setValidating(false);
+
+    if (!staffRpcError && staffData && staffData.length > 0) {
+      const staff = staffData[0];
+      onSuccess(staff.id, `${staff.first_name} ${staff.last_name}`.trim(), staff.organization_id ?? "");
+      return;
+    }
+
+    if (staffRpcError) {
+      setPin("");
+      setError("Connection error. Check your network and try again.");
       return;
     }
 

--- a/src/test/pages/Kiosk.test.tsx
+++ b/src/test/pages/Kiosk.test.tsx
@@ -853,18 +853,94 @@ describe("Kiosk — PIN Entry Modal", () => {
   });
 
   it("entering 4 digits triggers validation — shows error for wrong PIN (no match)", async () => {
+    const { supabase } = await import("@/lib/supabase");
+    supabase.rpc.mockImplementation((fn: string) => {
+      if (fn === "get_kiosk_checklists") {
+        return Promise.resolve({
+          data: [{ id: "ck-test-1", title: "Table Setup Check", location_id: "00000000-0000-0000-0000-000000000011", sections: [] }],
+          error: null,
+        });
+      }
+      if (fn === "verify_kiosk_token") return Promise.resolve({ data: true, error: null });
+      // Both admin and staff PIN return no match → should show error
+      return Promise.resolve({ data: [], error: null });
+    });
+
     const opened = await openPinModal();
     if (!opened) return;
-    // The rpc mock returns empty data, so any PIN will fail
     for (const d of ["9", "9", "9", "9"]) {
       fireEvent.click(screen.getByRole("button", { name: d }));
     }
     await waitFor(() => {
-      // Either "PIN not recognised" or "Checking PIN…" should appear
-      const errorMsg = screen.queryByText(/PIN not recognised/i);
-      const checkingMsg = screen.queryByText(/Checking PIN/i);
-      expect(errorMsg || checkingMsg).not.toBeNull();
-    }, { timeout: 2000 });
+      expect(screen.queryByText(/PIN not recognised/i)).not.toBeNull();
+    }, { timeout: 3000 });
+  });
+
+  it("staff PIN: valid staff PIN opens the runner with staff name", async () => {
+    const { supabase } = await import("@/lib/supabase");
+    supabase.rpc.mockImplementation((fn: string) => {
+      if (fn === "get_kiosk_checklists") {
+        return Promise.resolve({
+          data: [{
+            id: "ck-test-1",
+            title: "Table Setup Check",
+            location_id: "00000000-0000-0000-0000-000000000011",
+            sections: [{ name: "Main", questions: [{ id: "q1", text: "Check done?", responseType: "checkbox", required: false, config: {} }] }],
+          }],
+          error: null,
+        });
+      }
+      if (fn === "verify_kiosk_token") return Promise.resolve({ data: true, error: null });
+      if (fn === "validate_admin_pin") return Promise.resolve({ data: [], error: null });
+      if (fn === "validate_staff_pin") {
+        return Promise.resolve({
+          data: [{ id: "sp-1", first_name: "Jay", last_name: "Chen", role: "Waiter", organization_id: "org-1" }],
+          error: null,
+        });
+      }
+      return Promise.resolve({ data: [], error: null });
+    });
+
+    const opened = await openPinModal();
+    if (!opened) return;
+
+    for (const d of ["5", "6", "7", "8"]) {
+      fireEvent.click(screen.getByRole("button", { name: d }));
+    }
+
+    await waitFor(() => {
+      // Runner opens — staff name appears in the header (alongside a time string)
+      expect(screen.getByText(/Jay Chen/)).toBeInTheDocument();
+    }, { timeout: 3000 });
+  });
+
+  it("staff PIN: RPC error shows connection error message", async () => {
+    const { supabase } = await import("@/lib/supabase");
+    supabase.rpc.mockImplementation((fn: string) => {
+      if (fn === "get_kiosk_checklists") {
+        return Promise.resolve({
+          data: [{ id: "ck-test-1", title: "Table Setup Check", location_id: "00000000-0000-0000-0000-000000000011", sections: [] }],
+          error: null,
+        });
+      }
+      if (fn === "verify_kiosk_token") return Promise.resolve({ data: true, error: null });
+      if (fn === "validate_admin_pin") return Promise.resolve({ data: [], error: null });
+      if (fn === "validate_staff_pin") {
+        return Promise.resolve({ data: null, error: { message: "network error" } });
+      }
+      return Promise.resolve({ data: [], error: null });
+    });
+
+    const opened = await openPinModal();
+    if (!opened) return;
+
+    for (const d of ["1", "2", "3", "4"]) {
+      fireEvent.click(screen.getByRole("button", { name: d }));
+    }
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Connection error/i)).not.toBeNull();
+    }, { timeout: 3000 });
   });
 });
 


### PR DESCRIPTION
## Summary

- `PinEntryModal` was only calling `validate_admin_pin` — the `validate_staff_pin` RPC existed in the database but was never called from the frontend
- Staff members added by admins (with their own PINs) could never authenticate in kiosk mode; only the admin/owner PIN worked
- Fix tries the admin PIN first, then falls through to `validate_staff_pin` when there's no admin match

## Test plan

- [ ] New unit test: valid staff PIN → runner opens with the staff member's name
- [ ] New unit test: both admin + staff PIN fail → "PIN not recognised" error shown
- [ ] New unit test: staff PIN RPC error → "Connection error" shown
- [ ] Manually verify: add a staff member in Admin, set their PIN, open kiosk, enter staff PIN → should open the runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)