### PR TITLE
fix: allow member pin_type in pin_attempts

### DIFF
--- a/supabase/migrations/20260708000002_pin_attempts_allow_member_type.sql
+++ b/supabase/migrations/20260708000002_pin_attempts_allow_member_type.sql
@@ -1,0 +1,11 @@
+-- Allow 'member' as a valid pin_type in pin_attempts.
+-- validate_kiosk_member_pin (added in 20260708000001) records attempts
+-- with pin_type = 'member', which the original CHECK only allowed
+-- 'admin' and 'staff', causing a 400 Bad Request at the kiosk.
+
+ALTER TABLE public.pin_attempts
+  DROP CONSTRAINT IF EXISTS pin_attempts_pin_type_check;
+
+ALTER TABLE public.pin_attempts
+  ADD CONSTRAINT pin_attempts_pin_type_check
+  CHECK (pin_type IN ('admin', 'staff', 'member'));


### PR DESCRIPTION
Hotfix for the 400 error on `validate_kiosk_member_pin`. The `pin_attempts` CHECK constraint only allowed `'admin'` and `'staff'` — extending it to also allow `'member'`. Migration already applied to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)