### PR TITLE
feat: preview uploaded files in an in-app modal instead of new tab

### DIFF
--- a/src/pages/Infohub.tsx
+++ b/src/pages/Infohub.tsx
@@ -32,7 +32,7 @@ import { canAccessInfohubContent, canManageInfohubAccess, type InfohubAccessCont
 import type { InfohubLibraryDoc as DocItem, InfohubLibraryFolder as FolderItem, InfohubTrainingDoc as TrainingDoc, InfohubTrainingFolder as TrainingFolder } from "@/lib/infohub-catalog";
 import { type AccessTarget, type SubTab } from "./infohub/infohub-types";
 import { countDocsInFolder, countTrainingDocsInFolder, sortFolders, useDragReorder } from "./infohub/infohub-utils";
-import { AIActionsSheet, CreateDocModal, CreateFolderModal, FolderBreadcrumb, ItemContextMenu, ManageAccessModal, MoveToFolderSheet, PlusMenu, RenameFolderModal, SearchOverlay, UploadDocModal } from "./infohub/InfohubShared";
+import { AIActionsSheet, CreateDocModal, CreateFolderModal, FilePreviewModal, FolderBreadcrumb, ItemContextMenu, ManageAccessModal, MoveToFolderSheet, PlusMenu, RenameFolderModal, SearchOverlay, UploadDocModal } from "./infohub/InfohubShared";
 import { LibraryDocDetail, TrainingDocDetail } from "./infohub/InfohubDocumentViews";
 
 // ─── Infohub Page ─────────────────────────────────────────────────────────────
@@ -63,6 +63,7 @@ export default function Infohub() {
   const [showCreateFolder, setShowCreateFolder] = useState(false);
   const [showCreateDoc, setShowCreateDoc] = useState(false);
   const [showUploadDoc, setShowUploadDoc] = useState(false);
+  const [filePreview, setFilePreview] = useState<{ signedUrl: string; fileType: string; title: string } | null>(null);
 
   // Data state
   const libFolders = infohubData.libraryFolders;
@@ -339,7 +340,7 @@ export default function Infohub() {
   const handleOpenLibDoc = async (doc: DocItem) => {
     if (doc.filePath) {
       const { data } = await supabase.storage.from("infohub-files").createSignedUrl(doc.filePath, 3600);
-      if (data?.signedUrl) window.open(data.signedUrl, "_blank");
+      if (data?.signedUrl) setFilePreview({ signedUrl: data.signedUrl, fileType: doc.fileType ?? "", title: doc.title });
     } else {
       setSelectedDoc(doc);
     }
@@ -729,6 +730,14 @@ export default function Infohub() {
               tags,
             });
           }}
+        />
+      )}
+      {filePreview && (
+        <FilePreviewModal
+          signedUrl={filePreview.signedUrl}
+          fileType={filePreview.fileType}
+          title={filePreview.title}
+          onClose={() => setFilePreview(null)}
         />
       )}
       {accessTarget && (

--- a/src/pages/infohub/InfohubShared.tsx
+++ b/src/pages/infohub/InfohubShared.tsx
@@ -328,6 +328,78 @@ export function CreateDocModal({
   );
 }
 
+export function FilePreviewModal({
+  signedUrl,
+  fileType,
+  title,
+  onClose,
+}: {
+  signedUrl: string;
+  fileType: string;
+  title: string;
+  onClose: () => void;
+}) {
+  const isImage = fileType.startsWith("image/");
+  const isPdf = fileType === "application/pdf";
+
+  return createPortal(
+    <div className="fixed inset-0 z-[60] flex flex-col bg-foreground/40 backdrop-blur-sm" onClick={onClose}>
+      <div className="flex items-center justify-between px-4 py-3 bg-card border-b border-border shrink-0" onClick={e => e.stopPropagation()}>
+        <p className="text-sm font-medium text-foreground truncate flex-1 mr-3">{title}</p>
+        <div className="flex items-center gap-2 shrink-0">
+          <a
+            href={signedUrl}
+            download={title}
+            onClick={e => e.stopPropagation()}
+            className="p-2 rounded-full hover:bg-muted transition-colors"
+            aria-label="Download"
+          >
+            <Download size={18} className="text-muted-foreground" />
+          </a>
+          <button onClick={onClose} className="p-2 rounded-full hover:bg-muted transition-colors" aria-label="Close preview">
+            <X size={18} className="text-muted-foreground" />
+          </button>
+        </div>
+      </div>
+      <div className="flex-1 overflow-hidden flex items-center justify-center p-4" onClick={e => e.stopPropagation()}>
+        {isImage && (
+          <img
+            src={signedUrl}
+            alt={title}
+            className="max-w-full max-h-full object-contain rounded-xl shadow-lg"
+          />
+        )}
+        {isPdf && (
+          <iframe
+            src={signedUrl}
+            title={title}
+            className="w-full h-full rounded-xl shadow-lg bg-white"
+          />
+        )}
+        {!isImage && !isPdf && (
+          <div className="flex flex-col items-center gap-4 text-center">
+            <div className="w-16 h-16 rounded-2xl bg-lavender-light flex items-center justify-center">
+              <FileText size={28} className="text-lavender-deep" />
+            </div>
+            <div>
+              <p className="text-sm font-medium text-foreground">{title}</p>
+              <p className="text-xs text-muted-foreground mt-1">This file type can't be previewed in the browser.</p>
+            </div>
+            <a
+              href={signedUrl}
+              download={title}
+              className="px-5 py-2.5 rounded-xl bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors"
+            >
+              Download to open
+            </a>
+          </div>
+        )}
+      </div>
+    </div>,
+    document.body
+  );
+}
+
 export function UploadDocModal({
   folderId,
   folders,


### PR DESCRIPTION
## Summary

Follow-up to #454. Instead of opening a new browser tab, tapping an uploaded file now shows a full-screen overlay modal so the user stays in the app.

- **PDF** → rendered via `<iframe>` (works in desktop browsers and iOS/Android WebView)
- **Images** (jpeg, png, webp) → rendered via `<img>`
- **DOC/DOCX and other types** → modal with a "Download to open" button (no native browser renderer for these)
- Header always includes a download button and close (×) button
- Clicking outside the content area closes the modal

## Test plan

- [ ] Upload a PDF → tap it → opens in full-screen iframe overlay, close button works
- [ ] Upload an image → tap it → shows full-screen image, close button works
- [ ] Upload a .docx → tap it → modal shows "Download to open" button
- [ ] Download button in modal header downloads the file
- [ ] Text docs still open the editor as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)