### PR TITLE
feat: add Date & Time as a selectable response type

### DIFF
--- a/src/pages/checklists/ChecklistPreviewModal.tsx
+++ b/src/pages/checklists/ChecklistPreviewModal.tsx
@@ -88,7 +88,20 @@ function MockResponse({
       </div>
     );
   }
-  // "datetime" removed from builder — legacy questions show text preview (falls through below)
+  if (responseType === "datetime") {
+    return (
+      <div className="mt-2 space-y-1.5">
+        <div className="flex items-center gap-2 px-3 py-2 rounded-lg border border-border bg-muted/50">
+          <Calendar size={11} className="text-muted-foreground shrink-0" />
+          <span className="text-xs text-muted-foreground">DD / MM / YYYY</span>
+        </div>
+        <div className="flex items-center gap-2 px-3 py-2 rounded-lg border border-border bg-muted/50 w-32">
+          <Calendar size={11} className="text-muted-foreground shrink-0" />
+          <span className="text-xs text-muted-foreground">HH : MM</span>
+        </div>
+      </div>
+    );
+  }
   if (responseType === "media") {
     return (
       <div className="mt-2 flex items-center gap-2 px-3 py-2 rounded-lg border border-dashed border-border bg-muted/30 w-32">

--- a/src/pages/checklists/data.ts
+++ b/src/pages/checklists/data.ts
@@ -100,9 +100,10 @@ export const RESPONSE_TYPES: { key: ResponseType; label: string; icon: ElementTy
   { key: "checkbox", label: "Checkbox", icon: CheckSquare, group: "response" },
   { key: "text", label: "Text answer", icon: Type, group: "response" },
   { key: "number", label: "Number", icon: Hash, group: "response" },
+  { key: "datetime", label: "Date & Time", icon: CalendarIcon, group: "response" },
   { key: "media", label: "Photo / Media", icon: Image, group: "response" },
   { key: "instruction", label: "Instruction", icon: Info, group: "response" },
-  // removed from builder: "datetime" (Date & Time), "signature", "person"
+  // removed from builder: "signature", "person"
   // Existing saved checklists that contain these types still run — the kiosk
   // runner falls back to a plain text input for any unrecognised/removed type.
 ];

--- a/src/test/pages/checklists/ResponseTypePicker.test.tsx
+++ b/src/test/pages/checklists/ResponseTypePicker.test.tsx
@@ -55,9 +55,9 @@ describe("ResponseTypePicker", () => {
     expect(screen.getByText("Number")).toBeInTheDocument();
   });
 
-  it("does NOT show Date & Time (removed from builder)", () => {
+  it("shows Date & Time response type", () => {
     render(<ResponseTypePicker onSelect={onSelect} onClose={onClose} />);
-    expect(screen.queryByText("Date & Time")).not.toBeInTheDocument();
+    expect(screen.getByText("Date & Time")).toBeInTheDocument();
   });
 
   it("shows Photo / Media response type", () => {

--- a/src/test/pages/checklists/data.test.ts
+++ b/src/test/pages/checklists/data.test.ts
@@ -156,10 +156,10 @@ describe("RESPONSE_TYPES", () => {
     expect(Array.isArray(RESPONSE_TYPES)).toBe(true);
   });
 
-  it("has 5 response types (datetime, signature, person removed from builder)", () => {
-    // datetime, signature, person are no longer exposed in the builder UI.
-    // checkbox, text, number, media, instruction remain.
-    expect(RESPONSE_TYPES).toHaveLength(5);
+  it("has 6 response types (signature, person removed from builder)", () => {
+    // signature, person are no longer exposed in the builder UI.
+    // checkbox, text, number, datetime, media, instruction remain.
+    expect(RESPONSE_TYPES).toHaveLength(6);
   });
 
   it("includes checkbox type", () => {


### PR DESCRIPTION
## Summary
- Re-adds `datetime` to the builder's response type picker so staff can select it when creating questions
- Adds a date/time mock preview in `ChecklistPreviewModal`
- Updates tests to reflect the new picker option

The kiosk runner already had full `DateTimeInput` support — this just unblocks it in the builder UI.

## Test plan
- [ ] Open the checklist builder, add a question, open the response type picker — "Date & Time" appears in the list
- [ ] Select "Date & Time" — the question card shows the correct label and icon
- [ ] Preview the checklist — the datetime question shows the DD/MM/YYYY + HH:MM placeholder
- [ ] Run the checklist in kiosk — date and time inputs render and submit correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)