### PR TITLE
GDPR: cookie consent banner, Privacy Policy, Terms of Service

### DIFF
--- a/GOLIVE.md
+++ b/GOLIVE.md
@@ -12,11 +12,12 @@ Items that must be completed before launching to real customers.
 - Stripe billing UI — connected to live Stripe account
 - Google Maps address autocomplete + map preview — working
 - Test suite — all 5 pre-existing failures fixed (4× Kiosk numpad, 1× Admin LocationModal)
-- Error monitoring — Sentry installed, `ErrorBoundary` wrapping app, `VITE_SENTRY_DSN` wired into deploy workflow (one manual step: create DSN in sentry.io and add as GitHub Actions variable)
+- Error monitoring — Sentry active, DSN set in GitHub Actions, deployed
 - Infohub — `infohub_folders` + `infohub_documents` Supabase tables + RLS + React Query hooks — fully working
 - Team member invitations — edge function (`invite-team-member`) sends email via Resend, `team_member_invites` table + `validate_invite_token()` + `accept_invite()` RPCs in migration, `AcceptInvite.tsx` OTP flow, pending invite badge + resend button in AccountTab, `/accept-invite` route registered
 - GDPR account deletion — `delete_my_account()` RPC in migration, Delete Account button with "type DELETE to confirm" modal in AccountTab, `?reason=account-deleted` banner on Signup
-- "Build with AI" / "Convert File" — edge function written, both modals have visible error states with humanized messages
+- "Build with AI" / "Convert File" — `generate-checklist`, `generate-training`, `infohub-ai-tools` all deployed, `ANTHROPIC_API_KEY` set, error states in place
+- Google Maps — API key set in GitHub, working in production
 
 ---
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,12 +3,13 @@ import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { createBrowserRouter, RouterProvider, Navigate } from "react-router-dom";
+import { createBrowserRouter, RouterProvider, Navigate, Outlet } from "react-router-dom";
 import { queryClient } from "@/lib/query-client";
 import { AuthProvider } from "@/contexts/AuthContext";
 import { ProtectedRoute } from "@/components/ProtectedRoute";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { routerFutureFlags } from "@/lib/router-future-flags";
+import { CookieBanner } from "@/components/CookieBanner";
 
 const Landing = lazy(() => import("./pages/Landing"));
 const Dashboard = lazy(() => import("./pages/Dashboard"));
@@ -24,6 +25,17 @@ const Login = lazy(() => import("./pages/Login"));
 const NotFound = lazy(() => import("./pages/NotFound"));
 const AuthCallback = lazy(() => import("./pages/AuthCallback"));
 const AcceptInvite = lazy(() => import("./pages/AcceptInvite"));
+const Privacy = lazy(() => import("./pages/Privacy"));
+const Terms = lazy(() => import("./pages/Terms"));
+
+function RootLayout() {
+  return (
+    <>
+      <Outlet />
+      <CookieBanner />
+    </>
+  );
+}
 
 function RouteLoadingFallback() {
   return (
@@ -38,28 +50,35 @@ function RouteLoadingFallback() {
 
 const router = createBrowserRouter(
   [
-    { path: "/", element: <Landing /> },
-    { path: "/kiosk", element: <Kiosk /> },
-    { path: "/signup", element: <Signup /> },
-    { path: "/login", element: <Login /> },
-    { path: "/auth/callback", element: <AuthCallback /> },
-    { path: "/accept-invite", element: <AcceptInvite /> },
-    { path: "/dashboard", element: <ProtectedRoute><Dashboard /></ProtectedRoute> },
-    { path: "/notifications", element: <ProtectedRoute><Notifications /></ProtectedRoute> },
-    { path: "/checklists/*", element: <ProtectedRoute><Checklists /></ProtectedRoute> },
-    { path: "/reporting", element: <ProtectedRoute><Reporting /></ProtectedRoute> },
-    { path: "/infohub", element: <Navigate to="/infohub/library" replace /> },
-    { path: "/infohub/library/*", element: <ProtectedRoute><Infohub /></ProtectedRoute> },
-    { path: "/infohub/training/*", element: <ProtectedRoute><Infohub /></ProtectedRoute> },
-    { path: "/training/*", element: <Navigate to="/infohub/training" replace /> },
-    { path: "/maintenance", element: <Navigate to="/dashboard" replace /> },
-    { path: "/admin", element: <Navigate to="/admin/location" replace /> },
-    { path: "/admin/location", element: <ProtectedRoute><Admin /></ProtectedRoute> },
-    { path: "/admin/users", element: <ProtectedRoute><Admin /></ProtectedRoute> },
-    { path: "/admin/account", element: <ProtectedRoute><Admin /></ProtectedRoute> },
-    { path: "/admin/billing", element: <ProtectedRoute><Admin /></ProtectedRoute> },
-    { path: "/billing", element: <ProtectedRoute><Billing /></ProtectedRoute> },
-    { path: "*", element: <NotFound /> },
+    {
+      element: <RootLayout />,
+      children: [
+        { path: "/", element: <Landing /> },
+        { path: "/privacy", element: <Privacy /> },
+        { path: "/terms", element: <Terms /> },
+        { path: "/kiosk", element: <Kiosk /> },
+        { path: "/signup", element: <Signup /> },
+        { path: "/login", element: <Login /> },
+        { path: "/auth/callback", element: <AuthCallback /> },
+        { path: "/accept-invite", element: <AcceptInvite /> },
+        { path: "/dashboard", element: <ProtectedRoute><Dashboard /></ProtectedRoute> },
+        { path: "/notifications", element: <ProtectedRoute><Notifications /></ProtectedRoute> },
+        { path: "/checklists/*", element: <ProtectedRoute><Checklists /></ProtectedRoute> },
+        { path: "/reporting", element: <ProtectedRoute><Reporting /></ProtectedRoute> },
+        { path: "/infohub", element: <Navigate to="/infohub/library" replace /> },
+        { path: "/infohub/library/*", element: <ProtectedRoute><Infohub /></ProtectedRoute> },
+        { path: "/infohub/training/*", element: <ProtectedRoute><Infohub /></ProtectedRoute> },
+        { path: "/training/*", element: <Navigate to="/infohub/training" replace /> },
+        { path: "/maintenance", element: <Navigate to="/dashboard" replace /> },
+        { path: "/admin", element: <Navigate to="/admin/location" replace /> },
+        { path: "/admin/location", element: <ProtectedRoute><Admin /></ProtectedRoute> },
+        { path: "/admin/users", element: <ProtectedRoute><Admin /></ProtectedRoute> },
+        { path: "/admin/account", element: <ProtectedRoute><Admin /></ProtectedRoute> },
+        { path: "/admin/billing", element: <ProtectedRoute><Admin /></ProtectedRoute> },
+        { path: "/billing", element: <ProtectedRoute><Billing /></ProtectedRoute> },
+        { path: "*", element: <NotFound /> },
+      ],
+    },
   ],
   {
     basename: import.meta.env.BASE_URL,

--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -1,0 +1,56 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { getCookieConsent, setCookieConsent, initSentryIfConsented } from "@/lib/sentry";
+
+export function CookieBanner() {
+  const [visible, setVisible] = useState(() => getCookieConsent() === null);
+
+  if (!visible) return null;
+
+  const accept = () => {
+    setCookieConsent("accepted");
+    initSentryIfConsented();
+    setVisible(false);
+  };
+
+  const decline = () => {
+    setCookieConsent("declined");
+    setVisible(false);
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Cookie consent"
+      className="fixed bottom-0 left-0 right-0 z-50 border-t border-border bg-card shadow-lg"
+    >
+      <div className="max-w-4xl mx-auto px-4 py-4 flex flex-col sm:flex-row sm:items-center gap-4">
+        <p className="text-sm text-muted-foreground flex-1">
+          We use essential cookies to run the app, and optional cookies for error
+          monitoring. See our{" "}
+          <Link
+            to="/privacy"
+            className="underline underline-offset-2 hover:text-foreground transition-colors"
+          >
+            Privacy Policy
+          </Link>{" "}
+          for details.
+        </p>
+        <div className="flex gap-2 shrink-0">
+          <button
+            onClick={decline}
+            className="px-4 py-2 text-sm font-medium border border-border rounded-xl hover:bg-muted transition-colors"
+          >
+            Essential only
+          </button>
+          <button
+            onClick={accept}
+            className="px-4 py-2 text-sm font-medium bg-sage text-white rounded-xl hover:opacity-90 transition-opacity"
+          >
+            Accept all
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/landing/LandingFooter.tsx
+++ b/src/components/landing/LandingFooter.tsx
@@ -46,12 +46,12 @@ export function LandingFooter({ onBookDemo }: { onBookDemo?: () => void }) {
             © {new Date().getFullYear()} Olia. All rights reserved.
           </p>
           <div className="flex gap-4">
-            <a href="#" className="text-xs text-muted-foreground hover:text-foreground transition-colors">
+            <Link to="/privacy" className="text-xs text-muted-foreground hover:text-foreground transition-colors">
               Privacy
-            </a>
-            <a href="#" className="text-xs text-muted-foreground hover:text-foreground transition-colors">
+            </Link>
+            <Link to="/terms" className="text-xs text-muted-foreground hover:text-foreground transition-colors">
               Terms
-            </a>
+            </Link>
           </div>
         </div>
       </div>

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -1,0 +1,28 @@
+import * as Sentry from "@sentry/react";
+
+const CONSENT_KEY = "olia_cookie_consent";
+
+let initialized = false;
+
+export function initSentryIfConsented(): void {
+  if (initialized || !import.meta.env.VITE_SENTRY_DSN) return;
+  if (localStorage.getItem(CONSENT_KEY) !== "accepted") return;
+
+  Sentry.init({
+    dsn: import.meta.env.VITE_SENTRY_DSN,
+    environment: import.meta.env.MODE,
+    integrations: [Sentry.browserTracingIntegration()],
+    tracesSampleRate: 0.1,
+  });
+  initialized = true;
+}
+
+export function getCookieConsent(): "accepted" | "declined" | null {
+  const v = localStorage.getItem(CONSENT_KEY);
+  if (v === "accepted" || v === "declined") return v;
+  return null;
+}
+
+export function setCookieConsent(value: "accepted" | "declined"): void {
+  localStorage.setItem(CONSENT_KEY, value);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/react";
+import { initSentryIfConsented } from "@/lib/sentry";
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
@@ -12,15 +13,8 @@ import { Capacitor } from "@capacitor/core";
 import { restoreGitHubPagesRoute as restoreGitHubPagesRoutePath } from "@/lib/github-pages-routing";
 
 // ── Sentry error monitoring ───────────────────────────────────────────────────
-// Only initialises when VITE_SENTRY_DSN is set (skipped in local dev).
-if (import.meta.env.VITE_SENTRY_DSN) {
-  Sentry.init({
-    dsn: import.meta.env.VITE_SENTRY_DSN,
-    environment: import.meta.env.MODE,
-    integrations: [Sentry.browserTracingIntegration()],
-    tracesSampleRate: 0.1,
-  });
-}
+// Only initialises when VITE_SENTRY_DSN is set AND the user has accepted cookies.
+initSentryIfConsented();
 
 function restoreGitHubPagesRoute() {
   const targetRoute = restoreGitHubPagesRoutePath(

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -1,0 +1,151 @@
+import { Link } from "react-router-dom";
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="space-y-3">
+      <h2 className="font-display text-xl text-foreground">{title}</h2>
+      <div className="space-y-2 text-sm text-muted-foreground leading-relaxed">{children}</div>
+    </section>
+  );
+}
+
+export default function Privacy() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="max-w-2xl mx-auto px-6 py-12 space-y-10">
+
+        {/* Back */}
+        <Link to="/" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
+          ← Back to Olia
+        </Link>
+
+        {/* Header */}
+        <div className="space-y-2">
+          <h1 className="font-display text-4xl text-foreground">Privacy Policy</h1>
+          <p className="text-sm text-muted-foreground">Last updated: 21 July 2026</p>
+        </div>
+
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          Olia ("we", "us", "our") operates oliahq.com and the Olia mobile app. This policy explains
+          what personal data we collect, why we collect it, and your rights under the General Data
+          Protection Regulation (GDPR).
+        </p>
+
+        <Section title="1. Who we are">
+          <p>
+            Olia is a hospitality operations platform. When your business signs up for Olia, your
+            business is the data controller for your team's and staff's data. Olia acts as a data
+            processor on your behalf.
+          </p>
+          <p>
+            For questions about this policy, contact us at{" "}
+            <a href="mailto:hello@oliahq.com" className="underline underline-offset-2 hover:text-foreground transition-colors">
+              hello@oliahq.com
+            </a>.
+          </p>
+        </Section>
+
+        <Section title="2. What data we collect">
+          <p><strong className="text-foreground">Account holders (owners):</strong> name, email address, business name.</p>
+          <p><strong className="text-foreground">Managers:</strong> name, email address, hashed PIN.</p>
+          <p><strong className="text-foreground">Staff profiles:</strong> name, role, hashed PIN. Staff profiles do not require an email address.</p>
+          <p><strong className="text-foreground">Operational data:</strong> checklists, checklist completion logs, locations, infohub documents and training materials you create within Olia.</p>
+          <p><strong className="text-foreground">Usage and error data:</strong> if you consent, we collect anonymised error and performance data via Sentry to help us fix bugs.</p>
+          <p><strong className="text-foreground">Payment data:</strong> billing is handled by Stripe. We do not store card numbers — only your subscription status and Stripe customer ID.</p>
+        </Section>
+
+        <Section title="3. Why we collect it">
+          <p>We process your data to:</p>
+          <ul className="list-disc pl-5 space-y-1">
+            <li>Provide and maintain the Olia service</li>
+            <li>Send transactional emails (team invitations, alerts)</li>
+            <li>Process subscription payments</li>
+            <li>Improve reliability by monitoring errors (with your consent)</li>
+          </ul>
+          <p>
+            Our legal basis is contract performance (Article 6(1)(b) GDPR) for service delivery,
+            and legitimate interests (Article 6(1)(f)) for security and fraud prevention.
+            Error monitoring relies on your consent (Article 6(1)(a)).
+          </p>
+        </Section>
+
+        <Section title="4. Who we share data with">
+          <p>We share data only with the processors listed below, all of which operate under GDPR-compliant data processing agreements:</p>
+          <ul className="list-disc pl-5 space-y-1">
+            <li><strong className="text-foreground">Supabase</strong> — database and authentication, hosted in the EU (Ireland)</li>
+            <li><strong className="text-foreground">Stripe</strong> — payment processing</li>
+            <li><strong className="text-foreground">Resend</strong> — transactional email delivery</li>
+            <li><strong className="text-foreground">Sentry</strong> — error monitoring, hosted in the EU (Frankfurt), only if you consent</li>
+            <li><strong className="text-foreground">Google Maps</strong> — address lookup for location setup</li>
+          </ul>
+          <p>We do not sell your data to any third party.</p>
+        </Section>
+
+        <Section title="5. Data retention">
+          <p>
+            We keep your data for as long as your account is active. When you delete your account,
+            all organisation data — including locations, team members, staff profiles, checklists,
+            and logs — is permanently deleted within 30 days.
+          </p>
+          <p>
+            You can delete your account at any time from the Admin → Account tab inside Olia.
+          </p>
+        </Section>
+
+        <Section title="6. Your rights">
+          <p>Under GDPR you have the right to:</p>
+          <ul className="list-disc pl-5 space-y-1">
+            <li><strong className="text-foreground">Access</strong> — request a copy of your personal data</li>
+            <li><strong className="text-foreground">Correction</strong> — ask us to correct inaccurate data</li>
+            <li><strong className="text-foreground">Deletion</strong> — delete your account and all associated data from within the app, or by emailing us</li>
+            <li><strong className="text-foreground">Portability</strong> — request your data in a machine-readable format</li>
+            <li><strong className="text-foreground">Objection</strong> — object to processing based on legitimate interests</li>
+            <li><strong className="text-foreground">Withdraw consent</strong> — change your cookie preference at any time by clearing your browser data</li>
+          </ul>
+          <p>
+            To exercise any right, email{" "}
+            <a href="mailto:hello@oliahq.com" className="underline underline-offset-2 hover:text-foreground transition-colors">
+              hello@oliahq.com
+            </a>. We will respond within 30 days.
+          </p>
+        </Section>
+
+        <Section title="7. Cookies">
+          <p>We use two categories of cookies:</p>
+          <ul className="list-disc pl-5 space-y-1">
+            <li>
+              <strong className="text-foreground">Essential:</strong> authentication session cookies set by Supabase. These are required
+              for the app to function and do not require consent.
+            </li>
+            <li>
+              <strong className="text-foreground">Analytics / monitoring:</strong> error tracking via Sentry. These are only active
+              if you click "Accept all" on the cookie banner. You can decline without affecting
+              any core functionality.
+            </li>
+          </ul>
+        </Section>
+
+        <Section title="8. Data security">
+          <p>
+            All data is encrypted in transit (TLS) and at rest. PINs are stored as salted hashes
+            and are never readable after creation. Access to the database is restricted to
+            authenticated users within their own organisation via row-level security policies.
+          </p>
+        </Section>
+
+        <Section title="9. Changes to this policy">
+          <p>
+            We may update this policy from time to time. If we make material changes, we will notify
+            you by email. The date at the top of this page shows when it was last updated.
+          </p>
+        </Section>
+
+        {/* Footer */}
+        <div className="pt-6 border-t border-border flex gap-4 text-xs text-muted-foreground">
+          <Link to="/terms" className="hover:text-foreground transition-colors">Terms of Service</Link>
+          <a href="mailto:hello@oliahq.com" className="hover:text-foreground transition-colors">Contact</a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -1,0 +1,176 @@
+import { Link } from "react-router-dom";
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="space-y-3">
+      <h2 className="font-display text-xl text-foreground">{title}</h2>
+      <div className="space-y-2 text-sm text-muted-foreground leading-relaxed">{children}</div>
+    </section>
+  );
+}
+
+export default function Terms() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="max-w-2xl mx-auto px-6 py-12 space-y-10">
+
+        {/* Back */}
+        <Link to="/" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
+          ← Back to Olia
+        </Link>
+
+        {/* Header */}
+        <div className="space-y-2">
+          <h1 className="font-display text-4xl text-foreground">Terms of Service</h1>
+          <p className="text-sm text-muted-foreground">Last updated: 21 July 2026</p>
+        </div>
+
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          These Terms of Service ("Terms") govern your use of Olia, operated by Olia ("we", "us",
+          "our"). By creating an account you agree to these Terms.
+        </p>
+
+        <Section title="1. The service">
+          <p>
+            Olia is a hospitality operations platform that helps teams manage checklists, staff
+            schedules, and daily operations. We provide the platform on a subscription basis.
+          </p>
+        </Section>
+
+        <Section title="2. Your account">
+          <p>
+            You must provide accurate information when creating an account. You are responsible for
+            keeping your login credentials secure and for all activity that occurs under your account.
+          </p>
+          <p>
+            One account represents one organisation. You may add multiple locations and team members
+            within your subscription limits.
+          </p>
+        </Section>
+
+        <Section title="3. Acceptable use">
+          <p>You agree not to:</p>
+          <ul className="list-disc pl-5 space-y-1">
+            <li>Use Olia for any unlawful purpose</li>
+            <li>Attempt to gain unauthorised access to any part of the service or another organisation's data</li>
+            <li>Upload content that is harmful, defamatory, or infringes third-party rights</li>
+            <li>Resell or sublicense access to Olia without our written consent</li>
+            <li>Reverse engineer or attempt to extract the source code of the service</li>
+          </ul>
+        </Section>
+
+        <Section title="4. Subscription and payment">
+          <p>
+            Olia is offered on monthly and annual subscription plans. Prices are shown on the
+            billing page. All prices exclude VAT where applicable.
+          </p>
+          <p>
+            Subscriptions renew automatically at the end of each billing period. You can cancel at
+            any time from Admin → Account → Billing. Cancellation takes effect at the end of the
+            current paid period — you will not be charged again, and you retain access until that
+            date.
+          </p>
+          <p>
+            We do not offer refunds for partial periods except where required by law.
+          </p>
+        </Section>
+
+        <Section title="5. Free trial">
+          <p>
+            New accounts receive a free trial period as shown at signup. No payment method is
+            required during the trial. At the end of the trial you must subscribe to continue
+            using the service.
+          </p>
+        </Section>
+
+        <Section title="6. Your data">
+          <p>
+            You own your data. We process it only to provide the service and as described in our{" "}
+            <Link to="/privacy" className="underline underline-offset-2 hover:text-foreground transition-colors">
+              Privacy Policy
+            </Link>
+            .
+          </p>
+          <p>
+            You can export your checklist data at any time from within the app. On account deletion,
+            all your data is permanently removed from our systems.
+          </p>
+        </Section>
+
+        <Section title="7. Availability">
+          <p>
+            We aim for high availability but do not guarantee uninterrupted access. We may perform
+            maintenance that temporarily affects the service. We will notify you of planned downtime
+            where reasonably possible.
+          </p>
+        </Section>
+
+        <Section title="8. Intellectual property">
+          <p>
+            Olia and its underlying software, design, and content are owned by us and protected by
+            intellectual property law. These Terms do not grant you any rights to our intellectual
+            property beyond what is necessary to use the service.
+          </p>
+          <p>
+            Content you create within Olia (checklists, documents, training materials) remains
+            yours.
+          </p>
+        </Section>
+
+        <Section title="9. Limitation of liability">
+          <p>
+            To the maximum extent permitted by law, Olia is not liable for indirect, incidental,
+            special, or consequential damages arising from your use of the service, including loss
+            of profits or data.
+          </p>
+          <p>
+            Our total liability to you for any claim arising under these Terms is limited to the
+            amount you paid us in the three months before the claim arose.
+          </p>
+        </Section>
+
+        <Section title="10. Termination">
+          <p>
+            Either party may terminate at any time. We may suspend or terminate your account if you
+            breach these Terms, with or without notice depending on the severity of the breach.
+          </p>
+          <p>
+            On termination, your right to access the service ceases immediately. We will retain
+            your data for 30 days before permanent deletion, during which time you may contact us
+            to request an export.
+          </p>
+        </Section>
+
+        <Section title="11. Changes to these Terms">
+          <p>
+            We may update these Terms from time to time. We will notify you by email at least 14
+            days before material changes take effect. Continued use of Olia after that date
+            constitutes acceptance of the new Terms.
+          </p>
+        </Section>
+
+        <Section title="12. Governing law">
+          <p>
+            These Terms are governed by the laws of England and Wales. Any disputes will be subject
+            to the exclusive jurisdiction of the courts of England and Wales.
+          </p>
+        </Section>
+
+        <Section title="13. Contact">
+          <p>
+            For any questions about these Terms, email us at{" "}
+            <a href="mailto:hello@oliahq.com" className="underline underline-offset-2 hover:text-foreground transition-colors">
+              hello@oliahq.com
+            </a>.
+          </p>
+        </Section>
+
+        {/* Footer */}
+        <div className="pt-6 border-t border-border flex gap-4 text-xs text-muted-foreground">
+          <Link to="/privacy" className="hover:text-foreground transition-colors">Privacy Policy</Link>
+          <a href="mailto:hello@oliahq.com" className="hover:text-foreground transition-colors">Contact</a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/test/components/CookieBanner.test.tsx
+++ b/src/test/components/CookieBanner.test.tsx
@@ -1,0 +1,85 @@
+import { screen, fireEvent } from "@testing-library/react";
+import { beforeEach, afterEach } from "vitest";
+import { CookieBanner } from "@/components/CookieBanner";
+import { renderWithProviders } from "../test-utils";
+
+vi.mock("@/lib/sentry", () => ({
+  getCookieConsent: vi.fn(),
+  setCookieConsent: vi.fn(),
+  initSentryIfConsented: vi.fn(),
+}));
+
+import { getCookieConsent, setCookieConsent, initSentryIfConsented } from "@/lib/sentry";
+
+describe("CookieBanner", () => {
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.mocked(getCookieConsent).mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it("renders when no consent is stored", () => {
+    renderWithProviders(<CookieBanner />);
+    expect(screen.getByRole("dialog", { name: /cookie consent/i })).toBeInTheDocument();
+  });
+
+  it("does not render when consent is already given", () => {
+    vi.mocked(getCookieConsent).mockReturnValue("accepted");
+    renderWithProviders(<CookieBanner />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("does not render when consent was declined", () => {
+    vi.mocked(getCookieConsent).mockReturnValue("declined");
+    renderWithProviders(<CookieBanner />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("shows Accept all and Essential only buttons", () => {
+    renderWithProviders(<CookieBanner />);
+    expect(screen.getByRole("button", { name: /accept all/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /essential only/i })).toBeInTheDocument();
+  });
+
+  it("accepting sets consent to accepted and inits Sentry", () => {
+    renderWithProviders(<CookieBanner />);
+    fireEvent.click(screen.getByRole("button", { name: /accept all/i }));
+    expect(setCookieConsent).toHaveBeenCalledWith("accepted");
+    expect(initSentryIfConsented).toHaveBeenCalled();
+  });
+
+  it("accepting hides the banner", () => {
+    renderWithProviders(<CookieBanner />);
+    fireEvent.click(screen.getByRole("button", { name: /accept all/i }));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("declining sets consent to declined", () => {
+    renderWithProviders(<CookieBanner />);
+    fireEvent.click(screen.getByRole("button", { name: /essential only/i }));
+    expect(setCookieConsent).toHaveBeenCalledWith("declined");
+  });
+
+  it("declining hides the banner", () => {
+    renderWithProviders(<CookieBanner />);
+    fireEvent.click(screen.getByRole("button", { name: /essential only/i }));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("declining does not init Sentry", () => {
+    renderWithProviders(<CookieBanner />);
+    fireEvent.click(screen.getByRole("button", { name: /essential only/i }));
+    expect(initSentryIfConsented).not.toHaveBeenCalled();
+  });
+
+  it("shows a link to the Privacy Policy", () => {
+    renderWithProviders(<CookieBanner />);
+    expect(screen.getByRole("link", { name: /privacy policy/i })).toBeInTheDocument();
+  });
+});

--- a/src/test/pages/Privacy.test.tsx
+++ b/src/test/pages/Privacy.test.tsx
@@ -1,0 +1,50 @@
+import { screen } from "@testing-library/react";
+import { beforeEach, afterEach } from "vitest";
+import Privacy from "@/pages/Privacy";
+import { renderWithProviders } from "../test-utils";
+
+describe("Privacy page", () => {
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("renders without crashing", () => {
+    renderWithProviders(<Privacy />);
+    expect(document.body).toBeDefined();
+  });
+
+  it("shows the Privacy Policy heading", () => {
+    renderWithProviders(<Privacy />);
+    expect(screen.getByRole("heading", { name: /privacy policy/i })).toBeInTheDocument();
+  });
+
+  it("shows a link back to home", () => {
+    renderWithProviders(<Privacy />);
+    expect(screen.getByRole("link", { name: /back to olia/i })).toBeInTheDocument();
+  });
+
+  it("shows a contact email link", () => {
+    renderWithProviders(<Privacy />);
+    const links = screen.getAllByRole("link");
+    const emailLink = links.find(l => l.getAttribute("href")?.includes("hello@oliahq.com"));
+    expect(emailLink).toBeDefined();
+  });
+
+  it("shows a link to Terms of Service", () => {
+    renderWithProviders(<Privacy />);
+    expect(screen.getByRole("link", { name: /terms of service/i })).toBeInTheDocument();
+  });
+
+  it("covers key GDPR sections", () => {
+    renderWithProviders(<Privacy />);
+    expect(screen.getByRole("heading", { name: /your rights/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /cookies/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /data retention/i })).toBeInTheDocument();
+  });
+});

--- a/src/test/pages/Terms.test.tsx
+++ b/src/test/pages/Terms.test.tsx
@@ -1,0 +1,54 @@
+import { screen } from "@testing-library/react";
+import { beforeEach, afterEach } from "vitest";
+import Terms from "@/pages/Terms";
+import { renderWithProviders } from "../test-utils";
+
+describe("Terms page", () => {
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("renders without crashing", () => {
+    renderWithProviders(<Terms />);
+    expect(document.body).toBeDefined();
+  });
+
+  it("shows the Terms of Service heading", () => {
+    renderWithProviders(<Terms />);
+    expect(screen.getByRole("heading", { name: /terms of service/i })).toBeInTheDocument();
+  });
+
+  it("shows a link back to home", () => {
+    renderWithProviders(<Terms />);
+    expect(screen.getByRole("link", { name: /back to olia/i })).toBeInTheDocument();
+  });
+
+  it("shows links to the Privacy Policy", () => {
+    renderWithProviders(<Terms />);
+    const links = screen.getAllByRole("link", { name: /privacy policy/i });
+    expect(links.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows a contact email link", () => {
+    renderWithProviders(<Terms />);
+    const links = screen.getAllByRole("link");
+    const emailLink = links.find(l => l.getAttribute("href")?.includes("hello@oliahq.com"));
+    expect(emailLink).toBeDefined();
+  });
+
+  it("covers subscription and payment section", () => {
+    renderWithProviders(<Terms />);
+    expect(screen.getByText(/subscription and payment/i)).toBeInTheDocument();
+  });
+
+  it("covers acceptable use section", () => {
+    renderWithProviders(<Terms />);
+    expect(screen.getByText(/acceptable use/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- **Cookie consent banner** — fixed to the bottom of every page on first visit. "Accept all" activates Sentry error monitoring; "Essential only" keeps only auth cookies. Choice persisted in localStorage, never shown again after deciding.
- **Privacy Policy** (`/privacy`) — covers what data is collected, why, who it's shared with (Supabase EU, Stripe, Resend, Sentry EU, Google Maps), data retention, GDPR rights, cookies, and security.
- **Terms of Service** (`/terms`) — covers subscription and payment, acceptable use, cancellation, data ownership, limitation of liability, and governing law (England & Wales).
- **Footer links fixed** — Privacy and Terms in the landing page footer now link to real pages instead of `#`.
- **Sentry wired to consent** — Sentry only initialises if the user has previously accepted cookies, both on page load and immediately after accepting in the banner.

## What still needs human review
The legal text in both pages covers the right areas but should be reviewed by a lawyer before launch, particularly the governing law clause and liability limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)