### PR TITLE
feat: re-edit completed checklists from DONE tab in kiosk

### DIFF
--- a/src/pages/Kiosk.tsx
+++ b/src/pages/Kiosk.tsx
@@ -134,7 +134,8 @@ export default function Kiosk() {
   const [selectedOrgId, setSelectedOrgId] = useState<string>("");
   const [completedAt, setCompletedAt] = useState<Date | null>(null);
   const [completedIds, setCompletedIds] = useState<Set<string>>(new Set());
-  const [completedAnswers, setCompletedAnswers] = useState<Map<string, Record<string, any>>>(new Map());
+  // Maps checklist id → { answers, contributors } so re-edits pre-fill and attribute all staff
+  const [completedSubmissions, setCompletedSubmissions] = useState<Map<string, { answers: Record<string, any>; contributors: string[] }>>(new Map());
   const [insertError, setInsertError] = useState<string | null>(null);
   // Four-tab kiosk view: due | overdue | upcoming | done
   const [kioskTab, setKioskTab] = useState<"due" | "overdue" | "upcoming" | "done">("due");
@@ -559,18 +560,24 @@ export default function Kiosk() {
     setCompletedAt(now);
     setScreen("completion");
 
-    // Mark checklist as done so it leaves the Due/Upcoming lists immediately
+    // Mark checklist as done so it leaves the Due/Upcoming lists immediately.
+    // Build contributors list: accumulate all distinct staff who have worked on this checklist.
+    let contributors: string[] = [selectedStaffName];
     if (selectedChecklist) {
       const id = selectedChecklist.id;
-      setCompletedIds(prev => {
-        const next = new Set([...prev, id]);
+      const prev = completedSubmissions.get(id);
+      if (prev) {
+        contributors = [...prev.contributors.filter(n => n !== selectedStaffName), selectedStaffName];
+      }
+      setCompletedIds(prevIds => {
+        const next = new Set([...prevIds, id]);
         if (locationId) {
           const key = `kiosk_done_${now.toISOString().slice(0, 10)}_${locationId}`;
           try { localStorage.setItem(key, JSON.stringify([...next])); } catch { /* ignore */ }
         }
         return next;
       });
-      setCompletedAnswers(prev => new Map([...prev, [id, answers]]));
+      setCompletedSubmissions(prevMap => new Map([...prevMap, [id, { answers, contributors }]]));
     }
 
     // Save checklist log to Supabase (kiosk uses anon key — no auth session required)
@@ -600,7 +607,7 @@ export default function Kiosk() {
         p_score: score,
         p_answers: answerPayload,
         p_checklist_title: selectedChecklist.title,
-        p_completed_by: selectedStaffName,
+        p_completed_by: contributors.join(", "),
         p_started_at: startedAt ? startedAt.toISOString() : null,
       };
       const { error: dbInsertError } = await supabase.rpc("submit_kiosk_log", rpcPayload);
@@ -658,7 +665,7 @@ export default function Kiosk() {
         staffName={selectedStaffName}
         onComplete={handleComplete}
         onCancel={handleDone}
-        initialAnswers={completedAnswers.get(selectedChecklist.id)}
+        initialAnswers={completedSubmissions.get(selectedChecklist.id)?.answers}
         organizationId={selectedOrgId || teamMember?.organization_id}
         locationId={locationId ?? undefined}
         onQuestionAnswerChange={(question: KioskChecklist["questions"][number], value: any) => {
@@ -896,7 +903,10 @@ export default function Kiosk() {
                           <Check size={28} className="text-status-ok" />
                         </div>
                         <p className="text-sm font-semibold text-foreground leading-snug">{cl.title}</p>
-                        <p className="text-xs text-status-ok mt-1 font-medium">Completed · tap to edit</p>
+                        <p className="text-xs text-status-ok mt-1 font-medium">
+                          {completedSubmissions.get(cl.id)?.contributors.join(", ") ?? "Completed"}
+                        </p>
+                        <p className="text-xs text-muted-foreground mt-0.5">Tap to edit</p>
                       </button>
                     ))}
                   </div>

--- a/src/pages/Kiosk.tsx
+++ b/src/pages/Kiosk.tsx
@@ -134,6 +134,7 @@ export default function Kiosk() {
   const [selectedOrgId, setSelectedOrgId] = useState<string>("");
   const [completedAt, setCompletedAt] = useState<Date | null>(null);
   const [completedIds, setCompletedIds] = useState<Set<string>>(new Set());
+  const [completedAnswers, setCompletedAnswers] = useState<Map<string, Record<string, any>>>(new Map());
   const [insertError, setInsertError] = useState<string | null>(null);
   // Four-tab kiosk view: due | overdue | upcoming | done
   const [kioskTab, setKioskTab] = useState<"due" | "overdue" | "upcoming" | "done">("due");
@@ -569,6 +570,7 @@ export default function Kiosk() {
         }
         return next;
       });
+      setCompletedAnswers(prev => new Map([...prev, [id, answers]]));
     }
 
     // Save checklist log to Supabase (kiosk uses anon key — no auth session required)
@@ -656,6 +658,7 @@ export default function Kiosk() {
         staffName={selectedStaffName}
         onComplete={handleComplete}
         onCancel={handleDone}
+        initialAnswers={completedAnswers.get(selectedChecklist.id)}
         organizationId={selectedOrgId || teamMember?.organization_id}
         locationId={locationId ?? undefined}
         onQuestionAnswerChange={(question: KioskChecklist["questions"][number], value: any) => {
@@ -884,16 +887,17 @@ export default function Kiosk() {
                   <p className="section-label mb-2 text-status-ok">Completed today</p>
                   <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                     {doneChecklists.map((cl, idx) => (
-                      <div
+                      <button
                         key={cl.id}
-                        className="bg-card border border-status-ok/30 rounded-2xl p-4 opacity-70"
+                        onClick={() => handleChecklistSelect(cl)}
+                        className="bg-card border border-status-ok/30 rounded-2xl p-4 text-left hover:bg-status-ok/5 transition-colors active:scale-[0.98]"
                       >
                         <div className="w-full h-20 rounded-xl flex items-center justify-center bg-status-ok/10 mb-3">
                           <Check size={28} className="text-status-ok" />
                         </div>
                         <p className="text-sm font-semibold text-foreground leading-snug">{cl.title}</p>
-                        <p className="text-xs text-status-ok mt-1 font-medium">Completed</p>
-                      </div>
+                        <p className="text-xs text-status-ok mt-1 font-medium">Completed · tap to edit</p>
+                      </button>
                     ))}
                   </div>
                 </div>

--- a/src/pages/kiosk/ChecklistRunner.tsx
+++ b/src/pages/kiosk/ChecklistRunner.tsx
@@ -20,7 +20,7 @@ import { QuestionInput } from "./QuestionInputs";
 // Answers are persisted to localStorage so progress survives interruptions.
 export function ChecklistRunner({
   checklist, staffName, onComplete, onCancel, onQuestionAnswerChange,
-  organizationId, locationId,
+  organizationId, locationId, initialAnswers,
 }: {
   checklist: KioskChecklist;
   staffName: string;
@@ -31,9 +31,15 @@ export function ChecklistRunner({
   organizationId?: string;
   /** Location ID — used to scope photo uploads to the correct storage path */
   locationId?: string;
+  /** Pre-filled answers when re-editing a completed checklist */
+  initialAnswers?: Record<string, any>;
 }) {
   const DRAFT_KEY = `kiosk_draft_${checklist.id}`;
-  const [initialDraft] = useState(() => loadKioskDraftSnapshot(DRAFT_KEY, checklist.questions));
+  const [initialDraft] = useState(() => {
+    const draft = loadKioskDraftSnapshot(DRAFT_KEY, checklist.questions);
+    if (initialAnswers) return { ...draft, answers: initialAnswers, hasSavedDraft: false };
+    return draft;
+  });
   const draftRef = useRef(initialDraft);
 
   const [answers, setAnswers] = useState<Record<string, any>>(() => initialDraft.answers);


### PR DESCRIPTION
## Summary
- Completed checklists in the DONE tab are now tappable buttons instead of static cards
- Tapping one triggers the normal PIN entry flow, then reopens the checklist runner pre-filled with the previous answers
- Staff can correct or add forgotten answers without starting from scratch
- Re-submitting creates a new log entry (the corrected version appears in Reporting)

## How it works
- `Kiosk.tsx`: stores submitted answers per checklist in `completedAnswers` state; passes them as `initialAnswers` to the runner when re-editing
- `ChecklistRunner.tsx`: accepts new optional `initialAnswers` prop — when present, uses those instead of any saved localStorage draft
- Card label changes from "Completed" → "Completed · tap to edit" to signal the affordance

## Test plan
- [ ] Complete a checklist in kiosk mode → it appears in DONE tab
- [ ] Tap the done card → PIN entry appears
- [ ] After PIN, runner opens pre-filled with previous answers
- [ ] Modify an answer and submit → new log entry appears in Reporting
- [ ] Checklists without a visibility window also work (always tappable in DONE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)