### PR TITLE
fix: remove duplicate question text input in ask_question trigger

### DIFF
--- a/src/pages/checklists/LogicRulesEditor.tsx
+++ b/src/pages/checklists/LogicRulesEditor.tsx
@@ -218,21 +218,6 @@ export function LogicRulesEditor({
 
                       {trigger.type === "ask_question" && (
                         <div className="space-y-2">
-                          <input
-                            type="text"
-                            placeholder="Follow-up question text"
-                            value={trigger.config?.questionText || ""}
-                            onChange={e => {
-                              const nextFollowUp = trigger.config?.followUpQuestion
-                                ? { ...trigger.config.followUpQuestion, text: e.target.value }
-                                : createDefaultFollowUpQuestion(e.target.value);
-                              updateTriggerConfig(ri, ti, {
-                                questionText: e.target.value,
-                                followUpQuestion: nextFollowUp,
-                              });
-                            }}
-                            className="w-full text-xs border border-border rounded-lg px-2 py-1.5 bg-background focus:outline-none focus:ring-1 focus:ring-ring"
-                          />
                           {trigger.config?.followUpQuestion ? (
                             <FollowUpQuestionEditor
                               question={trigger.config.followUpQuestion}


### PR DESCRIPTION
## Summary
- The `ask_question` trigger in `LogicRulesEditor` was rendering a standalone text input on top of the `FollowUpQuestionEditor` component
- `FollowUpQuestionEditor` already has its own text field, so the two appeared side-by-side and both said "Follow-up question text"
- Removed the redundant standalone input

🤖 Generated with [Claude Code](https://claude.com/claude-code)