### PR TITLE
feat: persistent PIN reveal for Owners (pin_vault)

### DIFF
--- a/src/hooks/useStaffProfiles.ts
+++ b/src/hooks/useStaffProfiles.ts
@@ -70,6 +70,9 @@ export function useSaveStaffProfile() {
         if (!updated || updated.length === 0) {
           throw new Error("Profile update failed — your session may have expired. Please refresh and try again.");
         }
+        if (sp.rawPin) {
+          await supabase.rpc("vault_staff_pin", { p_profile_id: sp.id, p_pin: sp.rawPin });
+        }
       } else {
         // ── Creating a new profile: explicit INSERT ─────────────────────────
         if (!sp.rawPin) {
@@ -85,8 +88,12 @@ export function useSaveStaffProfile() {
           email: sp.email?.trim() || null,
           pin: await hashPin(sp.rawPin),
         };
-        const { error } = await supabase.from("staff_profiles").insert(insertPayload);
+        const { data: inserted, error } = await supabase.from("staff_profiles").insert(insertPayload).select("id");
         if (error) throw error;
+        const newId = inserted?.[0]?.id as string | undefined;
+        if (newId) {
+          await supabase.rpc("vault_staff_pin", { p_profile_id: newId, p_pin: sp.rawPin });
+        }
       }
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ["staff_profiles"] }),

--- a/src/pages/admin/AccountTab.tsx
+++ b/src/pages/admin/AccountTab.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import {
-  MapPin, Plus, Pencil, Trash2, Check, X, ChevronDown, ChevronUp, MailCheck, Send,
+  MapPin, Plus, Pencil, Trash2, Check, X, ChevronDown, ChevronUp, MailCheck, Send, Eye, EyeOff,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { supabase } from "@/lib/supabase";
@@ -88,6 +88,9 @@ export function AccountTab({
   const [profileName, setProfileName] = useState(authUserName ?? currentAccount?.name ?? "");
   const [profileEmail, setProfileEmail] = useState(authUserEmail ?? currentAccount?.email ?? "");
   const [pin, setPin] = useState("");
+  const [showNewPin, setShowNewPin] = useState(false);
+  const [savedPin, setSavedPin] = useState<string | null>(null);
+  const [showSavedPin, setShowSavedPin] = useState(false);
 
   const [showAddDepartment, setShowAddDepartment] = useState(false);
   const [profileSaving, setProfileSaving] = useState(false);
@@ -162,8 +165,12 @@ export function AccountTab({
     if (!currentAccount || pin.length !== 4) return;
     setPinSaving(true);
     try {
-      await saveAdminPin.mutateAsync({ memberId: currentAccount.id, rawPin: pin });
+      const savedValue = pin;
+      await saveAdminPin.mutateAsync({ memberId: currentAccount.id, rawPin: savedValue });
       setPin("");
+      setShowNewPin(false);
+      setSavedPin(savedValue);
+      setShowSavedPin(false);
       toast.success("Admin PIN updated");
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Could not update admin PIN");
@@ -318,19 +325,56 @@ export function AccountTab({
                 Default PIN is <span className="font-semibold">{DEFAULT_ADMIN_PIN}</span>. Change it before using kiosk mode.
               </div>
             )}
+            {/* Current PIN (shown once after save) */}
+            {savedPin && (
+              <div className="space-y-1">
+                <span className="text-xs text-muted-foreground font-medium">Current PIN</span>
+                <div className="relative">
+                  <input
+                    readOnly
+                    type={showSavedPin ? "text" : "password"}
+                    value={savedPin}
+                    className="w-full border border-border rounded-xl px-3 py-2.5 pr-16 text-sm bg-muted/50 text-muted-foreground tracking-[0.3em] cursor-default select-none"
+                  />
+                  <div className="absolute right-2 top-1/2 -translate-y-1/2 flex items-center gap-1">
+                    <button
+                      type="button"
+                      onClick={() => setShowSavedPin(v => !v)}
+                      className="text-muted-foreground hover:text-foreground transition-colors p-0.5"
+                    >
+                      {showSavedPin ? <EyeOff size={14} /> : <Eye size={14} />}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => { setSavedPin(null); setShowSavedPin(false); }}
+                      className="text-muted-foreground hover:text-foreground transition-colors p-0.5"
+                    >
+                      <X size={14} />
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
             {/* PIN */}
             <div className="space-y-1">
               <span className="text-xs text-muted-foreground font-medium">New PIN</span>
               <div className="relative">
                 <input
-                  type="password"
+                  type={showNewPin ? "text" : "password"}
                   inputMode="numeric"
                   maxLength={4}
                   value={pin}
                   onChange={e => setPin(e.target.value.replace(/\D/g, "").slice(0, 4))}
                   placeholder="4 digits"
-                  className="w-full border border-border rounded-xl px-3 py-2.5 text-sm bg-muted focus:outline-none focus:ring-1 focus:ring-ring tracking-[0.3em]"
+                  className="w-full border border-border rounded-xl px-3 py-2.5 pr-9 text-sm bg-muted focus:outline-none focus:ring-1 focus:ring-ring tracking-[0.3em]"
                 />
+                <button
+                  type="button"
+                  onClick={() => setShowNewPin(v => !v)}
+                  className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  {showNewPin ? <EyeOff size={14} /> : <Eye size={14} />}
+                </button>
               </div>
             </div>
             <button

--- a/src/pages/admin/AccountTab.tsx
+++ b/src/pages/admin/AccountTab.tsx
@@ -91,6 +91,34 @@ export function AccountTab({
   const [showNewPin, setShowNewPin] = useState(false);
   const [savedPin, setSavedPin] = useState<string | null>(null);
   const [showSavedPin, setShowSavedPin] = useState(false);
+  // PIN vault reveal — keyed by "tm:{id}" or "sp:{id}"
+  const [revealedPins, setRevealedPins] = useState<Record<string, string>>({});
+  const [showingPins, setShowingPins] = useState<Record<string, boolean>>({});
+  const [loadingPinId, setLoadingPinId] = useState<string | null>(null);
+
+  const revealPin = async (memberType: "team_member" | "staff_profile", memberId: string) => {
+    const key = `${memberType}:${memberId}`;
+    if (revealedPins[key] !== undefined) {
+      setShowingPins(prev => ({ ...prev, [key]: !prev[key] }));
+      return;
+    }
+    setLoadingPinId(key);
+    try {
+      const { data, error } = await supabase.rpc("admin_reveal_pin", {
+        p_member_type: memberType,
+        p_member_id: memberId,
+      });
+      if (error) throw error;
+      setRevealedPins(prev => ({ ...prev, [key]: (data as string) ?? "" }));
+      setShowingPins(prev => ({ ...prev, [key]: true }));
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Could not reveal PIN");
+    } finally {
+      setLoadingPinId(null);
+    }
+  };
+
+  const isOwner = currentAccount?.role === "Owner";
 
   const [showAddDepartment, setShowAddDepartment] = useState(false);
   const [profileSaving, setProfileSaving] = useState(false);
@@ -606,6 +634,13 @@ export function AccountTab({
                         Last seen {new Date(member.last_seen_at).toLocaleDateString("en-GB", { day: "numeric", month: "short" })}
                       </p>
                     ) : null}
+                    {isOwner && revealedPins[`team_member:${member.id}`] !== undefined && (
+                      <p className="text-xs font-mono text-muted-foreground mt-0.5">
+                        PIN: {showingPins[`team_member:${member.id}`]
+                          ? revealedPins[`team_member:${member.id}`]
+                          : "••••"}
+                      </p>
+                    )}
                   </div>
                   <span className={cn(
                     "text-xs px-2 py-0.5 rounded-full font-medium",
@@ -627,6 +662,19 @@ export function AccountTab({
                       className="p-1.5 rounded-lg hover:bg-muted transition-colors"
                     >
                       <Send size={14} className="text-status-warn" />
+                    </button>
+                  )}
+                  {isOwner && (
+                    <button
+                      onClick={() => revealPin("team_member", member.id)}
+                      disabled={loadingPinId === `team_member:${member.id}`}
+                      aria-label={`Reveal PIN for ${member.name}`}
+                      title="Reveal PIN"
+                      className="p-1.5 rounded-lg hover:bg-muted transition-colors"
+                    >
+                      {showingPins[`team_member:${member.id}`]
+                        ? <EyeOff size={14} className="text-muted-foreground" />
+                        : <Eye size={14} className="text-muted-foreground" />}
                     </button>
                   )}
                   <button
@@ -694,9 +742,32 @@ export function AccountTab({
               <div className="w-9 h-9 rounded-full bg-muted flex items-center justify-center text-xs font-semibold text-muted-foreground shrink-0">
                 {(sp.first_name[0] ?? "") + (sp.last_name[0] ?? "")}
               </div>
-              <p className="flex-1 min-w-0 text-sm font-medium text-foreground truncate">{sp.first_name} {sp.last_name}</p>
-              <span className="w-20 text-xs text-muted-foreground truncate">{sp.role}</span>
-              <div className="w-20 shrink-0" />
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-foreground truncate">{sp.first_name} {sp.last_name}</p>
+                {isOwner && revealedPins[`staff_profile:${sp.id}`] !== undefined && (
+                  <p className="text-xs font-mono text-muted-foreground mt-0.5">
+                    PIN: {showingPins[`staff_profile:${sp.id}`]
+                      ? revealedPins[`staff_profile:${sp.id}`]
+                      : "••••"}
+                  </p>
+                )}
+              </div>
+              <span className="text-xs text-muted-foreground truncate">{sp.role}</span>
+              {isOwner ? (
+                <button
+                  onClick={() => revealPin("staff_profile", sp.id)}
+                  disabled={loadingPinId === `staff_profile:${sp.id}`}
+                  aria-label={`Reveal PIN for ${sp.first_name}`}
+                  title="Reveal PIN"
+                  className="p-1.5 rounded-lg hover:bg-muted transition-colors shrink-0"
+                >
+                  {showingPins[`staff_profile:${sp.id}`]
+                    ? <EyeOff size={14} className="text-muted-foreground" />
+                    : <Eye size={14} className="text-muted-foreground" />}
+                </button>
+              ) : (
+                <div className="w-8 shrink-0" />
+              )}
             </div>
           ))}
           <div className="flex justify-end px-4 py-3 border-t border-border">

--- a/src/test/hooks/useStaffProfiles.test.tsx
+++ b/src/test/hooks/useStaffProfiles.test.tsx
@@ -20,6 +20,7 @@ vi.mock("@/lib/supabase", () => ({
       }),
     },
     from: (...args: any[]) => mockFrom(...args),
+    rpc: vi.fn().mockResolvedValue({ data: null, error: null }),
   },
 }));
 
@@ -122,7 +123,8 @@ describe("useStaffProfiles", () => {
 
 describe("useSaveStaffProfile — INSERT (new profile)", () => {
   it("inserts a new profile and hashes the raw PIN before storage", async () => {
-    const insertFn = vi.fn().mockResolvedValue({ error: null });
+    const selectAfterInsertFn = vi.fn().mockResolvedValue({ data: [{ id: "sp-new" }], error: null });
+    const insertFn = vi.fn().mockReturnValue({ select: selectAfterInsertFn });
     mockFrom.mockReturnValue({
       select: vi.fn().mockReturnThis(),
       order: vi.fn().mockResolvedValue({ data: [], error: null }),

--- a/supabase/migrations/20260724000001_pin_vault.sql
+++ b/supabase/migrations/20260724000001_pin_vault.sql
@@ -1,0 +1,156 @@
+-- ================================================================
+-- Pin Vault: persistent, owner-only PIN retrieval.
+--
+-- Owners can look up any member's PIN at any time (e.g. a staff
+-- member returns from holiday and forgets their kiosk PIN).
+--
+-- Security model:
+--   - pin_vault stores plaintext PINs, but RLS has NO SELECT/INSERT/
+--     UPDATE/DELETE policies, so no client can read or write it directly.
+--   - hash_team_member_pin trigger (SECURITY DEFINER) writes to
+--     pin_vault before bcrypt-hashing, so team-member PINs are
+--     captured automatically on every INSERT or UPDATE OF pin.
+--   - vault_staff_pin RPC (SECURITY DEFINER) is called by the client
+--     to capture raw staff-profile PINs (which are SHA-256-hashed
+--     client-side, so the trigger cannot intercept them).
+--   - admin_reveal_pin RPC (SECURITY DEFINER) checks the caller is
+--     an Owner in the same org before returning any PIN.
+-- ================================================================
+
+-- ── 1. Create pin_vault ───────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.pin_vault (
+  member_type  text    NOT NULL CHECK (member_type IN ('team_member', 'staff_profile')),
+  member_id    uuid    NOT NULL,
+  org_id       uuid    NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  pin          text    NOT NULL,
+  updated_at   timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (member_type, member_id)
+);
+
+ALTER TABLE public.pin_vault ENABLE ROW LEVEL SECURITY;
+-- No policies → authenticated/anon roles cannot touch this table directly.
+
+-- ── 2. Modify hash_team_member_pin to also write to pin_vault ─────
+CREATE OR REPLACE FUNCTION public.hash_team_member_pin()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+BEGIN
+  IF NEW.pin IS NOT NULL AND (
+    NEW.pin NOT LIKE '$2a$%' AND
+    NEW.pin NOT LIKE '$2b$%' AND
+    NEW.pin NOT LIKE '$2x$%' AND
+    NEW.pin NOT LIKE '$2y$%'
+  ) THEN
+    -- Persist raw PIN to vault before hashing.
+    INSERT INTO public.pin_vault (member_type, member_id, org_id, pin, updated_at)
+    VALUES ('team_member', NEW.id, NEW.organization_id, NEW.pin, now())
+    ON CONFLICT (member_type, member_id)
+    DO UPDATE SET pin = EXCLUDED.pin, updated_at = now();
+
+    NEW.pin_uniqueness_hash := encode(
+      digest(NEW.organization_id::text || NEW.pin, 'sha256'),
+      'hex'
+    );
+    NEW.pin := crypt(NEW.pin, gen_salt('bf', 12));
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+-- ── 3. vault_staff_pin — store raw staff-profile PIN ─────────────
+-- Called from the client right after the SHA-256 hashed pin is saved.
+-- Verifies the profile belongs to the caller's org before writing.
+CREATE OR REPLACE FUNCTION public.vault_staff_pin(
+  p_profile_id uuid,
+  p_pin        text
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_org_id      uuid;
+  v_caller_org  uuid;
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  SELECT organization_id INTO v_org_id
+  FROM public.staff_profiles
+  WHERE id = p_profile_id;
+
+  IF v_org_id IS NULL THEN
+    RAISE EXCEPTION 'Staff profile not found';
+  END IF;
+
+  SELECT organization_id INTO v_caller_org
+  FROM public.team_members
+  WHERE id = auth.uid();
+
+  IF v_org_id <> v_caller_org THEN
+    RAISE EXCEPTION 'Unauthorized';
+  END IF;
+
+  INSERT INTO public.pin_vault (member_type, member_id, org_id, pin, updated_at)
+  VALUES ('staff_profile', p_profile_id, v_org_id, p_pin, now())
+  ON CONFLICT (member_type, member_id)
+  DO UPDATE SET pin = EXCLUDED.pin, updated_at = now();
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.vault_staff_pin(uuid, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.vault_staff_pin(uuid, text) TO authenticated;
+
+-- ── 4. admin_reveal_pin — Owner-only PIN lookup ───────────────────
+CREATE OR REPLACE FUNCTION public.admin_reveal_pin(
+  p_member_type text,
+  p_member_id   uuid
+)
+RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_caller_org  uuid;
+  v_caller_role text;
+  v_vault_org   uuid;
+  v_pin         text;
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  SELECT organization_id, role
+  INTO v_caller_org, v_caller_role
+  FROM public.team_members
+  WHERE id = auth.uid();
+
+  IF v_caller_role <> 'Owner' THEN
+    RAISE EXCEPTION 'Only Owners can reveal PINs';
+  END IF;
+
+  SELECT org_id, pin
+  INTO v_vault_org, v_pin
+  FROM public.pin_vault
+  WHERE member_type = p_member_type AND member_id = p_member_id;
+
+  IF v_vault_org IS NULL THEN
+    RAISE EXCEPTION 'PIN not found — it may have been set before this feature was enabled';
+  END IF;
+
+  IF v_vault_org <> v_caller_org THEN
+    RAISE EXCEPTION 'Unauthorized';
+  END IF;
+
+  RETURN v_pin;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.admin_reveal_pin(text, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.admin_reveal_pin(text, uuid) TO authenticated;


### PR DESCRIPTION
## Summary

Owners can now see any team member's or staff profile's PIN at any time — not just immediately after saving. Classic use-case: a staff member returns from holiday and has forgotten their kiosk PIN.

### Why the original feature was removed

The old `pin_plaintext` column sat on `team_members` inside an RLS policy that let every org member read all rows — so every PIN was visible to everyone. It was removed in #407.

### How this is different

No plaintext column on any user-readable table. Instead:

- **`pin_vault` table** — RLS enabled, **zero policies** → PostgREST blocks all direct client access
- **`hash_team_member_pin` trigger** (already SECURITY DEFINER) extended to `INSERT … ON CONFLICT DO UPDATE` into `pin_vault` before bcrypt-hashing, capturing every team-member PIN automatically
- **`vault_staff_pin` RPC** (SECURITY DEFINER) called by the client after SHA-256-hashing staff profile PINs; verifies org membership before writing
- **`admin_reveal_pin` RPC** (SECURITY DEFINER) checks `role = 'Owner'` in the same org before returning a PIN

### UI

- Eye icon on every team member row in the "Team members" section — Owner-only
- Eye icon on every active staff profile row — Owner-only
- First click fetches via RPC; subsequent clicks toggle `••••` / digits without re-fetching
- Also kept the show-once banner in the Security section (from first commit) as a convenience right after the Owner updates their own PIN

## Test plan

- [ ] As Owner: open Admin → Account → Team members section → click Eye on any member → digits appear below the name
- [ ] Click Eye again → masked to `••••`
- [ ] Click Eye on a staff profile row → PIN appears
- [ ] Log in as Manager → Eye icons not visible
- [ ] Create a new staff profile → their PIN appears when Owner clicks Eye
- [ ] Edit a staff profile with a new PIN → Eye reflects the updated PIN
- [ ] Apply the migration to Supabase: `supabase db push`
- [ ] All 1281 unit tests pass (`bun run test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)