### PR TITLE
fix: team member kiosk PINs now work without location assignment

### DIFF
--- a/src/pages/kiosk/PinEntryModal.tsx
+++ b/src/pages/kiosk/PinEntryModal.tsx
@@ -24,6 +24,16 @@ export async function validateKioskStaffPin(pin: string, locationId: string) {
   });
 }
 
+// Validates any team member in the same org as the kiosk location.
+// Unlike validate_admin_pin this has no location_ids restriction —
+// physical presence at the kiosk is sufficient for checklist access.
+export async function validateKioskMemberPin(pin: string, locationId: string) {
+  return supabase.rpc("validate_kiosk_member_pin", {
+    p_pin: pin,
+    p_location_id: locationId,
+  });
+}
+
 // ─── clearKioskLocationSelection (needed by AdminLoginModal) ──────────────────
 
 export function clearKioskLocationSelectionForModal() {
@@ -336,19 +346,22 @@ export function PinEntryModal({
         return;
       }
     }
-    const { data: adminData, error: adminRpcError } = await validateKioskAdminPin(enteredPin, locationId);
+    // Check team members org-wide (any team member of the location's org).
+    // Uses a dedicated RPC with no location_ids restriction — physical presence
+    // at the kiosk is the access control, not the location assignment.
+    const { data: memberData, error: memberRpcError } = await validateKioskMemberPin(enteredPin, locationId);
 
-    if (!adminRpcError && adminData && adminData.length > 0) {
+    if (!memberRpcError && memberData && memberData.length > 0) {
       setValidating(false);
-      const admin = adminData[0];
-      onSuccess(null, admin.name, admin.organization_id ?? "");
+      const member = memberData[0];
+      onSuccess(null, member.name, member.organization_id ?? "");
       return;
     }
 
-    if (adminRpcError) {
+    if (memberRpcError) {
       setValidating(false);
       setPin("");
-      if (adminRpcError.message?.includes("Too many PIN attempts")) {
+      if (memberRpcError.message?.includes("Too many PIN attempts")) {
         // Server-side rate limit hit — enforce a 5-minute lockout in the UI
         const until = Date.now() + 5 * 60 * 1000;
         setLockedUntil(until);
@@ -360,7 +373,7 @@ export function PinEntryModal({
       return;
     }
 
-    // Admin PIN not recognised — try staff PIN
+    // No team member match — try staff profile PIN (SHA-256, location-scoped)
     const { data: staffData, error: staffRpcError } = await validateKioskStaffPin(enteredPin, locationId);
     setValidating(false);
 

--- a/src/test/pages/Kiosk.test.tsx
+++ b/src/test/pages/Kiosk.test.tsx
@@ -124,6 +124,13 @@ vi.mock("@/lib/supabase", () => ({
         });
       }
 
+      if (fn === "validate_kiosk_member_pin") {
+        return Promise.resolve({
+          data: [{ id: "tm-1", name: "Sarah Owner", organization_id: "org-1" }],
+          error: null,
+        });
+      }
+
       if (fn === "insert_kiosk_alert") {
         return mockInsertKioskAlert(params);
       }
@@ -210,19 +217,9 @@ async function openRunnerWithQuestions(questions: any[]) {
       return Promise.resolve({ data: true, error: null });
     }
 
-    if (fn === "validate_admin_pin") {
+    if (fn === "validate_kiosk_member_pin") {
       return Promise.resolve({
-        data: [
-          {
-            id: "tm-1",
-            name: "Sarah Owner",
-            email: "sarah@example.com",
-            role: "Owner",
-            organization_id: "org-1",
-            location_ids: [],
-            permissions: {},
-          },
-        ],
+        data: [{ id: "tm-1", name: "Sarah Owner", organization_id: "org-1" }],
         error: null,
       });
     }
@@ -635,7 +632,7 @@ describe("Kiosk — Grid Screen", () => {
     }
   });
 
-  it("uses the admin PIN validation path when starting a checklist", async () => {
+  it("uses the kiosk member PIN validation path when starting a checklist", async () => {
     const { supabase } = await import("@/lib/supabase");
     supabase.rpc.mockImplementation((fn: string) => {
       if (fn === "get_kiosk_checklists") {
@@ -658,15 +655,9 @@ describe("Kiosk — Grid Screen", () => {
         return Promise.resolve({ data: true, error: null });
       }
 
-      if (fn === "validate_admin_pin") {
+      if (fn === "validate_kiosk_member_pin") {
         return Promise.resolve({
-          data: [
-            {
-              id: "tm-1",
-              name: "Sarah Owner",
-              organization_id: "org-1",
-            },
-          ],
+          data: [{ id: "tm-1", name: "Sarah Owner", organization_id: "org-1" }],
           error: null,
         });
       }
@@ -688,7 +679,7 @@ describe("Kiosk — Grid Screen", () => {
     }
 
     await waitFor(() => {
-      expect(supabase.rpc).toHaveBeenCalledWith("validate_admin_pin", {
+      expect(supabase.rpc).toHaveBeenCalledWith("validate_kiosk_member_pin", {
         p_pin: "1234",
         p_location_id: "00000000-0000-0000-0000-000000000011",
       });
@@ -724,7 +715,7 @@ describe("Kiosk — Grid Screen", () => {
         return Promise.resolve({ data: true, error: null });
       }
 
-      if (fn === "validate_admin_pin") {
+      if (fn === "validate_kiosk_member_pin") {
         return Promise.resolve({
           data: [{ id: "tm-1", name: "Jay Tester", organization_id: "org-1" }],
           error: null,
@@ -891,7 +882,7 @@ describe("Kiosk — PIN Entry Modal", () => {
         });
       }
       if (fn === "verify_kiosk_token") return Promise.resolve({ data: true, error: null });
-      if (fn === "validate_admin_pin") return Promise.resolve({ data: [], error: null });
+      if (fn === "validate_kiosk_member_pin") return Promise.resolve({ data: [], error: null });
       if (fn === "validate_staff_pin") {
         return Promise.resolve({
           data: [{ id: "sp-1", first_name: "Jay", last_name: "Chen", role: "Waiter", organization_id: "org-1" }],
@@ -924,7 +915,7 @@ describe("Kiosk — PIN Entry Modal", () => {
         });
       }
       if (fn === "verify_kiosk_token") return Promise.resolve({ data: true, error: null });
-      if (fn === "validate_admin_pin") return Promise.resolve({ data: [], error: null });
+      if (fn === "validate_kiosk_member_pin") return Promise.resolve({ data: [], error: null });
       if (fn === "validate_staff_pin") {
         return Promise.resolve({ data: null, error: { message: "network error" } });
       }

--- a/supabase/migrations/20260708000001_validate_kiosk_member_pin.sql
+++ b/supabase/migrations/20260708000001_validate_kiosk_member_pin.sql
@@ -1,0 +1,85 @@
+-- ================================================================
+-- Add validate_kiosk_member_pin for checklist PIN entry.
+--
+-- Problem:
+--   PinEntryModal (checklist start flow) was calling validate_admin_pin,
+--   which requires team members to have the kiosk location in location_ids.
+--   Team members added via "Add team member" default to empty location_ids,
+--   so their kiosk PINs silently fail even though the UI implies they work.
+--
+-- Solution:
+--   New validate_kiosk_member_pin checks any team member belonging to the
+--   kiosk's organisation — no location_ids restriction. Checklist access is
+--   already scoped to the physical kiosk's location; the location_ids guard
+--   is only relevant for admin-panel access (validate_admin_pin unchanged).
+--
+--   validate_admin_pin remains strict (location + role check) and is still
+--   used by AdminLoginModal which grants full admin-panel access.
+-- ================================================================
+
+CREATE OR REPLACE FUNCTION public.validate_kiosk_member_pin(
+  p_pin        text,
+  p_location_id uuid
+)
+RETURNS TABLE (
+  id              uuid,
+  name            text,
+  organization_id uuid
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  v_recent_failures INT;
+  v_matched         BOOLEAN := false;
+  v_row             RECORD;
+BEGIN
+  -- Clean up stale attempts (> 1 hour)
+  DELETE FROM pin_attempts
+  WHERE location_id = p_location_id
+    AND attempted_at < now() - INTERVAL '1 hour';
+
+  -- Rate-limit: block after 10 failures in 5 minutes
+  SELECT COUNT(*) INTO v_recent_failures
+  FROM pin_attempts
+  WHERE location_id  = p_location_id
+    AND pin_type     = 'member'
+    AND succeeded    = false
+    AND attempted_at > now() - INTERVAL '5 minutes';
+
+  IF v_recent_failures >= 10 THEN
+    RAISE EXCEPTION 'Too many PIN attempts. Please wait before trying again.'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  -- Match any team member in the same org as the kiosk location.
+  -- No location_ids check: physical presence at the kiosk is sufficient
+  -- for checklist access (distinct from admin-panel access).
+  SELECT
+    tm.id,
+    tm.name,
+    tm.organization_id
+  INTO v_row
+  FROM public.locations loc
+  JOIN public.team_members tm
+    ON tm.organization_id = loc.organization_id
+  WHERE loc.id = p_location_id
+    AND tm.pin IS NOT NULL
+    AND crypt(p_pin, tm.pin) = tm.pin
+  ORDER BY (tm.role = 'Owner') DESC, tm.created_at ASC
+  LIMIT 1;
+
+  v_matched := (v_row IS NOT NULL AND v_row.id IS NOT NULL);
+
+  INSERT INTO pin_attempts (location_id, pin_type, succeeded)
+  VALUES (p_location_id, 'member', v_matched);
+
+  IF v_matched THEN
+    RETURN QUERY SELECT v_row.id, v_row.name, v_row.organization_id;
+  END IF;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.validate_kiosk_member_pin(text, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.validate_kiosk_member_pin(text, uuid) TO anon, authenticated;


### PR DESCRIPTION
## Root cause

`PinEntryModal` was calling `validate_admin_pin`, which rejects any team member whose `location_ids` doesn't include the kiosk's location. When you add a team member via "Add team member", `location_ids` defaults to `[]` — so their "Kiosk PIN" silently fails even though the UI implies it will work. Only Owner PINs bypassed the location check.

## Changes

**New Supabase migration** (`20260708000001_validate_kiosk_member_pin.sql`):
- Adds `validate_kiosk_member_pin(p_pin, p_location_id)` — bcrypt-validates any team member belonging to the kiosk location's org, with **no** `location_ids` restriction
- Physical presence at the kiosk is the relevant access control; `location_ids` is only meaningful for admin-panel access (which `validate_admin_pin` still enforces)
- Includes the same rate-limiting as the other PIN RPCs

**Frontend** (`PinEntryModal.tsx`):
- Checklist PIN flow now calls `validate_kiosk_member_pin` (org-wide team member check) → `validate_staff_pin` (SHA-256 staff profile check)
- `validate_admin_pin` is unchanged and still used exclusively by `AdminLoginModal` (the Admin button)

## Test plan

- [ ] Add a team member with no location assigned → their kiosk PIN should now open the runner
- [ ] Staff profiles still work via the `validate_staff_pin` path
- [ ] Admin button (AdminLoginModal) still requires location assignment / Owner role — `validate_admin_pin` untouched
- [ ] **Apply the new Supabase migration** to the hosted project via Supabase SQL Editor or `supabase db push`

🤖 Generated with [Claude Code](https://claude.com/claude-code)