### PR TITLE
fix: discard prompt shows on existing checklists without changes

### DIFF
--- a/src/pages/checklists/ChecklistBuilderModal.tsx
+++ b/src/pages/checklists/ChecklistBuilderModal.tsx
@@ -121,18 +121,17 @@ export function ChecklistBuilderModal({
 
   const hasContent = !!(title.trim() || sections.some(s => s.name.trim() || s.questions.some(q => q.text.trim())));
 
-  // Track whether the user has made any changes to an existing checklist after mount
-  const isDirtyRef = useRef(false);
-  const isMountedRef = useRef(false);
-  useEffect(() => {
-    if (!isMountedRef.current) { isMountedRef.current = true; return; }
-    if (editId) isDirtyRef.current = true;
-  }, [title, sections, editId]);
+  // Snapshot initial values so we can detect real changes at close time
+  const initialTitleRef = useRef(initialTitle ?? "");
+  const initialSectionsRef = useRef(JSON.stringify(initialSections ?? []));
 
   // Intercept Back/X when there's unsaved content — show a confirmation first
   const handleRequestClose = () => {
     const warnForNew = !editId && hasContent;
-    const warnForEdit = !!editId && isDirtyRef.current;
+    const warnForEdit = !!editId && (
+      title !== initialTitleRef.current ||
+      JSON.stringify(sections) !== initialSectionsRef.current
+    );
     if (warnForNew || warnForEdit) {
       setShowDiscardConfirm(true);
     } else {


### PR DESCRIPTION
## Summary
- Replaces the mutation-flag approach (`isDirtyRef` + `isMountedRef` effect) with a snapshot comparison against the initial title and sections values
- The old `useEffect` on `[title, sections, editId]` could fire spuriously (e.g. if `editId` changed after mount), marking the form dirty before the user touched anything
- New approach: snapshot `initialTitle` and `initialSections` into refs on mount, then compare at close time with `JSON.stringify` — the discard prompt only appears if values actually changed

## Test plan
- [ ] Open an existing checklist, press Back immediately — no discard prompt
- [ ] Open an existing checklist, make a change, press Back — discard prompt appears
- [ ] Open an existing checklist, make a change, revert it, press Back — no discard prompt (bonus: old code warned here too)
- [ ] All 283 checklist unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)