### PR TITLE
feat: customisable notify email + Safari fix + mobile nav

### DIFF
--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -448,6 +448,14 @@ const css = `
     .ol-footer-links { justify-content: flex-start; }
     .ol-footer-copy { text-align: left; }
   }
+  @media (max-width: 640px) {
+    .ol-nav { padding: 0 20px; height: 56px; }
+    .ol-nav-links { display: none; }
+    .ol-nav-actions .ol-btn-ghost { display: none; }
+    .ol-signin { display: none; }
+    .ol-container { padding: 0 20px; }
+    .ol-hero { padding: 88px 0 48px; }
+  }
 `;
 
 function Tick() {

--- a/src/pages/checklists/FollowUpQuestionEditor.tsx
+++ b/src/pages/checklists/FollowUpQuestionEditor.tsx
@@ -684,6 +684,7 @@ function LogicRulesEditor({
                                 onChange={e => updateTriggerConfig(ri, ti, { notifyUser: e.target.value })}
                                 className="flex-1 text-xs border border-border rounded-lg px-2 py-1.5 bg-background focus:outline-none focus:ring-1 focus:ring-ring"
                               >
+
                                 <option value="">Select recipient…</option>
                                 {notifyRecipients.map(m => (
                                   <option key={m.id} value={m.email}>
@@ -693,7 +694,13 @@ function LogicRulesEditor({
                               </select>
                             )}
                           </div>
-                          <p className="text-xs text-muted-foreground pl-4">Notification sent by email. SMS/push coming soon.</p>
+                          <input
+                            type="text"
+                            placeholder="Email subject (optional — auto-generated if blank)"
+                            value={trigger.config?.notifyMessage || ""}
+                            onChange={e => updateTriggerConfig(ri, ti, { notifyMessage: e.target.value })}
+                            className="w-full text-xs border border-border rounded-lg px-2 py-1.5 bg-background focus:outline-none focus:ring-1 focus:ring-ring"
+                          />
                         </div>
                       )}
 

--- a/src/pages/checklists/FollowUpQuestionEditor.tsx
+++ b/src/pages/checklists/FollowUpQuestionEditor.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useRef, useState, useEffect } from "react";
 import {
   Bell,
   Camera,
@@ -474,6 +474,19 @@ function LogicRulesEditor({
   const showLogic = rules.length > 0;
   const isNumericType = question.responseType === "number";
   const isMcType = question.responseType === "multiple_choice" || question.responseType === "checkbox";
+  const [openDropdown, setOpenDropdown] = useState<number | null>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (openDropdown === null) return;
+    const handleClick = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setOpenDropdown(null);
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [openDropdown]);
 
   const NUMERIC_COMPARATORS: { key: LogicComparator; label: string }[] = [
     { key: "lt", label: "Less than" },
@@ -720,23 +733,29 @@ function LogicRulesEditor({
                     </button>
                   </div>
                 ))}
-                <div className="relative group inline-block">
-                  <button className="text-xs text-sage hover:text-sage-deep transition-colors flex items-center gap-1">
+                <div className="relative inline-block" ref={openDropdown === ri ? dropdownRef : undefined}>
+                  <button
+                    type="button"
+                    onClick={() => setOpenDropdown(openDropdown === ri ? null : ri)}
+                    className="text-xs text-sage hover:text-sage-deep transition-colors flex items-center gap-1"
+                  >
                     <Plus size={11} /> trigger
                   </button>
-                  <div className="hidden group-focus-within:block absolute left-0 top-full mt-1 bg-card border border-border rounded-lg shadow-lg z-10 py-1 min-w-[160px]">
-                    {TRIGGER_OPTIONS.filter(t => t.key !== "require_action" && !rule.triggers.some(rt => rt.type === t.key)).map(t => (
-                      <button
-                        key={t.key}
-                        onClick={() => addTrigger(ri, t.key)}
-                        className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-muted/50 transition-colors"
-                        type="button"
-                      >
-                        <t.icon size={13} className="text-sage shrink-0" />
-                        <span className="text-xs text-foreground">{t.label}</span>
-                      </button>
-                    ))}
-                  </div>
+                  {openDropdown === ri && (
+                    <div className="absolute left-0 top-full mt-1 bg-card border border-border rounded-lg shadow-lg z-10 py-1 min-w-[160px]">
+                      {TRIGGER_OPTIONS.filter(t => t.key !== "require_action" && !rule.triggers.some(rt => rt.type === t.key)).map(t => (
+                        <button
+                          key={t.key}
+                          type="button"
+                          onClick={() => { addTrigger(ri, t.key); setOpenDropdown(null); }}
+                          className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-muted/50 transition-colors"
+                        >
+                          <t.icon size={13} className="text-sage shrink-0" />
+                          <span className="text-xs text-foreground">{t.label}</span>
+                        </button>
+                      ))}
+                    </div>
+                  )}
                 </div>
               </div>
             </div>

--- a/src/pages/checklists/LogicRulesEditor.tsx
+++ b/src/pages/checklists/LogicRulesEditor.tsx
@@ -282,7 +282,13 @@ export function LogicRulesEditor({
                               </select>
                             )}
                           </div>
-                          <p className="text-xs text-muted-foreground pl-4">Notification sent by email. SMS/push coming soon.</p>
+                          <input
+                            type="text"
+                            placeholder={`Email subject (optional — auto: "${questionText || "question"}: [answer]")`}
+                            value={trigger.config?.notifyMessage || ""}
+                            onChange={e => updateTriggerConfig(ri, ti, { notifyMessage: e.target.value })}
+                            className="w-full text-xs border border-border rounded-lg px-2 py-1.5 bg-background focus:outline-none focus:ring-1 focus:ring-ring"
+                          />
                         </div>
                       )}
 

--- a/src/pages/checklists/LogicRulesEditor.tsx
+++ b/src/pages/checklists/LogicRulesEditor.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect, useRef } from "react";
 import { Plus, X, GitBranch, MessageSquare, Bell, FileText, Image, AlertTriangle, Mail, User } from "lucide-react";
 import { FollowUpQuestionEditor, createDefaultFollowUpQuestion } from "./FollowUpQuestionEditor";
 import type { LogicRule, LogicComparator, LogicTrigger, LogicTriggerType, ResponseType } from "./types";
@@ -49,6 +50,21 @@ export function LogicRulesEditor({
   rules, onRulesChange, responseType, choices, questionText, questionIndex, notifyRecipients,
 }: LogicRulesEditorProps) {
   const showLogic = rules.length > 0;
+  // openDropdown tracks which rule's "add trigger" dropdown is open.
+  // group-focus-within doesn't fire on button click in Safari, so we use state.
+  const [openDropdown, setOpenDropdown] = useState<number | null>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (openDropdown === null) return;
+    const handleClick = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setOpenDropdown(null);
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [openDropdown]);
   const isNumericType = responseType === "number";
   const isMcType = responseType === "multiple_choice" || responseType === "checkbox";
   const comparators = isNumericType ? NUMERIC_COMPARATORS : isMcType ? CHOICE_COMPARATORS : TEXT_COMPARATORS;
@@ -309,24 +325,31 @@ export function LogicRulesEditor({
                     </button>
                   </div>
                 ))}
-                <div className="relative group inline-block">
-                  <button className="text-xs text-sage hover:text-sage-deep transition-colors flex items-center gap-1">
+                <div className="relative inline-block" ref={openDropdown === ri ? dropdownRef : undefined}>
+                  <button
+                    type="button"
+                    onClick={() => setOpenDropdown(openDropdown === ri ? null : ri)}
+                    className="text-xs text-sage hover:text-sage-deep transition-colors flex items-center gap-1"
+                  >
                     <Plus size={11} /> trigger
                   </button>
-                  <div className="hidden group-focus-within:block absolute left-0 top-full mt-1 bg-card border border-border rounded-lg shadow-lg z-10 py-1 min-w-[160px]">
-                    {TRIGGER_OPTIONS
-                      .filter(t => t.key !== "require_action" && !rule.triggers.some(rt => rt.type === t.key))
-                      .map(t => (
-                        <button
-                          key={t.key}
-                          onClick={() => addTrigger(ri, t.key)}
-                          className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-muted/50 transition-colors"
-                        >
-                          <t.icon size={13} className="text-sage shrink-0" />
-                          <span className="text-xs text-foreground">{t.label}</span>
-                        </button>
-                      ))}
-                  </div>
+                  {openDropdown === ri && (
+                    <div className="absolute left-0 top-full mt-1 bg-card border border-border rounded-lg shadow-lg z-10 py-1 min-w-[160px]">
+                      {TRIGGER_OPTIONS
+                        .filter(t => t.key !== "require_action" && !rule.triggers.some(rt => rt.type === t.key))
+                        .map(t => (
+                          <button
+                            key={t.key}
+                            type="button"
+                            onClick={() => { addTrigger(ri, t.key); setOpenDropdown(null); }}
+                            className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-muted/50 transition-colors"
+                          >
+                            <t.icon size={13} className="text-sage shrink-0" />
+                            <span className="text-xs text-foreground">{t.label}</span>
+                          </button>
+                        ))}
+                    </div>
+                  )}
                 </div>
               </div>
             </div>

--- a/src/pages/checklists/types.ts
+++ b/src/pages/checklists/types.ts
@@ -57,6 +57,7 @@ export interface LogicTrigger {
     questionText?: string;
     followUpQuestion?: QuestionDef;
     notifyUser?: string;
+    notifyMessage?: string;
     actionTitle?: string;
     actionAssignee?: string;
   };

--- a/src/pages/kiosk/logic-rules.ts
+++ b/src/pages/kiosk/logic-rules.ts
@@ -115,14 +115,20 @@ export function collectNotifyAlerts(
         );
         if (alreadyAdded) continue;
 
-        const answerStr =
-          answer === undefined || answer === null || answer === "" || answer === false
-            ? "unanswered"
-            : String(answer);
+        const isBlank = answer === undefined || answer === null || answer === "" || answer === false;
+        const answerStr = isBlank ? "not answered" : String(answer);
+
+        const customMessage = trigger.config?.notifyMessage?.trim();
+        const message = customMessage
+          ? customMessage
+          : isBlank
+            ? `"${question.text}" — not answered`
+            : `"${question.text}": ${answerStr}`;
+
         alerts.push({
           recipientEmail,
           questionText: question.text,
-          message: `"${question.text}" answered: ${answerStr} — notify rule triggered`,
+          message,
         });
       }
     }

--- a/supabase/functions/send-alert-email/email.ts
+++ b/supabase/functions/send-alert-email/email.ts
@@ -44,7 +44,10 @@ export function formatAlertWhen(createdAt: string, fallbackTime?: string | null)
 }
 
 export function buildAlertEmail(alert: AlertPayload) {
-  const severityLabel = alert.type === "error" ? "🔴 Error" : "⚠️ Warning";
+  const severityLabel =
+    alert.type === "error" ? "🔴 Error" :
+    alert.type === "warn"  ? "⚠️ Warning" :
+                             "📋 Notification";
   const subject = `${severityLabel}: ${alert.message}`;
   const when = formatAlertWhen(alert.created_at, alert.time);
 
@@ -58,7 +61,7 @@ export function buildAlertEmail(alert: AlertPayload) {
     alert.source ? `Source   : ${alert.source}` : null,
     "",
     "---",
-    "You are receiving this because your location has alert notifications enabled.",
+    "You are receiving this because a checklist notification rule matched.",
     "Log in to Olia to view and dismiss this alert.",
   ]
     .filter((line): line is string => line !== null)
@@ -81,7 +84,7 @@ export function buildAlertEmail(alert: AlertPayload) {
       ${alert.source ? row("Source", alert.source) : ""}
     </table>
     <p style="margin:24px 0 0;font-size:12px;color:#857B72">
-      You are receiving this because your location has alert notifications enabled.
+      You are receiving this because a checklist notification rule matched.
       Log in to Olia to view and dismiss this alert.
     </p>
   </div>

--- a/supabase/migrations/20260713000006_fix_pg_net_call.sql
+++ b/supabase/migrations/20260713000006_fix_pg_net_call.sql
@@ -1,0 +1,85 @@
+-- ================================================================
+-- Fix pg_net function call in the alert email trigger.
+--
+-- Supabase updated pg_net and the function now lives in the `net`
+-- schema only. The previous trigger called `extensions.net.http_post`
+-- which no longer exists; the EXCEPTION block was silently catching
+-- the "function does not exist" error, so no HTTP calls were made.
+--
+-- Also: pass _payload (jsonb) directly instead of _payload::text,
+-- matching the actual net.http_post(url, body jsonb, ...) signature.
+-- ================================================================
+
+CREATE OR REPLACE FUNCTION public.send_alert_email_on_insert()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  _url       text;
+  _secret    text;
+  _recipient text;
+  _payload   jsonb;
+BEGIN
+  SELECT value INTO _url    FROM public.app_config WHERE key = 'supabase_url';
+  SELECT value INTO _secret FROM public.app_config WHERE key = 'alert_secret';
+
+  IF _url IS NULL OR _url = '' THEN
+    RAISE WARNING 'send_alert_email: supabase_url not set in app_config table.';
+    RETURN NEW;
+  END IF;
+
+  IF _secret IS NULL OR _secret = '' THEN
+    RAISE WARNING 'send_alert_email: alert_secret not set in app_config table.';
+    RETURN NEW;
+  END IF;
+
+  IF NEW.recipient_email IS NOT NULL AND NEW.recipient_email <> '' THEN
+    _recipient := NEW.recipient_email;
+  ELSE
+    SELECT COALESCE(NULLIF(l.contact_email, ''), NULLIF(l.alert_email, ''))
+      INTO _recipient
+      FROM public.locations l
+     WHERE l.organization_id = NEW.organization_id
+       AND COALESCE(NULLIF(l.contact_email, ''), NULLIF(l.alert_email, '')) IS NOT NULL
+     ORDER BY l.created_at
+     LIMIT 1;
+  END IF;
+
+  IF _recipient IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  _payload := jsonb_build_object(
+    'id',              NEW.id,
+    'type',            NEW.type,
+    'message',         NEW.message,
+    'area',            NEW.area,
+    'time',            NEW.time,
+    'source',          NEW.source,
+    'created_at',      NEW.created_at,
+    'organization_id', NEW.organization_id,
+    'recipient_email', _recipient
+  );
+
+  PERFORM net.http_post(
+    url     := _url || '/functions/v1/send-alert-email',
+    headers := jsonb_build_object(
+                 'Content-Type',   'application/json',
+                 'x-alert-secret', _secret
+               ),
+    body    := _payload,
+    timeout_milliseconds := 5000
+  );
+
+  RETURN NEW;
+
+EXCEPTION WHEN OTHERS THEN
+  RAISE WARNING 'send_alert_email: pg_net call failed: %', SQLERRM;
+  RETURN NEW;
+END;
+$$;
+
+-- Remove duplicate trigger created by an earlier migration run.
+DROP TRIGGER IF EXISTS trigger_send_alert_email ON public.alerts;


### PR DESCRIPTION
## Summary

- **Custom email subject** — notify trigger in the checklist builder now has an optional "Email subject" field. Leave blank for a clean auto-generated subject; fill it in to send exactly that text.
- **Better auto-message format** — `"Fridge temp": 3` instead of `'"Fridge temp" answered: 3 — notify rule triggered'`; unanswered questions show `"Fridge temp" — not answered`
- **Email label fix** — info-type alerts now show 📋 Notification instead of ⚠️ Warning
- **Safari trigger dropdown** — `group-focus-within` replaced with React state in `LogicRulesEditor` and `FollowUpQuestionEditor`; trigger dropdown now works in Safari
- **Landing nav mobile** — added ≤640px breakpoint hiding nav links and secondary actions so the nav stays a single row on phones

## Migrations / deploys
- `20260713000006` — fix `net.http_post` call in alert trigger (pg_net schema change)
- `send-alert-email` edge function redeployed with new severity label + footer copy

## Test plan
- [ ] Add a notify rule to a checklist, fill in a custom email subject → complete checklist in kiosk → email arrives with that exact subject
- [ ] Leave subject blank → email subject auto-generates from question text + answer
- [ ] Info-type notify alert email shows 📋 Notification, not ⚠️ Warning
- [ ] Open checklist builder in Safari → click "+ trigger" → dropdown opens
- [ ] View landing page on mobile → nav shows logo + Get started only, no wrapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)