### PR TITLE
feat: sticky Publish button in checklist builder header

### DIFF
--- a/src/pages/checklists/ChecklistBuilderModal.tsx
+++ b/src/pages/checklists/ChecklistBuilderModal.tsx
@@ -355,24 +355,31 @@ export function ChecklistBuilderModal({
   const formContent = (
     <>
       {/* Header bar */}
-      <div className="flex items-center justify-between px-5 pt-5 pb-3 border-b border-border shrink-0">
+      <div className="flex items-center justify-between px-5 pt-5 pb-3 border-b border-border shrink-0 sticky top-0 z-10 bg-card">
         {asPage ? (
           <button onClick={handleRequestClose} className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors">
             <ArrowLeft size={16} /> Back
           </button>
         ) : (
-          <div />
-        )}
-        <h2 className="font-display text-lg text-foreground">
-          {editId ? "Edit checklist" : "Build checklist"}
-        </h2>
-        {asPage ? (
-          <div className="w-16" />
-        ) : (
           <button onClick={handleRequestClose} className="btn-icon">
             <X size={18} className="text-muted-foreground" />
           </button>
         )}
+        <h2 className="font-display text-lg text-foreground">
+          {editId ? "Edit checklist" : "Build checklist"}
+        </h2>
+        <button
+          disabled={isSaving || !title.trim() || (locationMode === "specific" && selectedLocationIds.length === 0)}
+          onClick={handleCreate}
+          className={cn(
+            "px-4 py-2 rounded-xl text-sm font-medium transition-colors",
+            !isSaving && title.trim() && (locationMode === "all" || selectedLocationIds.length > 0)
+              ? "bg-sage text-primary-foreground hover:bg-sage-deep"
+              : "bg-muted text-muted-foreground cursor-not-allowed"
+          )}
+        >
+          {isSaving ? "Publishing…" : "Publish"}
+        </button>
       </div>
 
       {/* Form body — no inner scroll; outer overlay handles all scrolling */}
@@ -1204,7 +1211,7 @@ export function ChecklistBuilderModal({
           className={cn("w-full py-3 rounded-xl text-sm font-medium transition-colors",
             !isSaving && title.trim() && (locationMode === "all" || selectedLocationIds.length > 0) ? "bg-sage text-primary-foreground hover:bg-sage-deep" : "bg-muted text-muted-foreground cursor-not-allowed"
           )}>
-          {isSaving ? "Saving…" : editId ? "Save checklist" : "Create checklist"}
+          {isSaving ? "Publishing…" : "Publish"}
         </button>
       </div>
     </>

--- a/src/test/pages/checklists/ChecklistBuilderModal.test.tsx
+++ b/src/test/pages/checklists/ChecklistBuilderModal.test.tsx
@@ -133,14 +133,14 @@ describe("ChecklistBuilderModal - new checklist", () => {
     expect(afterInputs).toBe(beforeInputs + 1);
   });
 
-  it("has a Create checklist button", () => {
+  it("has a Publish button", () => {
     renderWithClient(<ChecklistBuilderModal onClose={onClose} onAdd={onAdd} />);
-    expect(screen.getByText("Create checklist")).toBeInTheDocument();
+    expect(screen.getAllByText("Publish")[0]).toBeInTheDocument();
   });
 
   it("does not call onAdd if title is empty", () => {
     renderWithClient(<ChecklistBuilderModal onClose={onClose} onAdd={onAdd} />);
-    fireEvent.click(screen.getByText("Create checklist"));
+    fireEvent.click(screen.getAllByText("Publish")[0]);
     expect(onAdd).not.toHaveBeenCalled();
   });
 
@@ -149,7 +149,7 @@ describe("ChecklistBuilderModal - new checklist", () => {
     renderWithClient(<ChecklistBuilderModal onClose={onClose} onAdd={onAdd} />);
     const titleInput = screen.getByPlaceholderText(/Morning Opening Checklist/);
     fireEvent.change(titleInput, { target: { value: "New Checklist" } });
-    fireEvent.click(screen.getByText("Create checklist"));
+    fireEvent.click(screen.getAllByText("Publish")[0]);
     await waitFor(() => expect(onAdd).toHaveBeenCalledWith(expect.objectContaining({ title: "New Checklist" })));
     await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
@@ -193,7 +193,7 @@ describe("ChecklistBuilderModal - new checklist", () => {
     fireEvent.change(screen.getByPlaceholderText(/Morning Opening Checklist/), {
       target: { value: "Nested Follow-up Checklist" },
     });
-    fireEvent.click(screen.getByText("Create checklist"));
+    fireEvent.click(screen.getAllByText("Publish")[0]);
 
     expect(onAdd).toHaveBeenCalledWith(expect.objectContaining({
       title: "Nested Follow-up Checklist",
@@ -231,7 +231,7 @@ describe("ChecklistBuilderModal - new checklist", () => {
     fireEvent.change(screen.getByPlaceholderText(/Morning Opening Checklist/), {
       target: { value: "Unanswered Checklist" },
     });
-    fireEvent.click(screen.getByText("Create checklist"));
+    fireEvent.click(screen.getAllByText("Publish")[0]);
 
     const saved = onAdd.mock.calls[0][0] as any;
     expect(saved.sections[0].questions[0].config.logicRules[0].comparator).toBe("unanswered");
@@ -298,7 +298,7 @@ describe("ChecklistBuilderModal - new checklist", () => {
     fireEvent.change(screen.getByPlaceholderText(/Morning Opening Checklist/), {
       target: { value: "Location Checklist" },
     });
-    fireEvent.click(screen.getByText("Create checklist"));
+    fireEvent.click(screen.getAllByText("Publish")[0]);
 
     expect(onAdd).toHaveBeenCalledWith(expect.objectContaining({
       title: "Location Checklist",
@@ -316,7 +316,7 @@ describe("ChecklistBuilderModal - new checklist", () => {
     fireEvent.change(screen.getByPlaceholderText(/Morning Opening Checklist/), {
       target: { value: "All Locations Checklist" },
     });
-    fireEvent.click(screen.getByText("Create checklist"));
+    fireEvent.click(screen.getAllByText("Publish")[0]);
 
     expect(onAdd).toHaveBeenCalledWith(expect.objectContaining({
       title: "All Locations Checklist",
@@ -362,7 +362,7 @@ describe("ChecklistBuilderModal - new checklist", () => {
       target: { value: "MC Checklist" },
     });
 
-    fireEvent.click(screen.getByText("Create checklist"));
+    fireEvent.click(screen.getAllByText("Publish")[0]);
 
     expect(onAdd).toHaveBeenCalledWith(expect.objectContaining({
       title: "MC Checklist",
@@ -434,7 +434,7 @@ describe("ChecklistBuilderModal - new checklist", () => {
       target: { value: "Instruction Checklist" },
     });
 
-    fireEvent.click(screen.getByText("Create checklist"));
+    fireEvent.click(screen.getAllByText("Publish")[0]);
 
     expect(onAdd).toHaveBeenCalledWith(expect.objectContaining({
       title: "Instruction Checklist",
@@ -465,7 +465,7 @@ describe("ChecklistBuilderModal - new checklist", () => {
       target: { value: "Window Checklist" },
     });
 
-    fireEvent.click(screen.getByText("Create checklist"));
+    fireEvent.click(screen.getAllByText("Publish")[0]);
 
     expect(onAdd).toHaveBeenCalledWith(expect.objectContaining({
       title: "Window Checklist",
@@ -490,7 +490,7 @@ describe("ChecklistBuilderModal - new checklist", () => {
       target: { value: "Date Checklist" },
     });
 
-    fireEvent.click(screen.getByText("Create checklist"));
+    fireEvent.click(screen.getAllByText("Publish")[0]);
 
     expect(onAdd).toHaveBeenCalledWith(expect.objectContaining({
       title: "Date Checklist",
@@ -568,7 +568,7 @@ describe("ChecklistBuilderModal - edit mode", () => {
     expect(screen.getByDisplayValue("Check temps")).toBeInTheDocument();
   });
 
-  it("shows 'Save checklist' button in edit mode", () => {
+  it("shows 'Publish' button in edit mode", () => {
     renderWithClient(
       <ChecklistBuilderModal
         onClose={onClose}
@@ -578,7 +578,7 @@ describe("ChecklistBuilderModal - edit mode", () => {
         initialTitle="Existing Checklist"
       />
     );
-    expect(screen.getByText("Save checklist")).toBeInTheDocument();
+    expect(screen.getAllByText("Publish")[0]).toBeInTheDocument();
   });
 
   it("calls onUpdate (not onAdd) when saving in edit mode", () => {
@@ -591,7 +591,7 @@ describe("ChecklistBuilderModal - edit mode", () => {
         initialTitle="Existing Checklist"
       />
     );
-    fireEvent.click(screen.getByText("Save checklist"));
+    fireEvent.click(screen.getAllByText("Publish")[0]);
     expect(onUpdate).toHaveBeenCalledWith("cl-1", expect.objectContaining({ title: "Existing Checklist" }));
     expect(onAdd).not.toHaveBeenCalled();
   });
@@ -623,7 +623,7 @@ describe("ChecklistBuilderModal - edit mode", () => {
     );
 
     expect(screen.getByRole("button", { name: "Select specific locations" })).toHaveClass("bg-sage");
-    fireEvent.click(screen.getByText("Save checklist"));
+    fireEvent.click(screen.getAllByText("Publish")[0]);
 
     expect(onUpdate).toHaveBeenCalledWith("cl-1", expect.objectContaining({
       location_id: "loc-2",


### PR DESCRIPTION
## Summary
- Adds a sticky `Publish` button to the top-right of the checklist builder header so it stays visible while scrolling — no more hunting for the save button at the bottom
- In modal mode, the X close button moves to the left to make room for Publish on the right
- Renames all "Save checklist" / "Create checklist" labels → **Publish** (footer button + loading state)

## Test plan
- [ ] Open the checklist builder (create or edit) and scroll down — confirm the header with Publish stays pinned at the top
- [ ] Click Publish from the header (without scrolling to the bottom) — confirm it saves/creates correctly
- [ ] Confirm the footer Publish button still works too
- [ ] In modal mode, confirm X is on the left and Publish is on the right
- [ ] All 47 unit tests pass (`bun run test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)