### PR TITLE
fix: remove background from sticky Back/Publish row

### DIFF
--- a/src/pages/checklists/ChecklistBuilderModal.tsx
+++ b/src/pages/checklists/ChecklistBuilderModal.tsx
@@ -372,7 +372,7 @@ export function ChecklistBuilderModal({
       {/* Form body — no inner scroll; outer overlay handles all scrolling */}
       <div className="p-5 space-y-5">
         {asPage && (
-          <div className="sticky top-0 z-10 -mx-5 px-5 py-2 bg-background flex items-center justify-between">
+          <div className="sticky top-0 z-10 -mx-5 px-5 py-2 flex items-center justify-between">
             <button onClick={handleRequestClose} className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors">
               <ArrowLeft size={16} /> Back
             </button>


### PR DESCRIPTION
## Summary
- Removes `bg-background` from the sticky Back/Publish container that was creating a visible beige band while scrolling
- Buttons now float without any background strip behind them

🤖 Generated with [Claude Code](https://claude.com/claude-code)