### PR TITLE
fix: modals render in viewport (createPortal)

### DIFF
--- a/src/components/UpgradePrompt.tsx
+++ b/src/components/UpgradePrompt.tsx
@@ -1,3 +1,4 @@
+import { createPortal } from "react-dom";
 import { useNavigate } from "react-router-dom";
 import { Sparkles, X, ExternalLink } from "lucide-react";
 import { PLAN_LABELS, type Plan } from "@/lib/plan-features";
@@ -17,7 +18,7 @@ export function UpgradePrompt({
   const navigate = useNavigate();
   const isNative = useIsNativeApp();
 
-  return (
+  return createPortal(
     <div className="fixed inset-0 z-[60] flex items-end justify-center bg-foreground/20 backdrop-blur-sm animate-fade-in sm:items-center sm:px-4 sm:py-8">
       <div className="bg-card w-full max-w-lg rounded-t-2xl p-5 pb-10 space-y-4 animate-fade-in sm:max-w-xl sm:rounded-2xl sm:pb-6">
         {/* Header */}
@@ -72,6 +73,7 @@ export function UpgradePrompt({
           )}
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }

--- a/src/pages/checklists/ChecklistPreviewModal.tsx
+++ b/src/pages/checklists/ChecklistPreviewModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { createPortal } from "react-dom";
 import { X, Pencil, CheckSquare, Square, Hash, Type, Calendar, Camera, PenLine, User, Info, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { ChecklistItem, ResponseType } from "./types";
@@ -157,7 +158,7 @@ export function ChecklistPreviewModal({ checklist, onClose, onEdit }: {
     return () => window.removeEventListener("keydown", handler);
   }, [onClose]);
 
-  return (
+  return createPortal(
     <div
       className="fixed inset-0 z-[60] flex items-end justify-center bg-foreground/20 backdrop-blur-sm animate-fade-in sm:items-center sm:px-4 sm:py-8"
       onClick={onClose}
@@ -294,6 +295,7 @@ export function ChecklistPreviewModal({ checklist, onClose, onEdit }: {
           </div>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }

--- a/src/pages/checklists/LogDetailModal.tsx
+++ b/src/pages/checklists/LogDetailModal.tsx
@@ -1,3 +1,4 @@
+import { createPortal } from "react-dom";
 import { X, Camera, Check, MessageSquare, FileText, Hash, Type, Calendar, GitBranch, Info } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { exportLogDetailPdf } from "@/lib/export-utils";
@@ -48,7 +49,7 @@ export function LogDetailModal({ log, onClose }: { log: LogEntry; onClose: () =>
     });
   };
 
-  return (
+  return createPortal(
     <div className="fixed inset-0 z-[60] flex items-end justify-center bg-foreground/20 backdrop-blur-sm animate-fade-in sm:items-center sm:px-4 sm:py-8" onClick={onClose}>
       <div className="bg-card w-full rounded-t-2xl flex flex-col max-h-[85vh] animate-fade-in sm:max-w-2xl sm:rounded-2xl sm:max-h-[90vh]" onClick={e => e.stopPropagation()}>
         <div className="flex flex-col gap-3 px-5 pt-5 pb-4 border-b border-border shrink-0 sm:flex-row sm:items-start sm:justify-between">
@@ -184,6 +185,7 @@ export function LogDetailModal({ log, onClose }: { log: LogEntry; onClose: () =>
           </p>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }


### PR DESCRIPTION
## Summary
- The `fade-in` animation leaves `transform: translateY(0)` permanently on `<main>` (`fill-mode: both`), making it a CSS containing block for `position: fixed` descendants
- Modals were anchoring to the top of the inner scroll container instead of the viewport — visible as a cropped/mispositioned popup when scrolled down
- Applied `createPortal(…, document.body)` to `LogDetailModal`, `ChecklistPreviewModal`, and `UpgradePrompt`

## Test plan
- [ ] Open Reporting tab, scroll down to the Completion Log, click a checklist entry — modal should appear centred in the viewport, not at the top of the page
- [ ] Same check for Checklists tab → preview a checklist while scrolled down
- [ ] Trigger an upgrade prompt while scrolled down — should appear correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)