### PR TITLE
refactor: floating Publish button in checklist builder

### DIFF
--- a/src/pages/checklists/ChecklistBuilderModal.tsx
+++ b/src/pages/checklists/ChecklistBuilderModal.tsx
@@ -354,36 +354,13 @@ export function ChecklistBuilderModal({
 
   const formContent = (
     <>
-      {/* Header bar */}
-      <div className="flex items-center justify-between px-5 pt-5 pb-3 border-b border-border shrink-0 sticky top-0 z-10 bg-card">
-        {asPage ? (
+      {/* Form body — no inner scroll; outer overlay handles all scrolling */}
+      <div className="p-5 space-y-5">
+        {asPage && (
           <button onClick={handleRequestClose} className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors">
             <ArrowLeft size={16} /> Back
           </button>
-        ) : (
-          <button onClick={handleRequestClose} className="btn-icon">
-            <X size={18} className="text-muted-foreground" />
-          </button>
         )}
-        <h2 className="font-display text-lg text-foreground">
-          {editId ? "Edit checklist" : "Build checklist"}
-        </h2>
-        <button
-          disabled={isSaving || !title.trim() || (locationMode === "specific" && selectedLocationIds.length === 0)}
-          onClick={handleCreate}
-          className={cn(
-            "px-4 py-2 rounded-xl text-sm font-medium transition-colors",
-            !isSaving && title.trim() && (locationMode === "all" || selectedLocationIds.length > 0)
-              ? "bg-sage text-primary-foreground hover:bg-sage-deep"
-              : "bg-muted text-muted-foreground cursor-not-allowed"
-          )}
-        >
-          {isSaving ? "Publishing…" : "Publish"}
-        </button>
-      </div>
-
-      {/* Form body — no inner scroll; outer overlay handles all scrolling */}
-      <div className="p-5 space-y-5">
         {/* Locations */}
         <div className="space-y-3">
           <label className="text-xs text-muted-foreground block font-semibold uppercase tracking-wide">Locations</label>
@@ -1317,6 +1294,21 @@ export function ChecklistBuilderModal({
         </div>
         {subModals}
         {discardConfirmDialog}
+        {createPortal(
+          <button
+            disabled={isSaving || !title.trim() || (locationMode === "specific" && selectedLocationIds.length === 0)}
+            onClick={handleCreate}
+            className={cn(
+              "fixed bottom-24 right-4 z-50 shadow-lg px-5 py-3 rounded-2xl text-sm font-medium transition-colors",
+              !isSaving && title.trim() && (locationMode === "all" || selectedLocationIds.length > 0)
+                ? "bg-sage text-primary-foreground hover:bg-sage-deep"
+                : "bg-muted text-muted-foreground cursor-not-allowed"
+            )}
+          >
+            {isSaving ? "Publishing…" : "Publish"}
+          </button>,
+          document.body
+        )}
       </>
     );
   }
@@ -1326,7 +1318,10 @@ export function ChecklistBuilderModal({
     <>
       <div className="fixed inset-0 z-[60] bg-foreground/20 backdrop-blur-sm overflow-y-auto">
         <div className="flex min-h-full items-end sm:items-center justify-center sm:py-8 px-0 sm:px-4 pb-20">
-          <div className="bg-card w-full max-w-3xl rounded-t-2xl sm:rounded-2xl flex flex-col shadow-xl">
+          <div className="relative bg-card w-full max-w-3xl rounded-t-2xl sm:rounded-2xl flex flex-col shadow-xl">
+            <button onClick={handleRequestClose} className="absolute top-3 right-3 z-10 btn-icon">
+              <X size={18} className="text-muted-foreground" />
+            </button>
             {formContent}
           </div>
         </div>

--- a/src/test/pages/checklists/ChecklistBuilderModal.test.tsx
+++ b/src/test/pages/checklists/ChecklistBuilderModal.test.tsx
@@ -51,12 +51,12 @@ describe("ChecklistBuilderModal - new checklist", () => {
 
   it("renders without crashing", () => {
     renderWithClient(<ChecklistBuilderModal onClose={onClose} onAdd={onAdd} />);
-    expect(screen.getByText("Build checklist")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/Morning Opening Checklist/)).toBeInTheDocument();
   });
 
-  it("shows 'Build checklist' title for new checklist", () => {
+  it("shows the Title input for a new checklist", () => {
     renderWithClient(<ChecklistBuilderModal onClose={onClose} onAdd={onAdd} />);
-    expect(screen.getByText("Build checklist")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/Morning Opening Checklist/)).toBeInTheDocument();
   });
 
   it("has a Title input field", () => {
@@ -508,7 +508,7 @@ describe("ChecklistBuilderModal - edit mode", () => {
     vi.clearAllMocks();
   });
 
-  it("shows 'Edit checklist' title when editId is provided", () => {
+  it("pre-fills the title input when editId is provided", () => {
     renderWithClient(
       <ChecklistBuilderModal
         onClose={onClose}
@@ -525,7 +525,8 @@ describe("ChecklistBuilderModal - edit mode", () => {
         ]}
       />
     );
-    expect(screen.getByText("Edit checklist")).toBeInTheDocument();
+    const titleInput = screen.getByPlaceholderText(/Morning Opening Checklist/);
+    expect((titleInput as HTMLInputElement).value).toBe("Existing Checklist");
   });
 
   it("pre-fills title in edit mode", () => {


### PR DESCRIPTION
## Summary
- Removes the sticky header bar that created a distracting white band with a duplicate "Edit checklist" title
- In page mode: Publish is now a floating pill button fixed to `bottom-right` above the bottom nav (rendered via portal)
- Back link moves to a small non-sticky text link at the top of the form body
- In modal mode: X close button sits `absolute top-3 right-3` on the card, no full header bar

## Test plan
- [ ] Open checklist builder (create or edit) in page mode — confirm no white header band, floating Publish button visible bottom-right
- [ ] Scroll through a long checklist — Publish stays fixed, doesn't move
- [ ] Click floating Publish — saves correctly
- [ ] Footer Publish button still works
- [ ] Open in modal mode — X is top-right of card, no title bar
- [ ] All 47 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)