### PR TITLE
fix: correct team_members auth lookup in infohub-files RLS policies

### DIFF
--- a/supabase/migrations/20260715000001_infohub_files_storage.sql
+++ b/supabase/migrations/20260715000001_infohub_files_storage.sql
@@ -31,7 +31,7 @@ CREATE POLICY "infohub_file_upload_own_org"
     AND (storage.foldername(name))[1] = (
       SELECT organization_id::text
       FROM public.team_members
-      WHERE user_id = auth.uid()
+      WHERE id = auth.uid() OR auth_user_id = auth.uid()
       LIMIT 1
     )
   );
@@ -44,7 +44,7 @@ CREATE POLICY "infohub_file_read_own_org"
     AND (storage.foldername(name))[1] = (
       SELECT organization_id::text
       FROM public.team_members
-      WHERE user_id = auth.uid()
+      WHERE id = auth.uid() OR auth_user_id = auth.uid()
       LIMIT 1
     )
   );
@@ -57,7 +57,7 @@ CREATE POLICY "infohub_file_delete_own_org"
     AND (storage.foldername(name))[1] = (
       SELECT organization_id::text
       FROM public.team_members
-      WHERE user_id = auth.uid()
+      WHERE id = auth.uid() OR auth_user_id = auth.uid()
       LIMIT 1
     )
   );


### PR DESCRIPTION
## Summary

Hotfix for the failed migration in #452.

`team_members` links to `auth.uid()` via `id` (owners) or `auth_user_id` (invited members) — there is no `user_id` column. The previous migration failed with `ERROR: column "user_id" does not exist (SQLSTATE 42703)`, which blocked the entire deploy.

## Test plan

- [ ] CI migrate step applies `20260715000001_infohub_files_storage.sql` cleanly
- [ ] Deploy succeeds and upload dialog works in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)