### PR TITLE
fix: router blocker only shows when builder has unsaved changes

### DIFF
--- a/src/pages/checklists/ChecklistBuilderModal.tsx
+++ b/src/pages/checklists/ChecklistBuilderModal.tsx
@@ -68,11 +68,13 @@ interface ChecklistBuilderModalProps {
   /** When true, renders as a full-page editor (no overlay).
    *  The parent is responsible for showing/hiding it. */
   asPage?: boolean;
+  /** Called whenever the dirty state changes so the parent can gate router-level navigation blocking. */
+  onDirtyChange?: (isDirty: boolean) => void;
 }
 
 export function ChecklistBuilderModal({
   onClose, onAdd, onUpdate, initialTitle, initialSections, initialLocationIds,
-  initialSchedule, initialStartDate, initialVisibilityFrom, initialVisibilityUntil, editId, asPage = false,
+  initialSchedule, initialStartDate, initialVisibilityFrom, initialVisibilityUntil, editId, asPage = false, onDirtyChange,
 }: ChecklistBuilderModalProps) {
   const createAlert = useCreateAlert();
   const { user, teamMember: authTeamMember } = useAuth();
@@ -161,6 +163,14 @@ export function ChecklistBuilderModal({
     observer.observe(el);
     return () => observer.disconnect();
   }, [asPage]);
+
+  useEffect(() => {
+    if (!onDirtyChange) return;
+    const dirty = !editId
+      ? !!(title.trim() || sections.some(s => s.name.trim() || s.questions.some(q => q.text.trim())))
+      : title !== initialTitleRef.current || JSON.stringify(sections) !== initialSectionsRef.current;
+    onDirtyChange(dirty);
+  }, [title, sections, editId, onDirtyChange]);
 
   useEffect(() => {
     if (insertDropdown === null) return;

--- a/src/pages/checklists/ChecklistsTab.tsx
+++ b/src/pages/checklists/ChecklistsTab.tsx
@@ -123,6 +123,7 @@ export function ChecklistsTab() {
   const [prefillLocationIds, setPrefillLocationIds] = useState<string[] | null | undefined>(undefined);
   const [dragFolderId, setDragFolderId] = useState<string | null>(null);
   const [editingChecklistId, setEditingChecklistId] = useState<string | null>(null);
+  const [isBuilderDirty, setIsBuilderDirty] = useState(false);
   const [previewChecklist, setPreviewChecklist] = useState<ChecklistItem | null>(null);
   const editingChecklist = editingChecklistId ? dbChecklists.find(c => c.id === editingChecklistId) : null;
   const normalizedSearch = search.trim().toLowerCase();
@@ -143,15 +144,15 @@ export function ChecklistsTab() {
 
   const isEmpty = visibleFolders.length === 0 && visibleChecklists.length === 0 && !normalizedSearch;
 
-  const blocker = useBlocker(showBuilder);
+  const blocker = useBlocker(showBuilder && isBuilderDirty);
 
-  // Warn the browser when the user tries to leave the tab/app entirely while the builder is open
+  // Warn the browser when the user tries to leave the tab/app entirely while the builder has unsaved changes
   useEffect(() => {
-    if (!showBuilder) return;
+    if (!showBuilder || !isBuilderDirty) return;
     const handler = (e: BeforeUnloadEvent) => { e.preventDefault(); e.returnValue = ""; };
     window.addEventListener("beforeunload", handler);
     return () => window.removeEventListener("beforeunload", handler);
-  }, [showBuilder]);
+  }, [showBuilder, isBuilderDirty]);
 
   const handleCreateFolder = () => {
     if (!newFolderName.trim()) return;
@@ -211,6 +212,7 @@ export function ChecklistsTab() {
       setPrefillSections(undefined);
       setPrefillLocationIds(undefined);
       setEditingChecklistId(null);
+      setIsBuilderDirty(false);
     };
 
     return (
@@ -259,6 +261,7 @@ export function ChecklistsTab() {
         initialVisibilityFrom={editingChecklist?.visibility_from ?? null}
         initialVisibilityUntil={editingChecklist?.visibility_until ?? null}
         editId={editingChecklistId || undefined}
+        onDirtyChange={setIsBuilderDirty}
       />
       </Suspense>
       {blocker.state === "blocked" && createPortal(


### PR DESCRIPTION
## Summary
- `useBlocker(showBuilder)` was triggering the "Leave without saving?" dialog on any navigation (bottom nav, browser back) even when the user hadn't changed anything in the checklist builder.
- Added `onDirtyChange` callback prop to `ChecklistBuilderModal` — notifies the parent whenever the dirty state changes, using the same comparison logic as the in-app Back button guard.
- `ChecklistsTab` now gates `useBlocker` and the `beforeunload` handler on `isBuilderDirty`, so the dialog only appears after an actual change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)