### PR TITLE
fix: Safari trigger dropdown + landing nav mobile layout

### DIFF
--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -448,6 +448,14 @@ const css = `
     .ol-footer-links { justify-content: flex-start; }
     .ol-footer-copy { text-align: left; }
   }
+  @media (max-width: 640px) {
+    .ol-nav { padding: 0 20px; height: 56px; }
+    .ol-nav-links { display: none; }
+    .ol-nav-actions .ol-btn-ghost { display: none; }
+    .ol-signin { display: none; }
+    .ol-container { padding: 0 20px; }
+    .ol-hero { padding: 88px 0 48px; }
+  }
 `;
 
 function Tick() {

--- a/src/pages/checklists/FollowUpQuestionEditor.tsx
+++ b/src/pages/checklists/FollowUpQuestionEditor.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useRef, useState, useEffect } from "react";
 import {
   Bell,
   Camera,
@@ -474,6 +474,19 @@ function LogicRulesEditor({
   const showLogic = rules.length > 0;
   const isNumericType = question.responseType === "number";
   const isMcType = question.responseType === "multiple_choice" || question.responseType === "checkbox";
+  const [openDropdown, setOpenDropdown] = useState<number | null>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (openDropdown === null) return;
+    const handleClick = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setOpenDropdown(null);
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [openDropdown]);
 
   const NUMERIC_COMPARATORS: { key: LogicComparator; label: string }[] = [
     { key: "lt", label: "Less than" },
@@ -720,23 +733,29 @@ function LogicRulesEditor({
                     </button>
                   </div>
                 ))}
-                <div className="relative group inline-block">
-                  <button className="text-xs text-sage hover:text-sage-deep transition-colors flex items-center gap-1">
+                <div className="relative inline-block" ref={openDropdown === ri ? dropdownRef : undefined}>
+                  <button
+                    type="button"
+                    onClick={() => setOpenDropdown(openDropdown === ri ? null : ri)}
+                    className="text-xs text-sage hover:text-sage-deep transition-colors flex items-center gap-1"
+                  >
                     <Plus size={11} /> trigger
                   </button>
-                  <div className="hidden group-focus-within:block absolute left-0 top-full mt-1 bg-card border border-border rounded-lg shadow-lg z-10 py-1 min-w-[160px]">
-                    {TRIGGER_OPTIONS.filter(t => t.key !== "require_action" && !rule.triggers.some(rt => rt.type === t.key)).map(t => (
-                      <button
-                        key={t.key}
-                        onClick={() => addTrigger(ri, t.key)}
-                        className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-muted/50 transition-colors"
-                        type="button"
-                      >
-                        <t.icon size={13} className="text-sage shrink-0" />
-                        <span className="text-xs text-foreground">{t.label}</span>
-                      </button>
-                    ))}
-                  </div>
+                  {openDropdown === ri && (
+                    <div className="absolute left-0 top-full mt-1 bg-card border border-border rounded-lg shadow-lg z-10 py-1 min-w-[160px]">
+                      {TRIGGER_OPTIONS.filter(t => t.key !== "require_action" && !rule.triggers.some(rt => rt.type === t.key)).map(t => (
+                        <button
+                          key={t.key}
+                          type="button"
+                          onClick={() => { addTrigger(ri, t.key); setOpenDropdown(null); }}
+                          className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-muted/50 transition-colors"
+                        >
+                          <t.icon size={13} className="text-sage shrink-0" />
+                          <span className="text-xs text-foreground">{t.label}</span>
+                        </button>
+                      ))}
+                    </div>
+                  )}
                 </div>
               </div>
             </div>

--- a/src/pages/checklists/LogicRulesEditor.tsx
+++ b/src/pages/checklists/LogicRulesEditor.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect, useRef } from "react";
 import { Plus, X, GitBranch, MessageSquare, Bell, FileText, Image, AlertTriangle, Mail, User } from "lucide-react";
 import { FollowUpQuestionEditor, createDefaultFollowUpQuestion } from "./FollowUpQuestionEditor";
 import type { LogicRule, LogicComparator, LogicTrigger, LogicTriggerType, ResponseType } from "./types";
@@ -49,6 +50,21 @@ export function LogicRulesEditor({
   rules, onRulesChange, responseType, choices, questionText, questionIndex, notifyRecipients,
 }: LogicRulesEditorProps) {
   const showLogic = rules.length > 0;
+  // openDropdown tracks which rule's "add trigger" dropdown is open.
+  // group-focus-within doesn't fire on button click in Safari, so we use state.
+  const [openDropdown, setOpenDropdown] = useState<number | null>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (openDropdown === null) return;
+    const handleClick = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setOpenDropdown(null);
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [openDropdown]);
   const isNumericType = responseType === "number";
   const isMcType = responseType === "multiple_choice" || responseType === "checkbox";
   const comparators = isNumericType ? NUMERIC_COMPARATORS : isMcType ? CHOICE_COMPARATORS : TEXT_COMPARATORS;
@@ -309,24 +325,31 @@ export function LogicRulesEditor({
                     </button>
                   </div>
                 ))}
-                <div className="relative group inline-block">
-                  <button className="text-xs text-sage hover:text-sage-deep transition-colors flex items-center gap-1">
+                <div className="relative inline-block" ref={openDropdown === ri ? dropdownRef : undefined}>
+                  <button
+                    type="button"
+                    onClick={() => setOpenDropdown(openDropdown === ri ? null : ri)}
+                    className="text-xs text-sage hover:text-sage-deep transition-colors flex items-center gap-1"
+                  >
                     <Plus size={11} /> trigger
                   </button>
-                  <div className="hidden group-focus-within:block absolute left-0 top-full mt-1 bg-card border border-border rounded-lg shadow-lg z-10 py-1 min-w-[160px]">
-                    {TRIGGER_OPTIONS
-                      .filter(t => t.key !== "require_action" && !rule.triggers.some(rt => rt.type === t.key))
-                      .map(t => (
-                        <button
-                          key={t.key}
-                          onClick={() => addTrigger(ri, t.key)}
-                          className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-muted/50 transition-colors"
-                        >
-                          <t.icon size={13} className="text-sage shrink-0" />
-                          <span className="text-xs text-foreground">{t.label}</span>
-                        </button>
-                      ))}
-                  </div>
+                  {openDropdown === ri && (
+                    <div className="absolute left-0 top-full mt-1 bg-card border border-border rounded-lg shadow-lg z-10 py-1 min-w-[160px]">
+                      {TRIGGER_OPTIONS
+                        .filter(t => t.key !== "require_action" && !rule.triggers.some(rt => rt.type === t.key))
+                        .map(t => (
+                          <button
+                            key={t.key}
+                            type="button"
+                            onClick={() => { addTrigger(ri, t.key); setOpenDropdown(null); }}
+                            className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-muted/50 transition-colors"
+                          >
+                            <t.icon size={13} className="text-sage shrink-0" />
+                            <span className="text-xs text-foreground">{t.label}</span>
+                          </button>
+                        ))}
+                    </div>
+                  )}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary

- **Safari bug fix** — the "add trigger" dropdown in the checklist logic rule editor never opened in Safari. Root cause: Safari doesn't fire `focus` on button click, so the CSS-only `group-focus-within` trick was silently broken. Replaced with React state + outside-click handler in both `LogicRulesEditor` and the nested one inside `FollowUpQuestionEditor`.
- **Landing nav mobile** — no mobile breakpoint existed on the nav, causing links to wrap to a second line and blow the nav height on narrow screens. Added `≤640px` rule that hides the nav links and secondary actions, leaving just logo + "Get started".

## Test plan
- [ ] Open checklist builder in Safari → add a logic rule → click "+ trigger" → dropdown appears
- [ ] Same in Chrome/Comet — behaviour unchanged
- [ ] View landing page on a phone — nav stays a single clean row

🤖 Generated with [Claude Code](https://claude.com/claude-code)