### PR TITLE
fix: kiosk date/time picker + temperature slider range and step

### DIFF
--- a/src/pages/checklists/ChecklistPreviewModal.tsx
+++ b/src/pages/checklists/ChecklistPreviewModal.tsx
@@ -88,7 +88,20 @@ function MockResponse({
       </div>
     );
   }
-  // "datetime" removed from builder — legacy questions show text preview (falls through below)
+  if (responseType === "datetime") {
+    return (
+      <div className="mt-2 space-y-1.5">
+        <div className="flex items-center gap-2 px-3 py-2 rounded-lg border border-border bg-muted/50">
+          <Calendar size={11} className="text-muted-foreground shrink-0" />
+          <span className="text-xs text-muted-foreground">DD / MM / YYYY</span>
+        </div>
+        <div className="flex items-center gap-2 px-3 py-2 rounded-lg border border-border bg-muted/50 w-32">
+          <Calendar size={11} className="text-muted-foreground shrink-0" />
+          <span className="text-xs text-muted-foreground">HH : MM</span>
+        </div>
+      </div>
+    );
+  }
   if (responseType === "media") {
     return (
       <div className="mt-2 flex items-center gap-2 px-3 py-2 rounded-lg border border-dashed border-border bg-muted/30 w-32">

--- a/src/pages/checklists/data.ts
+++ b/src/pages/checklists/data.ts
@@ -100,9 +100,10 @@ export const RESPONSE_TYPES: { key: ResponseType; label: string; icon: ElementTy
   { key: "checkbox", label: "Checkbox", icon: CheckSquare, group: "response" },
   { key: "text", label: "Text answer", icon: Type, group: "response" },
   { key: "number", label: "Number", icon: Hash, group: "response" },
+  { key: "datetime", label: "Date & Time", icon: CalendarIcon, group: "response" },
   { key: "media", label: "Photo / Media", icon: Image, group: "response" },
   { key: "instruction", label: "Instruction", icon: Info, group: "response" },
-  // removed from builder: "datetime" (Date & Time), "signature", "person"
+  // removed from builder: "signature", "person"
   // Existing saved checklists that contain these types still run — the kiosk
   // runner falls back to a plain text input for any unrecognised/removed type.
 ];

--- a/src/pages/kiosk/QuestionInputs.tsx
+++ b/src/pages/kiosk/QuestionInputs.tsx
@@ -94,9 +94,9 @@ export function TemperatureSliderInput({
   acceptableMax?: number;
   unit?: "C" | "F";
 }) {
-  const sliderMin = unit === "F" ? 32 : 0;
-  const sliderMax = unit === "F" ? 104 : 40;
-  const displayValue = value === "" ? sliderMin : Number(value);
+  const sliderMin = acceptableMin != null ? acceptableMin : (unit === "F" ? 32 : 0);
+  const sliderMax = acceptableMax != null ? acceptableMax : (unit === "F" ? 104 : 40);
+  const displayValue = value === "" ? sliderMin : Math.round(Number(value) * 10) / 10;
 
   const hasAcceptableRange = acceptableMin != null || acceptableMax != null;
   const outOfRange = hasAcceptableRange && value !== "" && (
@@ -124,9 +124,9 @@ export function TemperatureSliderInput({
         type="range"
         min={sliderMin}
         max={sliderMax}
-        step={1}
+        step={0.1}
         value={displayValue}
-        onChange={e => onChange(Number(e.target.value))}
+        onChange={e => onChange(Math.round(Number(e.target.value) * 10) / 10)}
         className="w-full cursor-pointer"
         style={{ accentColor: outOfRange ? "var(--status-error)" : "var(--sage)" }}
       />

--- a/src/pages/kiosk/types.ts
+++ b/src/pages/kiosk/types.ts
@@ -2,10 +2,6 @@
 
 export type TimeOfDay = "morning" | "afternoon" | "evening" | "anytime";
 
-// "datetime" removed from builder — kept here only as a type so the switch-case
-// below doesn't silently drop answers from legacy saved checklists.
-// The SUPPORTED_QUESTION_TYPES list no longer includes "datetime", so any
-// question stored with responseType "datetime" resolves to "text" in the runner.
 export type QuestionType = "checkbox" | "text" | "number" | "multiple_choice" | "datetime" | "instruction" | "media";
 
 export interface Question {

--- a/src/pages/kiosk/utils.ts
+++ b/src/pages/kiosk/utils.ts
@@ -3,11 +3,9 @@
 import type { LogicComparator, LogicRule, QuestionDef } from "@/pages/checklists/types";
 import type { KioskChecklist, KioskDraftSnapshot, Question, QuestionType, TimeOfDay } from "./types";
 
-// "datetime" is intentionally excluded — removed from builder in P0 triage pass.
-// Existing saved questions with responseType "datetime" fall back to "text".
-// "signature" and "person" are also excluded (removed earlier) for the same reason.
+// "signature" and "person" are excluded (removed from builder); they fall back to "text".
 export const SUPPORTED_QUESTION_TYPES: QuestionType[] = [
-  "checkbox", "text", "number", "multiple_choice", "instruction", "media",
+  "checkbox", "text", "number", "datetime", "multiple_choice", "instruction", "media",
 ];
 
 /**

--- a/src/test/pages/checklists/ResponseTypePicker.test.tsx
+++ b/src/test/pages/checklists/ResponseTypePicker.test.tsx
@@ -55,9 +55,9 @@ describe("ResponseTypePicker", () => {
     expect(screen.getByText("Number")).toBeInTheDocument();
   });
 
-  it("does NOT show Date & Time (removed from builder)", () => {
+  it("shows Date & Time response type", () => {
     render(<ResponseTypePicker onSelect={onSelect} onClose={onClose} />);
-    expect(screen.queryByText("Date & Time")).not.toBeInTheDocument();
+    expect(screen.getByText("Date & Time")).toBeInTheDocument();
   });
 
   it("shows Photo / Media response type", () => {

--- a/src/test/pages/checklists/data.test.ts
+++ b/src/test/pages/checklists/data.test.ts
@@ -156,10 +156,10 @@ describe("RESPONSE_TYPES", () => {
     expect(Array.isArray(RESPONSE_TYPES)).toBe(true);
   });
 
-  it("has 5 response types (datetime, signature, person removed from builder)", () => {
-    // datetime, signature, person are no longer exposed in the builder UI.
-    // checkbox, text, number, media, instruction remain.
-    expect(RESPONSE_TYPES).toHaveLength(5);
+  it("has 6 response types (signature, person removed from builder)", () => {
+    // signature, person are no longer exposed in the builder UI.
+    // checkbox, text, number, datetime, media, instruction remain.
+    expect(RESPONSE_TYPES).toHaveLength(6);
   });
 
   it("includes checkbox type", () => {


### PR DESCRIPTION
## Summary

- **Date/time questions** now render the native date/time picker in the kiosk runner instead of falling back to a text input — `datetime` is restored to `SUPPORTED_QUESTION_TYPES`
- **Temperature slider** now uses `acceptableMin`/`acceptableMax` as the slider bounds when set, so negative ranges (e.g. -5 to 5) are fully reachable instead of being clamped at 0
- **Temperature slider** step changed from `1` to `0.1` for decimal precision (e.g. 1.0, 1.1, 1.2 …)
- Values are rounded to 1 decimal place on change to avoid floating-point noise

## Test plan

- [ ] Set a temperature question with min -5, max 5 — confirm slider starts at -5 and moves in 0.1 increments
- [ ] Confirm negative values (e.g. -2.5) display correctly and trigger out-of-range warning when outside acceptable bounds
- [ ] Set a date/time question in the checklist builder and confirm the date/time picker renders in kiosk runner
- [ ] Run `bun run milestone` — lint, tests (≥95% coverage), and build must all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)