### PR TITLE
fix: wrap all remaining modals in createPortal

### DIFF
--- a/src/pages/Maintenance.tsx
+++ b/src/pages/Maintenance.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { createPortal } from "react-dom";
 import { Layout } from "@/components/Layout";
 import { Plus, X, List, CalendarDays, ChevronLeft, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -81,7 +82,7 @@ function NewTaskModal({ onClose, onAdd }: {
     onClose();
   };
 
-  return (
+  return createPortal(
     <div className="fixed inset-0 z-50 flex items-end justify-center bg-foreground/20 backdrop-blur-sm animate-fade-in">
       <div className="bg-card w-full max-w-lg rounded-t-2xl p-5 pb-8 space-y-4 animate-fade-in">
         <div className="flex items-center justify-between">
@@ -132,7 +133,8 @@ function NewTaskModal({ onClose, onAdd }: {
           Add task
         </button>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }
 

--- a/src/pages/SOPs.tsx
+++ b/src/pages/SOPs.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { createPortal } from "react-dom";
 import { Layout } from "@/components/Layout";
 import { ChevronRight, FileText, Link, Brain, Plus, Search } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -94,7 +95,7 @@ const catColors: Record<string, string> = {
 // ─── SOP Detail Sheet (simple modal) ─────────────────────────────────────────
 
 function SOPDetail({ sop, onClose }: { sop: SOP; onClose: () => void }) {
-  return (
+  return createPortal(
     <div className="fixed inset-0 z-50 flex flex-col bg-background animate-fade-in">
       <header className="flex items-center gap-3 px-5 py-4 border-b border-border">
         <button onClick={onClose} className="text-muted-foreground hover:text-foreground transition-colors text-sm">
@@ -159,7 +160,8 @@ function SOPDetail({ sop, onClose }: { sop: SOP; onClose: () => void }) {
 
         <p className="text-xs text-muted-foreground">Last updated {sop.updatedAt}</p>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }
 

--- a/src/pages/TrainingAIModal.tsx
+++ b/src/pages/TrainingAIModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { createPortal } from "react-dom";
 import { AlertCircle, Sparkles, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { supabase } from "@/lib/supabase";
@@ -40,7 +41,7 @@ export function TrainingAIModal({
     }
   };
 
-  return (
+  return createPortal(
     <div className="fixed inset-0 z-[60] flex items-end justify-center pb-16 bg-foreground/20 backdrop-blur-sm animate-fade-in sm:items-center sm:pb-0 sm:px-4 sm:py-8">
       <div className="bg-card w-full max-w-lg rounded-t-2xl p-5 pb-20 space-y-5 animate-fade-in sm:max-w-2xl sm:rounded-2xl sm:pb-8">
         <div className="flex items-center justify-between">
@@ -108,6 +109,7 @@ export function TrainingAIModal({
           {generating ? "Generating…" : "Generate training module"}
         </button>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }

--- a/src/pages/admin/SharedUI.tsx
+++ b/src/pages/admin/SharedUI.tsx
@@ -3,6 +3,7 @@
 // ConfirmModal, StaffProfileModal, TeamMemberModal, LocationModal
 
 import { useState, useEffect } from "react";
+import { createPortal } from "react-dom";
 import {
   MapPin, Plus, Pencil, X,
   ChevronDown,
@@ -30,7 +31,7 @@ export const inputCls = "w-full border border-border rounded-xl px-4 py-3 text-s
 // ─── BottomSheet ──────────────────────────────────────────────────────────────
 
 export function BottomSheet({ children, onClose }: { children: React.ReactNode; onClose: () => void }) {
-  return (
+  return createPortal(
     <div
       className="fixed inset-0 z-[60] flex items-end justify-center bg-foreground/20 backdrop-blur-sm animate-fade-in sm:items-center sm:px-4 sm:py-8"
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
@@ -38,7 +39,8 @@ export function BottomSheet({ children, onClose }: { children: React.ReactNode; 
       <div className="bg-card w-full max-w-lg rounded-t-2xl p-5 pb-8 space-y-4 animate-fade-in max-h-[85vh] overflow-y-auto sm:max-w-2xl sm:rounded-2xl sm:max-h-[90vh] sm:shadow-2xl">
         {children}
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }
 

--- a/src/pages/checklists/BuildWithAIModal.tsx
+++ b/src/pages/checklists/BuildWithAIModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { createPortal } from "react-dom";
 import { X, Sparkles, AlertCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { supabase } from "@/lib/supabase";
@@ -32,7 +33,7 @@ export function BuildWithAIModal({ onClose, onGenerate }: { onClose: () => void;
     }
   };
 
-  return (
+  return createPortal(
     <div className="fixed inset-0 z-[60] flex items-end justify-center pb-16 bg-foreground/20 backdrop-blur-sm animate-fade-in sm:items-center sm:pb-0 sm:px-4 sm:py-8">
       <div className="bg-card w-full max-w-lg rounded-t-2xl p-5 pb-20 space-y-5 animate-fade-in sm:max-w-2xl sm:rounded-2xl sm:pb-8">
         <div className="flex items-center justify-between">
@@ -70,6 +71,7 @@ export function BuildWithAIModal({ onClose, onGenerate }: { onClose: () => void;
           {generating ? "Generating…" : "Generate checklist"}
         </button>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }

--- a/src/pages/checklists/ChecklistBuilderModal.tsx
+++ b/src/pages/checklists/ChecklistBuilderModal.tsx
@@ -1330,7 +1330,7 @@ export function ChecklistBuilderModal({
   }
 
   // Modal mode — single scroll container is the outer overlay; card grows naturally
-  return (
+  return createPortal(
     <>
       <div className="fixed inset-0 z-[60] bg-foreground/20 backdrop-blur-sm overflow-y-auto">
         <div className="flex min-h-full items-end sm:items-center justify-center sm:py-8 px-0 sm:px-4 pb-20">
@@ -1344,6 +1344,7 @@ export function ChecklistBuilderModal({
       </div>
       {subModals}
       {discardConfirmDialog}
-    </>
+    </>,
+    document.body
   );
 }

--- a/src/pages/checklists/ChecklistsTab.tsx
+++ b/src/pages/checklists/ChecklistsTab.tsx
@@ -459,7 +459,7 @@ export function ChecklistsTab() {
         )}
       </Suspense>
 
-      {showNewFolder && (
+      {showNewFolder && createPortal(
         <div className="fixed inset-0 z-[60] flex items-end justify-center pb-16 bg-foreground/20 backdrop-blur-sm animate-fade-in">
           <div className="bg-card w-full max-w-lg rounded-t-2xl p-5 pb-20 space-y-4 animate-fade-in">
             <div className="flex items-center justify-between">
@@ -477,7 +477,8 @@ export function ChecklistsTab() {
               Create folder
             </button>
           </div>
-        </div>
+        </div>,
+        document.body
       )}
 
       {contextMenu && (
@@ -485,7 +486,7 @@ export function ChecklistsTab() {
           onClose={() => setContextMenu(null)} />
       )}
 
-      {deleteConfirm && (
+      {deleteConfirm && createPortal(
         <div className="fixed inset-0 z-[60] flex items-end justify-center pb-16 bg-foreground/20 backdrop-blur-sm animate-fade-in">
           <div className="bg-card w-full max-w-lg rounded-t-2xl p-5 pb-20 space-y-4 animate-fade-in">
             <div className="flex items-center gap-3">
@@ -512,7 +513,8 @@ export function ChecklistsTab() {
               </button>
             </div>
           </div>
-        </div>
+        </div>,
+        document.body
       )}
 
       {moveTarget && (
@@ -531,7 +533,7 @@ export function ChecklistsTab() {
         />
       )}
 
-      {renameTarget && (
+      {renameTarget && createPortal(
         <div className="fixed inset-0 z-[60] flex items-end justify-center pb-16 bg-foreground/20 backdrop-blur-sm animate-fade-in">
           <div className="bg-card w-full max-w-lg rounded-t-2xl p-5 pb-20 space-y-4 animate-fade-in">
             <div className="flex items-center justify-between">
@@ -553,7 +555,8 @@ export function ChecklistsTab() {
               Rename
             </button>
           </div>
-        </div>
+        </div>,
+        document.body
       )}
     </>
   );

--- a/src/pages/checklists/ConvertFileModal.tsx
+++ b/src/pages/checklists/ConvertFileModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { createPortal } from "react-dom";
 import { X, FileUp, AlertCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { supabase } from "@/lib/supabase";
@@ -119,7 +120,7 @@ export function ConvertFileModal({ onClose, onConvert }: { onClose: () => void; 
     }
   };
 
-  return (
+  return createPortal(
     <div
       className="fixed inset-0 z-[60] flex items-center justify-center bg-foreground/20 p-4 backdrop-blur-sm animate-fade-in sm:p-6"
       onClick={onClose}
@@ -185,6 +186,7 @@ export function ConvertFileModal({ onClose, onConvert }: { onClose: () => void; 
           {converting ? "Converting…" : "Convert to checklist"}
         </button>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }

--- a/src/pages/checklists/CreateMenuSheet.tsx
+++ b/src/pages/checklists/CreateMenuSheet.tsx
@@ -1,3 +1,4 @@
+import { createPortal } from "react-dom";
 import { X, ClipboardList, FileUp, Sparkles, FolderPlus, ChevronRight } from "lucide-react";
 
 export function CreateMenuSheet({ onClose, onBuildOwn, onConvertFile, onBuildAI, onCreateFolder }: {
@@ -14,7 +15,7 @@ export function CreateMenuSheet({ onClose, onBuildOwn, onConvertFile, onBuildAI,
     { label: "Create a folder", icon: FolderPlus, action: onCreateFolder },
   ];
 
-  return (
+  return createPortal(
     <div className="fixed inset-0 z-[60] flex items-end justify-center bg-foreground/20 px-4 pb-8 backdrop-blur-sm animate-fade-in sm:items-center sm:px-6 sm:py-10">
       <div className="bg-card w-full max-w-md rounded-3xl border border-border p-5 pb-6 space-y-1 shadow-2xl animate-fade-in">
         <div className="flex items-center justify-between mb-3">
@@ -40,6 +41,7 @@ export function CreateMenuSheet({ onClose, onBuildOwn, onConvertFile, onBuildAI,
           </button>
         ))}
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }

--- a/src/pages/checklists/CustomRecurrencePicker.tsx
+++ b/src/pages/checklists/CustomRecurrencePicker.tsx
@@ -1,3 +1,4 @@
+import { createPortal } from "react-dom";
 import { ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { CustomRecurrence } from "./types";
@@ -11,7 +12,7 @@ export function CustomRecurrencePicker({ value, onChange, onClose }: {
   const DAY_KEYS = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"];
   const UNITS: CustomRecurrence["unit"][] = ["day", "week", "month", "year"];
 
-  return (
+  return createPortal(
     <div className="fixed inset-0 z-[70] flex items-end justify-center pb-16 bg-foreground/20 backdrop-blur-sm animate-fade-in sm:items-center sm:pb-0 sm:px-4 sm:py-8">
       <div className="bg-card w-full max-w-lg rounded-t-2xl p-5 pb-20 space-y-5 animate-fade-in max-h-[85vh] overflow-y-auto sm:max-w-2xl sm:rounded-2xl sm:max-h-[90vh]">
         <h2 className="font-display text-xl text-foreground">Custom recurrence</h2>
@@ -99,6 +100,7 @@ export function CustomRecurrencePicker({ value, onChange, onClose }: {
           </button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }

--- a/src/pages/checklists/ItemContextMenu.tsx
+++ b/src/pages/checklists/ItemContextMenu.tsx
@@ -1,3 +1,4 @@
+import { createPortal } from "react-dom";
 import { Move, Pencil, Copy, Download, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -20,7 +21,7 @@ export function ItemContextMenu({ type, onAction, onClose }: {
   ];
   const actions = type === "folder" ? folderActions : checklistActions;
 
-  return (
+  return createPortal(
     <div className="fixed inset-0 z-[60] flex items-end justify-center pb-16 bg-foreground/20 backdrop-blur-sm animate-fade-in sm:items-center sm:pb-0 sm:px-4 sm:py-8" onClick={onClose}>
       <div className="bg-card w-full max-w-lg rounded-t-2xl p-2 pb-20 animate-fade-in sm:max-w-xl sm:rounded-2xl sm:pb-4" onClick={e => e.stopPropagation()}>
         {actions.map(a => (
@@ -32,6 +33,7 @@ export function ItemContextMenu({ type, onAction, onClose }: {
           </button>
         ))}
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }

--- a/src/pages/checklists/MoveToFolderSheet.tsx
+++ b/src/pages/checklists/MoveToFolderSheet.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { createPortal } from "react-dom";
 import { X, Folder, Home, Search } from "lucide-react";
 import type { FolderItem } from "./types";
 
@@ -13,7 +14,7 @@ export function MoveToFolderSheet({ folders, currentFolderId, onMove, onClose }:
   const filtered = [rootOption, ...folders.filter(f => f.id !== currentFolderId)]
     .filter(f => f.name.toLowerCase().includes(search.toLowerCase()));
 
-  return (
+  return createPortal(
     <div className="fixed inset-0 z-[60] flex items-end justify-center pb-16 bg-foreground/20 backdrop-blur-sm animate-fade-in sm:items-center sm:pb-0 sm:px-4 sm:py-8">
       <div className="bg-card w-full max-w-lg rounded-t-2xl p-5 pb-20 space-y-4 animate-fade-in max-h-[85vh] overflow-y-auto sm:max-w-2xl sm:rounded-2xl sm:max-h-[90vh]">
         <div className="flex items-center justify-between">
@@ -51,6 +52,7 @@ export function MoveToFolderSheet({ folders, currentFolderId, onMove, onClose }:
           </p>
         )}
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }

--- a/src/pages/infohub/InfohubShared.tsx
+++ b/src/pages/infohub/InfohubShared.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 
 import { supabase } from "@/lib/supabase";
 import { isInfohubAiResult, type InfohubAiAction, type InfohubAiResult } from "@/lib/infohub-ai";
@@ -45,7 +46,7 @@ export function CenteredModalShell({
   onClose: () => void;
   maxWidthClass?: string;
 }) {
-  return (
+  return createPortal(
     <div
       className="fixed inset-0 z-[60] flex items-end justify-center bg-foreground/30 px-4 pb-8 backdrop-blur-sm sm:items-center sm:px-6 sm:py-10"
       onClick={onClose}
@@ -59,7 +60,8 @@ export function CenteredModalShell({
       >
         {children}
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }
 


### PR DESCRIPTION
## Summary
- Sweeps all remaining modals affected by the `animate-fade-in` transform bug (see #445 for root cause explanation)
- 13 files changed across checklists, infohub, admin, training, maintenance, and SOPs
- Every `fixed inset-0` overlay now renders via `createPortal(…, document.body)` so it is always viewport-relative

## Files changed
| File | What |
|------|------|
| `CreateMenuSheet` | "Create new" bottom sheet |
| `BuildWithAIModal` | AI checklist builder |
| `ConvertFileModal` | File-to-checklist converter |
| `ItemContextMenu` | 3-dot action sheet (Checklists + Infohub) |
| `MoveToFolderSheet` | Move to folder sheet |
| `CustomRecurrencePicker` | Recurrence picker in builder |
| `ChecklistBuilderModal` | Main builder overlay |
| `ChecklistsTab` | New folder / Delete confirm / Rename dialogs |
| `TrainingAIModal` | AI training builder |
| `admin/SharedUI` `BottomSheet` | Admin bottom sheet wrapper |
| `infohub/InfohubShared` `CenteredModalShell` | Infohub modal shell |
| `Maintenance` | Add task sheet |
| `SOPs` | SOP detail overlay |

## Test plan
- [ ] Open each affected modal while scrolled down — confirm it appears centred in the viewport, not off-screen
- [ ] Confirm backdrop covers the full viewport including header and sidebar
- [ ] Verify close/confirm actions still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)