### PR TITLE
fix: open file upload dialog when choosing 'Upload file' in infohub

### DIFF
--- a/src/hooks/useInfohubContent.ts
+++ b/src/hooks/useInfohubContent.ts
@@ -44,6 +44,8 @@ interface InfohubDocumentRow {
     tags?: string[];
     duration?: string;
     steps?: string[];
+    filePath?: string;
+    fileType?: string;
   } | null;
   archived_at: string | null;
   access_scope: InfohubAccessControl["accessScope"];
@@ -78,6 +80,8 @@ interface CreateDocumentInput {
   title: string;
   folderId: string;
   tags?: string[];
+  filePath?: string;
+  fileType?: string;
 }
 
 interface UpdateFolderInput {
@@ -138,6 +142,8 @@ function mapLibraryDocRow(row: InfohubDocumentRow): InfohubLibraryDoc {
     lastUpdated: formatDate(row.updated_at),
     folderId: row.folder_id,
     access: mapAccess(row),
+    filePath: row.metadata?.filePath,
+    fileType: row.metadata?.fileType,
   };
 }
 
@@ -395,7 +401,10 @@ export function useInfohubContent() {
             title: input.title,
             summary: "New document — tap to edit.",
             body: "",
-            metadata: { tags: input.tags ?? [] },
+            metadata: {
+              tags: input.tags ?? [],
+              ...(input.filePath ? { filePath: input.filePath, fileType: input.fileType } : {}),
+            },
             ...applyAccessFields(DEFAULT_INFOHUB_ACCESS),
             created_by: teamMember?.id ?? null,
           }
@@ -436,6 +445,8 @@ export function useInfohubContent() {
                 lastUpdated: now,
                 folderId: input.folderId,
                 access: DEFAULT_INFOHUB_ACCESS,
+                filePath: input.filePath,
+                fileType: input.fileType,
               },
             ],
           };

--- a/src/lib/infohub-catalog.ts
+++ b/src/lib/infohub-catalog.ts
@@ -21,6 +21,8 @@ export interface InfohubLibraryDoc {
   lastUpdated: string;
   folderId: string;
   access: InfohubAccessControl;
+  filePath?: string;
+  fileType?: string;
 }
 
 export interface InfohubTrainingFolder {

--- a/src/pages/Infohub.tsx
+++ b/src/pages/Infohub.tsx
@@ -31,7 +31,7 @@ import { canAccessInfohubContent, canManageInfohubAccess, type InfohubAccessCont
 import type { InfohubLibraryDoc as DocItem, InfohubLibraryFolder as FolderItem, InfohubTrainingDoc as TrainingDoc, InfohubTrainingFolder as TrainingFolder } from "@/lib/infohub-catalog";
 import { type AccessTarget, type SubTab } from "./infohub/infohub-types";
 import { countDocsInFolder, countTrainingDocsInFolder, sortFolders, useDragReorder } from "./infohub/infohub-utils";
-import { AIActionsSheet, CreateDocModal, CreateFolderModal, FolderBreadcrumb, ItemContextMenu, ManageAccessModal, MoveToFolderSheet, PlusMenu, RenameFolderModal, SearchOverlay } from "./infohub/InfohubShared";
+import { AIActionsSheet, CreateDocModal, CreateFolderModal, FolderBreadcrumb, ItemContextMenu, ManageAccessModal, MoveToFolderSheet, PlusMenu, RenameFolderModal, SearchOverlay, UploadDocModal } from "./infohub/InfohubShared";
 import { LibraryDocDetail, TrainingDocDetail } from "./infohub/InfohubDocumentViews";
 
 // ─── Infohub Page ─────────────────────────────────────────────────────────────
@@ -61,6 +61,7 @@ export default function Infohub() {
   const [showPlusMenu, setShowPlusMenu] = useState(false);
   const [showCreateFolder, setShowCreateFolder] = useState(false);
   const [showCreateDoc, setShowCreateDoc] = useState(false);
+  const [showUploadDoc, setShowUploadDoc] = useState(false);
 
   // Data state
   const libFolders = infohubData.libraryFolders;
@@ -664,7 +665,7 @@ export default function Infohub() {
           setShowPlusMenu(false);
           if (action === "folder") setShowCreateFolder(true);
           if (action === "document") setShowCreateDoc(true);
-          if (action === "upload") setShowCreateDoc(true);
+          if (action === "upload") setShowUploadDoc(true);
         }} />
       )}
       {showCreateFolder && (
@@ -689,6 +690,23 @@ export default function Infohub() {
             }
 
             createDocument.mutate({ section: "training", title, folderId });
+          }}
+        />
+      )}
+      {showUploadDoc && (
+        <UploadDocModal
+          folderId={subTab === "library" ? currentLibFolder : currentTrainFolder}
+          folders={subTab === "library" ? allLibFolderOptions : allTrainFolderOptions}
+          onClose={() => setShowUploadDoc(false)}
+          onSave={(title, folderId, filePath, fileType, tags) => {
+            createDocument.mutate({
+              section: subTab === "library" ? "library" : "training",
+              title,
+              folderId,
+              filePath,
+              fileType,
+              tags,
+            });
           }}
         />
       )}

--- a/src/pages/infohub/InfohubDocumentViews.tsx
+++ b/src/pages/infohub/InfohubDocumentViews.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 
-import { CheckCircle, ChevronLeft, Circle, Pencil, Sparkles, Tag } from "lucide-react";
+import { CheckCircle, ChevronLeft, Circle, Download, FileText, Pencil, Sparkles, Tag } from "lucide-react";
+import { supabase } from "@/lib/supabase";
 
 import { cn } from "@/lib/utils";
 import type { InfohubLibraryDoc as DocItem, InfohubLibraryFolder as FolderItem, InfohubTrainingDoc as TrainingDoc } from "@/lib/infohub-catalog";
@@ -25,6 +26,14 @@ export function LibraryDocDetail({
   const [editSummary, setEditSummary] = useState(doc.summary);
   const [editContent, setEditContent] = useState(doc.content);
   const [editTags, setEditTags] = useState(doc.tags.join(", "));
+  const [fileSignedUrl, setFileSignedUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!doc.filePath) return;
+    supabase.storage.from("infohub-files").createSignedUrl(doc.filePath, 86400).then(({ data }) => {
+      if (data?.signedUrl) setFileSignedUrl(data.signedUrl);
+    });
+  }, [doc.filePath]);
 
   function handleSave() {
     onSave({
@@ -126,6 +135,33 @@ export function LibraryDocDetail({
                 </span>
               ))}
             </div>
+            {doc.filePath && (
+              <div className="card-surface p-4 flex items-center gap-3">
+                <div className="w-10 h-10 rounded-xl bg-lavender-light flex items-center justify-center shrink-0">
+                  <FileText size={18} className="text-lavender-deep" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-foreground truncate">{doc.title}</p>
+                  <p className="text-xs text-muted-foreground">{doc.fileType ?? "File"}</p>
+                </div>
+                {fileSignedUrl ? (
+                  <a
+                    href={fileSignedUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    download
+                    className="p-2 rounded-full hover:bg-muted transition-colors"
+                    aria-label="Download file"
+                  >
+                    <Download size={16} className="text-muted-foreground" />
+                  </a>
+                ) : (
+                  <div className="p-2 rounded-full">
+                    <Download size={16} className="text-muted-foreground/40" />
+                  </div>
+                )}
+              </div>
+            )}
             <div className="card-surface p-5">
               {doc.content ? (
                 <p className="text-sm text-foreground leading-relaxed whitespace-pre-line">{doc.content}</p>

--- a/src/pages/infohub/InfohubShared.tsx
+++ b/src/pages/infohub/InfohubShared.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
 import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/contexts/AuthContext";
 import { isInfohubAiResult, type InfohubAiAction, type InfohubAiResult } from "@/lib/infohub-ai";
 import { canAccessInfohubContent, type InfohubAccessControl, type InfohubPrincipal } from "@/lib/infohub-access";
 import type { InfohubLibraryDoc as DocItem, InfohubLibraryFolder as FolderItem, InfohubTrainingDoc as TrainingDoc, InfohubTrainingFolder as TrainingFolder } from "@/lib/infohub-catalog";
@@ -321,6 +322,159 @@ export function CreateDocModal({
           )}
         >
           Create document
+        </button>
+      </div>
+    </CenteredModalShell>
+  );
+}
+
+export function UploadDocModal({
+  folderId,
+  folders,
+  onClose,
+  onSave,
+}: {
+  folderId: string | null;
+  folders: { id: string; name: string }[];
+  onClose: () => void;
+  onSave: (title: string, folderId: string, filePath: string, fileType: string, tags: string[]) => void;
+}) {
+  const { teamMember } = useAuth();
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [title, setTitle] = useState("");
+  const [selectedFolder, setSelectedFolder] = useState(folderId || folders[0]?.id || "");
+  const [tagsInput, setTagsInput] = useState("");
+  const [isDragging, setIsDragging] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const MAX_SIZE = 20 * 1024 * 1024;
+
+  function handleFile(file: File) {
+    if (file.size > MAX_SIZE) {
+      setError("File is too large. Maximum size is 20 MB.");
+      return;
+    }
+    setError(null);
+    setSelectedFile(file);
+    if (!title) {
+      setTitle(file.name.replace(/\.[^.]+$/, ""));
+    }
+  }
+
+  function handleDrop(e: React.DragEvent) {
+    e.preventDefault();
+    setIsDragging(false);
+    const file = e.dataTransfer.files[0];
+    if (file) handleFile(file);
+  }
+
+  async function handleSubmit() {
+    if (!selectedFile || !title.trim() || !selectedFolder) return;
+    const orgId = teamMember?.organization_id;
+    if (!orgId) { setError("Not signed in."); return; }
+    setUploading(true);
+    setError(null);
+    try {
+      const ext = selectedFile.name.includes(".") ? selectedFile.name.slice(selectedFile.name.lastIndexOf(".")) : "";
+      const path = `${orgId}/${Date.now()}${ext}`;
+      const { error: uploadError } = await supabase.storage.from("infohub-files").upload(path, selectedFile);
+      if (uploadError) throw uploadError;
+      const tags = tagsInput.split(",").map((t) => t.trim()).filter(Boolean);
+      onSave(title.trim(), selectedFolder, path, selectedFile.type, tags);
+      onClose();
+    } catch (err: any) {
+      setError(err.message ?? "Upload failed. Please try again.");
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  const canSubmit = !!selectedFile && !!title.trim() && !!selectedFolder && !uploading;
+
+  return (
+    <CenteredModalShell onClose={onClose}>
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h3 className="font-display text-base text-foreground">Upload file</h3>
+          <button onClick={onClose} className="btn-icon">
+            <X size={18} className="text-muted-foreground" />
+          </button>
+        </div>
+
+        <div
+          data-testid="upload-dropzone"
+          onDragOver={(e) => { e.preventDefault(); setIsDragging(true); }}
+          onDragLeave={() => setIsDragging(false)}
+          onDrop={handleDrop}
+          onClick={() => fileInputRef.current?.click()}
+          className={cn(
+            "border-2 border-dashed rounded-xl p-6 flex flex-col items-center justify-center gap-2 cursor-pointer transition-colors",
+            isDragging ? "border-primary bg-sage-light/30" : "border-border hover:border-primary/50 hover:bg-muted/30",
+            selectedFile && "border-sage-deep/40 bg-sage-light/20",
+          )}
+        >
+          <input
+            ref={fileInputRef}
+            type="file"
+            data-testid="upload-file-input"
+            className="hidden"
+            accept=".pdf,.doc,.docx,.txt,image/jpeg,image/png,image/webp"
+            onChange={(e) => { const f = e.target.files?.[0]; if (f) handleFile(f); }}
+          />
+          {selectedFile ? (
+            <>
+              <FileText size={24} className="text-sage-deep" />
+              <p className="text-sm font-medium text-foreground text-center">{selectedFile.name}</p>
+              <p className="text-xs text-muted-foreground">{(selectedFile.size / 1024 / 1024).toFixed(1)} MB</p>
+            </>
+          ) : (
+            <>
+              <Upload size={24} className="text-muted-foreground" />
+              <p className="text-sm text-muted-foreground text-center">
+                Drag & drop or <span className="text-primary font-medium">browse</span>
+              </p>
+              <p className="text-xs text-muted-foreground">PDF, DOC, DOCX, images · max 20 MB</p>
+            </>
+          )}
+        </div>
+
+        {error && <p className="text-xs text-destructive">{error}</p>}
+
+        <div className="space-y-2">
+          <label className="text-xs font-medium text-muted-foreground">Title</label>
+          <Input data-testid="upload-title-input" value={title} onChange={(e) => setTitle(e.target.value)} placeholder="e.g. Fire safety procedure" />
+        </div>
+        <div className="space-y-2">
+          <label className="text-xs font-medium text-muted-foreground">Folder</label>
+          <select
+            value={selectedFolder}
+            onChange={(e) => setSelectedFolder(e.target.value)}
+            className="w-full h-10 rounded-md border border-input bg-background px-3 text-sm"
+          >
+            {folders.map((folder) => (
+              <option key={folder.id} value={folder.id}>{folder.name}</option>
+            ))}
+          </select>
+        </div>
+        <div className="space-y-2">
+          <label className="text-xs font-medium text-muted-foreground">Tags <span className="text-muted-foreground/60">(comma-separated, optional)</span></label>
+          <Input value={tagsInput} onChange={(e) => setTagsInput(e.target.value)} placeholder="e.g. Safety, Weekly, Kitchen" />
+        </div>
+
+        <button
+          data-testid="upload-submit-btn"
+          disabled={!canSubmit}
+          onClick={handleSubmit}
+          className={cn(
+            "w-full py-3 rounded-xl text-sm font-medium transition-colors flex items-center justify-center gap-2",
+            canSubmit ? "bg-primary text-primary-foreground hover:bg-primary/90" : "bg-muted text-muted-foreground",
+          )}
+        >
+          {uploading ? (
+            <><Loader2 size={16} className="animate-spin" /> Uploading…</>
+          ) : "Upload file"}
         </button>
       </div>
     </CenteredModalShell>

--- a/src/test/pages/Infohub.test.tsx
+++ b/src/test/pages/Infohub.test.tsx
@@ -34,6 +34,12 @@ vi.mock("@/lib/supabase", () => ({
     functions: {
       invoke: vi.fn(),
     },
+    storage: {
+      from: vi.fn().mockReturnValue({
+        upload: vi.fn().mockResolvedValue({ error: null }),
+        createSignedUrl: vi.fn().mockResolvedValue({ data: { signedUrl: "https://example.com/signed" } }),
+      }),
+    },
   },
 }));
 
@@ -415,6 +421,15 @@ describe("Infohub page", () => {
       expect(screen.getByText("New document")).toBeInTheDocument();
       expect(screen.queryByText("Title")).toBeTruthy();
     }
+  });
+
+  it("clicking 'Upload file' from Plus menu opens UploadDoc modal (not CreateDoc)", () => {
+    renderWithProviders(<Infohub />);
+    fireEvent.click(screen.getByLabelText("Add content"));
+    fireEvent.click(screen.getByText("Upload file"));
+    expect(screen.getByTestId("upload-dropzone")).toBeInTheDocument();
+    expect(screen.getByTestId("upload-file-input")).toBeInTheDocument();
+    expect(screen.queryByTestId("doc-title-input")).toBeNull();
   });
 
   it("folder context menu (3-dot) opens when MoreVertical button is clicked", () => {

--- a/supabase/migrations/20260715000001_infohub_files_storage.sql
+++ b/supabase/migrations/20260715000001_infohub_files_storage.sql
@@ -1,0 +1,63 @@
+-- Create private storage bucket for infohub document file uploads.
+-- Files are stored under {org_id}/{timestamp}.{ext} to scope by organisation.
+
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'infohub-files',
+  'infohub-files',
+  false,
+  20971520, -- 20 MB
+  ARRAY[
+    'application/pdf',
+    'application/msword',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    'image/jpeg',
+    'image/png',
+    'image/webp',
+    'text/plain'
+  ]
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- Files are stored as {org_id}/{timestamp}.{ext}. All three policies enforce that
+-- the path's first segment matches the caller's organisation, preventing cross-tenant
+-- read, write, and delete (IDOR).
+
+CREATE POLICY "infohub_file_upload_own_org"
+  ON storage.objects FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    bucket_id = 'infohub-files'
+    AND (storage.foldername(name))[1] = (
+      SELECT organization_id::text
+      FROM public.team_members
+      WHERE user_id = auth.uid()
+      LIMIT 1
+    )
+  );
+
+CREATE POLICY "infohub_file_read_own_org"
+  ON storage.objects FOR SELECT
+  TO authenticated
+  USING (
+    bucket_id = 'infohub-files'
+    AND (storage.foldername(name))[1] = (
+      SELECT organization_id::text
+      FROM public.team_members
+      WHERE user_id = auth.uid()
+      LIMIT 1
+    )
+  );
+
+CREATE POLICY "infohub_file_delete_own_org"
+  ON storage.objects FOR DELETE
+  TO authenticated
+  USING (
+    bucket_id = 'infohub-files'
+    AND (storage.foldername(name))[1] = (
+      SELECT organization_id::text
+      FROM public.team_members
+      WHERE user_id = auth.uid()
+      LIMIT 1
+    )
+  );


### PR DESCRIPTION
## Summary

- **Bug fix:** 'Upload file' in the PlusMenu was incorrectly opening the 'New document' dialog — routed to a new `UploadDocModal` instead
- **New `UploadDocModal`:** drag-and-drop zone + file browser, auto-fills title from filename, folder selector, optional tags
- **Storage:** files upload to a private Supabase `infohub-files` bucket (20 MB limit, PDF/DOC/DOCX/images); path stored in document metadata; doc detail view shows a file card with a signed-URL download button
- **Migration:** `20260715000001_infohub_files_storage.sql` — creates the bucket with org-scoped RLS (users can only read/write/delete files under their own org's path prefix)

## Test plan

- [ ] Tap the + button in infohub → choose **Upload file** → drag-and-drop or browse opens (not the new document dialog)
- [ ] Upload a PDF — document appears in the folder with a file attachment card
- [ ] Open the uploaded document — download button generates a working link
- [ ] Choose **New document** — still opens the text editor dialog as before
- [ ] CI: migration applies cleanly, all infohub tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)