### PR TITLE
Spain legal compliance: Aviso Legal, Cookie Policy, AEPD dark-pattern fix

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,8 @@ const AuthCallback = lazy(() => import("./pages/AuthCallback"));
 const AcceptInvite = lazy(() => import("./pages/AcceptInvite"));
 const Privacy = lazy(() => import("./pages/Privacy"));
 const Terms = lazy(() => import("./pages/Terms"));
+const Cookies = lazy(() => import("./pages/Cookies"));
+const AvisoLegal = lazy(() => import("./pages/AvisoLegal"));
 
 function RootLayout() {
   return (
@@ -56,6 +58,8 @@ const router = createBrowserRouter(
         { path: "/", element: <Landing /> },
         { path: "/privacy", element: <Privacy /> },
         { path: "/terms", element: <Terms /> },
+        { path: "/cookies", element: <Cookies /> },
+        { path: "/aviso-legal", element: <AvisoLegal /> },
         { path: "/kiosk", element: <Kiosk /> },
         { path: "/signup", element: <Signup /> },
         { path: "/login", element: <Login /> },

--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -29,17 +29,18 @@ export function CookieBanner() {
           We use essential cookies to run the app, and optional cookies for error
           monitoring. See our{" "}
           <Link
-            to="/privacy"
+            to="/cookies"
             className="underline underline-offset-2 hover:text-foreground transition-colors"
           >
-            Privacy Policy
+            Cookie Policy
           </Link>{" "}
           for details.
         </p>
         <div className="flex gap-2 shrink-0">
+          {/* Equal visual weight required by AEPD — no dark patterns */}
           <button
             onClick={decline}
-            className="px-4 py-2 text-sm font-medium border border-border rounded-xl hover:bg-muted transition-colors"
+            className="px-4 py-2 text-sm font-medium bg-muted text-foreground rounded-xl hover:opacity-80 transition-opacity"
           >
             Essential only
           </button>

--- a/src/components/landing/LandingFooter.tsx
+++ b/src/components/landing/LandingFooter.tsx
@@ -45,12 +45,18 @@ export function LandingFooter({ onBookDemo }: { onBookDemo?: () => void }) {
           <p className="text-xs text-muted-foreground">
             © {new Date().getFullYear()} Olia. All rights reserved.
           </p>
-          <div className="flex gap-4">
+          <div className="flex flex-wrap gap-4">
             <Link to="/privacy" className="text-xs text-muted-foreground hover:text-foreground transition-colors">
               Privacy
             </Link>
             <Link to="/terms" className="text-xs text-muted-foreground hover:text-foreground transition-colors">
               Terms
+            </Link>
+            <Link to="/cookies" className="text-xs text-muted-foreground hover:text-foreground transition-colors">
+              Cookies
+            </Link>
+            <Link to="/aviso-legal" className="text-xs text-muted-foreground hover:text-foreground transition-colors">
+              Aviso Legal
             </Link>
           </div>
         </div>

--- a/src/pages/AvisoLegal.tsx
+++ b/src/pages/AvisoLegal.tsx
@@ -1,0 +1,164 @@
+import { Link } from "react-router-dom";
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="space-y-3">
+      <h2 className="font-display text-xl text-foreground">{title}</h2>
+      <div className="space-y-2 text-sm text-muted-foreground leading-relaxed">{children}</div>
+    </section>
+  );
+}
+
+// ─── FILL IN THESE DETAILS ────────────────────────────────────────────────────
+// Required under LSSI Article 10. Update before going live.
+const COMPANY_NAME    = "[RAZÓN SOCIAL]";       // e.g. "Olia Technologies S.L."
+const CIF             = "[CIF]";                // e.g. "B12345678"
+const ADDRESS         = "[DOMICILIO SOCIAL]";   // e.g. "Carrer de Example 1, 1º 1ª, 08001 Barcelona"
+const REGISTRO        = "[REGISTRO MERCANTIL]"; // e.g. "Registro Mercantil de Barcelona, Tomo X, Folio Y, Hoja Z"
+// ─────────────────────────────────────────────────────────────────────────────
+
+export default function AvisoLegal() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="max-w-2xl mx-auto px-6 py-12 space-y-10">
+
+        <Link to="/" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
+          ← Back to Olia
+        </Link>
+
+        <div className="space-y-2">
+          <h1 className="font-display text-4xl text-foreground">Aviso Legal</h1>
+          <p className="text-sm text-muted-foreground">
+            Legal Notice — requerido por el artículo 10 de la Ley 34/2002, LSSI-CE.
+            Última actualización: 21 de julio de 2026.
+          </p>
+        </div>
+
+        <Section title="1. Datos identificativos del titular">
+          <p>
+            En cumplimiento del artículo 10 de la Ley 34/2002, de 11 de julio, de Servicios de la
+            Sociedad de la Información y de Comercio Electrónico (LSSI-CE), se facilitan los
+            siguientes datos identificativos:
+          </p>
+          <ul className="space-y-1 not-prose">
+            <li><strong className="text-foreground">Denominación social:</strong> {COMPANY_NAME}</li>
+            <li><strong className="text-foreground">NIF/CIF:</strong> {CIF}</li>
+            <li><strong className="text-foreground">Domicilio social:</strong> {ADDRESS}</li>
+            <li><strong className="text-foreground">Correo electrónico:</strong>{" "}
+              <a href="mailto:hello@oliahq.com" className="underline underline-offset-2 hover:text-foreground transition-colors">
+                hello@oliahq.com
+              </a>
+            </li>
+            <li><strong className="text-foreground">Sitio web:</strong> oliahq.com</li>
+            <li><strong className="text-foreground">Registro Mercantil:</strong> {REGISTRO}</li>
+          </ul>
+        </Section>
+
+        <Section title="2. Objeto y ámbito de aplicación">
+          <p>
+            El presente Aviso Legal regula el acceso y uso del sitio web oliahq.com y de la
+            aplicación Olia (en adelante, "el Servicio"), titularidad de {COMPANY_NAME}.
+          </p>
+          <p>
+            El acceso y uso del Servicio atribuye la condición de usuario e implica la aceptación
+            plena de las condiciones incluidas en este Aviso Legal.
+          </p>
+        </Section>
+
+        <Section title="3. Propiedad intelectual e industrial">
+          <p>
+            Todos los contenidos del Servicio —incluyendo, sin carácter limitativo, textos,
+            fotografías, gráficos, imágenes, iconos, tecnología, software, diseño gráfico y
+            códigos fuente— son propiedad intelectual de {COMPANY_NAME} o de terceros que han
+            autorizado su uso, y están protegidos por la legislación española e internacional de
+            propiedad intelectual e industrial.
+          </p>
+          <p>
+            Queda expresamente prohibida la reproducción, distribución, comunicación pública y
+            transformación de los contenidos del Servicio sin la autorización previa y por escrito
+            del titular.
+          </p>
+          <p>
+            El contenido que el usuario crea dentro de Olia (listas de verificación, documentos,
+            materiales de formación) es propiedad del usuario.
+          </p>
+        </Section>
+
+        <Section title="4. Condiciones de uso">
+          <p>El usuario se compromete a hacer un uso adecuado del Servicio y, en particular, a no:</p>
+          <ul className="list-disc pl-5 space-y-1">
+            <li>Utilizar el Servicio con fines ilícitos o contrarios a la ley</li>
+            <li>Introducir virus, malware u otros elementos dañinos</li>
+            <li>Intentar acceder sin autorización a datos de otras organizaciones</li>
+            <li>Reproducir o explotar comercialmente los contenidos sin autorización</li>
+          </ul>
+        </Section>
+
+        <Section title="5. Exclusión de responsabilidad">
+          <p>
+            {COMPANY_NAME} no se hace responsable de los daños y perjuicios de cualquier
+            naturaleza que puedan derivarse del acceso o uso del Servicio, de la imposibilidad de
+            acceso o de fallos en la seguridad que pudieran afectar a la información transmitida.
+          </p>
+          <p>
+            En la medida permitida por la ley española, la responsabilidad total de {COMPANY_NAME}
+            frente al usuario por cualquier reclamación derivada del uso del Servicio quedará
+            limitada al importe abonado por el usuario en los tres meses anteriores a la
+            reclamación.
+          </p>
+        </Section>
+
+        <Section title="6. Protección de datos">
+          <p>
+            El tratamiento de los datos personales de los usuarios del Servicio se rige por la
+            Política de Privacidad disponible en{" "}
+            <Link to="/privacy" className="underline underline-offset-2 hover:text-foreground transition-colors">
+              oliahq.com/privacy
+            </Link>
+            , elaborada de conformidad con el Reglamento (UE) 2016/679 (RGPD) y la Ley Orgánica
+            3/2018, de 5 de diciembre, de Protección de Datos Personales y garantía de los
+            derechos digitales (LOPDGDD).
+          </p>
+          <p>
+            La autoridad de control competente en España es la Agencia Española de Protección de
+            Datos (AEPD), con sede en C/ Jorge Juan, 6, 28001 Madrid —{" "}
+            <a
+              href="https://www.aepd.es"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline underline-offset-2 hover:text-foreground transition-colors"
+            >
+              www.aepd.es
+            </a>.
+          </p>
+        </Section>
+
+        <Section title="7. Cookies">
+          <p>
+            El Servicio utiliza cookies propias y de terceros. Para más información, consulte
+            nuestra{" "}
+            <Link to="/cookies" className="underline underline-offset-2 hover:text-foreground transition-colors">
+              Política de Cookies
+            </Link>
+            , elaborada de conformidad con el artículo 22.2 de la LSSI-CE y las directrices de la AEPD.
+          </p>
+        </Section>
+
+        <Section title="8. Ley aplicable y jurisdicción">
+          <p>
+            El presente Aviso Legal se rige por la legislación española. Para la resolución de
+            cualquier controversia derivada del acceso o uso del Servicio, las partes se someten,
+            con renuncia expresa a cualquier otro fuero que pudiera corresponderles, a la
+            jurisdicción de los Juzgados y Tribunales de la ciudad de Barcelona.
+          </p>
+        </Section>
+
+        <div className="pt-6 border-t border-border flex flex-wrap gap-4 text-xs text-muted-foreground">
+          <Link to="/privacy" className="hover:text-foreground transition-colors">Política de Privacidad</Link>
+          <Link to="/cookies" className="hover:text-foreground transition-colors">Política de Cookies</Link>
+          <Link to="/terms" className="hover:text-foreground transition-colors">Términos de Servicio</Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Cookies.tsx
+++ b/src/pages/Cookies.tsx
@@ -1,0 +1,201 @@
+import { Link } from "react-router-dom";
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="space-y-3">
+      <h2 className="font-display text-xl text-foreground">{title}</h2>
+      <div className="space-y-2 text-sm text-muted-foreground leading-relaxed">{children}</div>
+    </section>
+  );
+}
+
+function CookieRow({
+  name, provider, purpose, type, duration,
+}: {
+  name: string; provider: string; purpose: string; type: string; duration: string;
+}) {
+  return (
+    <tr className="border-b border-border last:border-0">
+      <td className="py-3 pr-4 font-mono text-xs text-foreground align-top">{name}</td>
+      <td className="py-3 pr-4 text-xs align-top">{provider}</td>
+      <td className="py-3 pr-4 text-xs align-top">{purpose}</td>
+      <td className="py-3 pr-4 text-xs align-top">{type}</td>
+      <td className="py-3 text-xs align-top">{duration}</td>
+    </tr>
+  );
+}
+
+export default function Cookies() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="max-w-3xl mx-auto px-6 py-12 space-y-10">
+
+        <Link to="/" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
+          ← Back to Olia
+        </Link>
+
+        <div className="space-y-2">
+          <h1 className="font-display text-4xl text-foreground">Cookie Policy</h1>
+          <p className="text-sm text-muted-foreground">Last updated: 21 July 2026</p>
+        </div>
+
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          This policy explains what cookies and similar technologies Olia uses, why, and how you
+          can control them. It applies to oliahq.com and the Olia app. It complies with Article
+          22.2 of Spain's LSSI-CE and the AEPD's cookie guidance.
+        </p>
+
+        <Section title="What are cookies?">
+          <p>
+            Cookies are small text files stored on your device when you visit a website. They help
+            the site remember information between pages or visits. Some are essential for the site
+            to work; others are optional and require your consent.
+          </p>
+        </Section>
+
+        <Section title="Essential cookies">
+          <p>
+            These cookies are necessary for Olia to function. They are set automatically when you
+            use the app and cannot be disabled without breaking core features. No consent is
+            required for essential cookies under LSSI Article 22.2.
+          </p>
+
+          <div className="overflow-x-auto mt-3">
+            <table className="w-full text-left border-collapse">
+              <thead>
+                <tr className="border-b border-border">
+                  <th className="pb-2 pr-4 text-xs font-semibold text-foreground">Cookie</th>
+                  <th className="pb-2 pr-4 text-xs font-semibold text-foreground">Provider</th>
+                  <th className="pb-2 pr-4 text-xs font-semibold text-foreground">Purpose</th>
+                  <th className="pb-2 pr-4 text-xs font-semibold text-foreground">Type</th>
+                  <th className="pb-2 text-xs font-semibold text-foreground">Duration</th>
+                </tr>
+              </thead>
+              <tbody>
+                <CookieRow
+                  name="sb-*-auth-token"
+                  provider="Supabase"
+                  purpose="Keeps you signed in to your Olia account across page loads"
+                  type="Essential"
+                  duration="Session / 1 year"
+                />
+                <CookieRow
+                  name="olia_cookie_consent"
+                  provider="Olia (localStorage)"
+                  purpose="Remembers your cookie preference so the banner is not shown again"
+                  type="Essential"
+                  duration="1 year"
+                />
+              </tbody>
+            </table>
+          </div>
+        </Section>
+
+        <Section title="Analytics and monitoring cookies">
+          <p>
+            These cookies are optional. They are only active if you click <strong className="text-foreground">Accept all</strong>{" "}
+            on the cookie banner. Declining does not affect any core Olia functionality.
+          </p>
+
+          <div className="overflow-x-auto mt-3">
+            <table className="w-full text-left border-collapse">
+              <thead>
+                <tr className="border-b border-border">
+                  <th className="pb-2 pr-4 text-xs font-semibold text-foreground">Cookie</th>
+                  <th className="pb-2 pr-4 text-xs font-semibold text-foreground">Provider</th>
+                  <th className="pb-2 pr-4 text-xs font-semibold text-foreground">Purpose</th>
+                  <th className="pb-2 pr-4 text-xs font-semibold text-foreground">Type</th>
+                  <th className="pb-2 text-xs font-semibold text-foreground">Duration</th>
+                </tr>
+              </thead>
+              <tbody>
+                <CookieRow
+                  name="sentry-sc (session storage)"
+                  provider="Sentry"
+                  purpose="Tracks error sessions to help us diagnose bugs and crashes"
+                  type="Analytics"
+                  duration="Session"
+                />
+              </tbody>
+            </table>
+          </div>
+        </Section>
+
+        <Section title="Third-party cookies (in-app only)">
+          <p>
+            The following third-party service is loaded only when you use a specific feature
+            inside the signed-in app. It is not active on the public landing page.
+          </p>
+
+          <div className="overflow-x-auto mt-3">
+            <table className="w-full text-left border-collapse">
+              <thead>
+                <tr className="border-b border-border">
+                  <th className="pb-2 pr-4 text-xs font-semibold text-foreground">Cookie</th>
+                  <th className="pb-2 pr-4 text-xs font-semibold text-foreground">Provider</th>
+                  <th className="pb-2 pr-4 text-xs font-semibold text-foreground">Purpose</th>
+                  <th className="pb-2 pr-4 text-xs font-semibold text-foreground">Type</th>
+                  <th className="pb-2 text-xs font-semibold text-foreground">Duration</th>
+                </tr>
+              </thead>
+              <tbody>
+                <CookieRow
+                  name="CONSENT, _GRECAPTCHA"
+                  provider="Google Maps"
+                  purpose="Address autocomplete when setting up a location in Admin"
+                  type="Functional"
+                  duration="6 months"
+                />
+              </tbody>
+            </table>
+          </div>
+          <p className="mt-2">
+            Google Maps is loaded only on the Admin → My Location screen. It is not loaded on
+            the landing page and does not track visitors. Google's privacy policy applies to
+            data processed by Google Maps.
+          </p>
+        </Section>
+
+        <Section title="How to change your preference">
+          <p>
+            You can change your cookie preference at any time by clearing your browser's local
+            storage for oliahq.com. The cookie banner will reappear on your next visit.
+          </p>
+          <p>
+            In most browsers: Settings → Privacy → Cookies / Site data → find oliahq.com → Clear.
+          </p>
+        </Section>
+
+        <Section title="Contact">
+          <p>
+            For questions about our use of cookies, email{" "}
+            <a href="mailto:hello@oliahq.com" className="underline underline-offset-2 hover:text-foreground transition-colors">
+              hello@oliahq.com
+            </a>{" "}
+            or write to us at the address in our{" "}
+            <Link to="/aviso-legal" className="underline underline-offset-2 hover:text-foreground transition-colors">
+              Aviso Legal
+            </Link>.
+          </p>
+          <p>
+            You may also file a complaint with Spain's data protection authority, the{" "}
+            <a
+              href="https://www.aepd.es"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline underline-offset-2 hover:text-foreground transition-colors"
+            >
+              AEPD
+            </a>.
+          </p>
+        </Section>
+
+        <div className="pt-6 border-t border-border flex flex-wrap gap-4 text-xs text-muted-foreground">
+          <Link to="/privacy" className="hover:text-foreground transition-colors">Privacy Policy</Link>
+          <Link to="/terms" className="hover:text-foreground transition-colors">Terms of Service</Link>
+          <Link to="/aviso-legal" className="hover:text-foreground transition-colors">Aviso Legal</Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -27,8 +27,9 @@ export default function Privacy() {
 
         <p className="text-sm text-muted-foreground leading-relaxed">
           Olia ("we", "us", "our") operates oliahq.com and the Olia mobile app. This policy explains
-          what personal data we collect, why we collect it, and your rights under the General Data
-          Protection Regulation (GDPR).
+          what personal data we collect, why we collect it, and your rights under the EU General Data
+          Protection Regulation (GDPR / RGPD) and Spain's Ley Orgánica 3/2018 de Protección de Datos
+          Personales y garantía de los derechos digitales (LOPDGDD).
         </p>
 
         <Section title="1. Who we are">
@@ -108,10 +109,23 @@ export default function Privacy() {
               hello@oliahq.com
             </a>. We will respond within 30 days.
           </p>
+          <p>
+            You also have the right to lodge a complaint with Spain's data protection authority,
+            the{" "}
+            <a href="https://www.aepd.es" target="_blank" rel="noopener noreferrer" className="underline underline-offset-2 hover:text-foreground transition-colors">
+              Agencia Española de Protección de Datos (AEPD)
+            </a>, C/ Jorge Juan 6, 28001 Madrid.
+          </p>
         </Section>
 
         <Section title="7. Cookies">
-          <p>We use two categories of cookies:</p>
+          <p>
+            We use cookies in compliance with Article 22.2 of Spain's LSSI-CE and AEPD guidelines.
+            A full list of every cookie we use is in our{" "}
+            <Link to="/cookies" className="underline underline-offset-2 hover:text-foreground transition-colors">
+              Cookie Policy
+            </Link>. In summary:
+          </p>
           <ul className="list-disc pl-5 space-y-1">
             <li>
               <strong className="text-foreground">Essential:</strong> authentication session cookies set by Supabase. These are required
@@ -119,8 +133,8 @@ export default function Privacy() {
             </li>
             <li>
               <strong className="text-foreground">Analytics / monitoring:</strong> error tracking via Sentry. These are only active
-              if you click "Accept all" on the cookie banner. You can decline without affecting
-              any core functionality.
+              if you click "Accept all" on the cookie banner. Both options are given equal
+              prominence — you can decline without affecting any core functionality.
             </li>
           </ul>
         </Section>
@@ -141,8 +155,10 @@ export default function Privacy() {
         </Section>
 
         {/* Footer */}
-        <div className="pt-6 border-t border-border flex gap-4 text-xs text-muted-foreground">
+        <div className="pt-6 border-t border-border flex flex-wrap gap-4 text-xs text-muted-foreground">
           <Link to="/terms" className="hover:text-foreground transition-colors">Terms of Service</Link>
+          <Link to="/cookies" className="hover:text-foreground transition-colors">Cookie Policy</Link>
+          <Link to="/aviso-legal" className="hover:text-foreground transition-colors">Aviso Legal</Link>
           <a href="mailto:hello@oliahq.com" className="hover:text-foreground transition-colors">Contact</a>
         </div>
       </div>

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -151,12 +151,22 @@ export default function Terms() {
 
         <Section title="12. Governing law">
           <p>
-            These Terms are governed by the laws of England and Wales. Any disputes will be subject
-            to the exclusive jurisdiction of the courts of England and Wales.
+            These Terms are governed by Spanish law. Any disputes arising from or relating to these
+            Terms or the use of the service will be subject to the exclusive jurisdiction of the
+            courts of Barcelona, Spain, unless mandatory consumer protection law in your country
+            grants you the right to bring proceedings in your local courts.
           </p>
         </Section>
 
-        <Section title="13. Contact">
+        <Section title="13. VAT / IVA">
+          <p>
+            Prices shown do not include VAT (IVA in Spain). For customers based in Spain, IVA at
+            the applicable rate (currently 21%) will be added to invoices. EU business customers
+            outside Spain may be subject to the reverse charge mechanism.
+          </p>
+        </Section>
+
+        <Section title="14. Contact">
           <p>
             For any questions about these Terms, email us at{" "}
             <a href="mailto:hello@oliahq.com" className="underline underline-offset-2 hover:text-foreground transition-colors">
@@ -166,8 +176,10 @@ export default function Terms() {
         </Section>
 
         {/* Footer */}
-        <div className="pt-6 border-t border-border flex gap-4 text-xs text-muted-foreground">
+        <div className="pt-6 border-t border-border flex flex-wrap gap-4 text-xs text-muted-foreground">
           <Link to="/privacy" className="hover:text-foreground transition-colors">Privacy Policy</Link>
+          <Link to="/cookies" className="hover:text-foreground transition-colors">Cookie Policy</Link>
+          <Link to="/aviso-legal" className="hover:text-foreground transition-colors">Aviso Legal</Link>
           <a href="mailto:hello@oliahq.com" className="hover:text-foreground transition-colors">Contact</a>
         </div>
       </div>

--- a/src/test/components/CookieBanner.test.tsx
+++ b/src/test/components/CookieBanner.test.tsx
@@ -78,8 +78,8 @@ describe("CookieBanner", () => {
     expect(initSentryIfConsented).not.toHaveBeenCalled();
   });
 
-  it("shows a link to the Privacy Policy", () => {
+  it("shows a link to the Cookie Policy", () => {
     renderWithProviders(<CookieBanner />);
-    expect(screen.getByRole("link", { name: /privacy policy/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /cookie policy/i })).toBeInTheDocument();
   });
 });

--- a/src/test/pages/AvisoLegal.test.tsx
+++ b/src/test/pages/AvisoLegal.test.tsx
@@ -1,0 +1,61 @@
+import { screen } from "@testing-library/react";
+import { beforeEach, afterEach } from "vitest";
+import AvisoLegal from "@/pages/AvisoLegal";
+import { renderWithProviders } from "../test-utils";
+
+describe("AvisoLegal page", () => {
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("renders without crashing", () => {
+    renderWithProviders(<AvisoLegal />);
+    expect(document.body).toBeDefined();
+  });
+
+  it("shows the Aviso Legal heading", () => {
+    renderWithProviders(<AvisoLegal />);
+    expect(screen.getByRole("heading", { name: /aviso legal/i })).toBeInTheDocument();
+  });
+
+  it("shows a link back to home", () => {
+    renderWithProviders(<AvisoLegal />);
+    expect(screen.getByRole("link", { name: /back to olia/i })).toBeInTheDocument();
+  });
+
+  it("shows LSSI reference", () => {
+    renderWithProviders(<AvisoLegal />);
+    const matches = screen.getAllByText(/LSSI/i);
+    expect(matches.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows LOPDGDD reference", () => {
+    renderWithProviders(<AvisoLegal />);
+    expect(screen.getByText(/LOPDGDD/i)).toBeInTheDocument();
+  });
+
+  it("shows AEPD reference with link", () => {
+    renderWithProviders(<AvisoLegal />);
+    const links = screen.getAllByRole("link");
+    const aepdLink = links.find(l => l.getAttribute("href")?.includes("aepd.es"));
+    expect(aepdLink).toBeDefined();
+  });
+
+  it("mentions Barcelona jurisdiction", () => {
+    renderWithProviders(<AvisoLegal />);
+    expect(screen.getByText(/barcelona/i)).toBeInTheDocument();
+  });
+
+  it("links to Cookie Policy", () => {
+    renderWithProviders(<AvisoLegal />);
+    const links = screen.getAllByRole("link");
+    const cookieLink = links.find(l => l.getAttribute("href") === "/cookies");
+    expect(cookieLink).toBeDefined();
+  });
+});

--- a/src/test/pages/Cookies.test.tsx
+++ b/src/test/pages/Cookies.test.tsx
@@ -1,0 +1,59 @@
+import { screen } from "@testing-library/react";
+import { beforeEach, afterEach } from "vitest";
+import Cookies from "@/pages/Cookies";
+import { renderWithProviders } from "../test-utils";
+
+describe("Cookies page", () => {
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("renders without crashing", () => {
+    renderWithProviders(<Cookies />);
+    expect(document.body).toBeDefined();
+  });
+
+  it("shows the Cookie Policy heading", () => {
+    renderWithProviders(<Cookies />);
+    expect(screen.getByRole("heading", { name: /cookie policy/i })).toBeInTheDocument();
+  });
+
+  it("shows a link back to home", () => {
+    renderWithProviders(<Cookies />);
+    expect(screen.getByRole("link", { name: /back to olia/i })).toBeInTheDocument();
+  });
+
+  it("lists essential cookies section", () => {
+    renderWithProviders(<Cookies />);
+    expect(screen.getByRole("heading", { name: /essential cookies/i })).toBeInTheDocument();
+  });
+
+  it("lists analytics cookies section", () => {
+    renderWithProviders(<Cookies />);
+    expect(screen.getByRole("heading", { name: /analytics/i })).toBeInTheDocument();
+  });
+
+  it("mentions Sentry", () => {
+    renderWithProviders(<Cookies />);
+    const matches = screen.getAllByText(/sentry/i);
+    expect(matches.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("mentions Supabase", () => {
+    renderWithProviders(<Cookies />);
+    expect(screen.getByText(/supabase/i)).toBeInTheDocument();
+  });
+
+  it("links to AEPD", () => {
+    renderWithProviders(<Cookies />);
+    const links = screen.getAllByRole("link");
+    const aepdLink = links.find(l => l.getAttribute("href")?.includes("aepd.es"));
+    expect(aepdLink).toBeDefined();
+  });
+});


### PR DESCRIPTION
## What and why

Spain has specific requirements beyond GDPR that weren't covered. This adds everything needed for a Barcelona-based SaaS:

### New pages
- **`/aviso-legal`** — Mandatory under LSSI Article 10. Written in Spanish. Covers company ID, intellectual property, liability, data protection (LOPDGDD/AEPD), cookies, and Barcelona jurisdiction. Contains placeholders for company name, CIF, and registered address — Dora to fill in before go-live.
- **`/cookies`** — Required by AEPD. Lists every cookie by name, provider, purpose, category, and duration (Supabase auth, Sentry session, Google Maps in-app).

### Fixes
- **Cookie banner dark pattern** — AEPD fines for "Accept" being visually dominant over "Decline". Both buttons are now equal fill weight (`bg-muted` vs `bg-sage`).
- **Cookie banner link** — now links to Cookie Policy (not Privacy Policy).
- **Privacy Policy** — references LOPDGDD, names AEPD as supervisory authority, adds right to complain to AEPD, links to Cookie Policy and Aviso Legal.
- **Terms** — governing law changed from England & Wales → Spain / courts of Barcelona. Added IVA section (21% Spain, reverse charge EU B2B).
- **Footer** — adds Cookies and Aviso Legal links.

## What still needs Dora's input
The Aviso Legal has three `[PLACEHOLDER]` values at the top of `src/pages/AvisoLegal.tsx` — company legal name, CIF, and registered address. Once she provides those, I'll fill them in and redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)