### PR TITLE
feat: move PIN reveal into edit modals

### DIFF
--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -566,6 +566,7 @@ export default function Admin() {
           departments={departments}
           onClose={() => setStaffModal(null)}
           onSave={sp => { saveStaff(sp); setStaffModal(null); }}
+          isOwner={isOwner}
         />
       )}
 
@@ -575,6 +576,7 @@ export default function Admin() {
           locations={locations}
           onClose={() => setMemberModal(null)}
           onSave={m => { saveMember(m); setMemberModal(null); }}
+          isOwner={isOwner}
         />
       )}
 

--- a/src/pages/admin/AccountTab.tsx
+++ b/src/pages/admin/AccountTab.tsx
@@ -91,34 +91,6 @@ export function AccountTab({
   const [showNewPin, setShowNewPin] = useState(false);
   const [savedPin, setSavedPin] = useState<string | null>(null);
   const [showSavedPin, setShowSavedPin] = useState(false);
-  // PIN vault reveal — keyed by "tm:{id}" or "sp:{id}"
-  const [revealedPins, setRevealedPins] = useState<Record<string, string>>({});
-  const [showingPins, setShowingPins] = useState<Record<string, boolean>>({});
-  const [loadingPinId, setLoadingPinId] = useState<string | null>(null);
-
-  const revealPin = async (memberType: "team_member" | "staff_profile", memberId: string) => {
-    const key = `${memberType}:${memberId}`;
-    if (revealedPins[key] !== undefined) {
-      setShowingPins(prev => ({ ...prev, [key]: !prev[key] }));
-      return;
-    }
-    setLoadingPinId(key);
-    try {
-      const { data, error } = await supabase.rpc("admin_reveal_pin", {
-        p_member_type: memberType,
-        p_member_id: memberId,
-      });
-      if (error) throw error;
-      setRevealedPins(prev => ({ ...prev, [key]: (data as string) ?? "" }));
-      setShowingPins(prev => ({ ...prev, [key]: true }));
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Could not reveal PIN");
-    } finally {
-      setLoadingPinId(null);
-    }
-  };
-
-  const isOwner = currentAccount?.role === "Owner";
 
   const [showAddDepartment, setShowAddDepartment] = useState(false);
   const [profileSaving, setProfileSaving] = useState(false);
@@ -634,13 +606,6 @@ export function AccountTab({
                         Last seen {new Date(member.last_seen_at).toLocaleDateString("en-GB", { day: "numeric", month: "short" })}
                       </p>
                     ) : null}
-                    {isOwner && revealedPins[`team_member:${member.id}`] !== undefined && (
-                      <p className="text-xs font-mono text-muted-foreground mt-0.5">
-                        PIN: {showingPins[`team_member:${member.id}`]
-                          ? revealedPins[`team_member:${member.id}`]
-                          : "••••"}
-                      </p>
-                    )}
                   </div>
                   <span className={cn(
                     "text-xs px-2 py-0.5 rounded-full font-medium",
@@ -662,19 +627,6 @@ export function AccountTab({
                       className="p-1.5 rounded-lg hover:bg-muted transition-colors"
                     >
                       <Send size={14} className="text-status-warn" />
-                    </button>
-                  )}
-                  {isOwner && (
-                    <button
-                      onClick={() => revealPin("team_member", member.id)}
-                      disabled={loadingPinId === `team_member:${member.id}`}
-                      aria-label={`Reveal PIN for ${member.name}`}
-                      title="Reveal PIN"
-                      className="p-1.5 rounded-lg hover:bg-muted transition-colors"
-                    >
-                      {showingPins[`team_member:${member.id}`]
-                        ? <EyeOff size={14} className="text-muted-foreground" />
-                        : <Eye size={14} className="text-muted-foreground" />}
                     </button>
                   )}
                   <button
@@ -742,32 +694,9 @@ export function AccountTab({
               <div className="w-9 h-9 rounded-full bg-muted flex items-center justify-center text-xs font-semibold text-muted-foreground shrink-0">
                 {(sp.first_name[0] ?? "") + (sp.last_name[0] ?? "")}
               </div>
-              <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium text-foreground truncate">{sp.first_name} {sp.last_name}</p>
-                {isOwner && revealedPins[`staff_profile:${sp.id}`] !== undefined && (
-                  <p className="text-xs font-mono text-muted-foreground mt-0.5">
-                    PIN: {showingPins[`staff_profile:${sp.id}`]
-                      ? revealedPins[`staff_profile:${sp.id}`]
-                      : "••••"}
-                  </p>
-                )}
-              </div>
-              <span className="text-xs text-muted-foreground truncate">{sp.role}</span>
-              {isOwner ? (
-                <button
-                  onClick={() => revealPin("staff_profile", sp.id)}
-                  disabled={loadingPinId === `staff_profile:${sp.id}`}
-                  aria-label={`Reveal PIN for ${sp.first_name}`}
-                  title="Reveal PIN"
-                  className="p-1.5 rounded-lg hover:bg-muted transition-colors shrink-0"
-                >
-                  {showingPins[`staff_profile:${sp.id}`]
-                    ? <EyeOff size={14} className="text-muted-foreground" />
-                    : <Eye size={14} className="text-muted-foreground" />}
-                </button>
-              ) : (
-                <div className="w-8 shrink-0" />
-              )}
+              <p className="flex-1 min-w-0 text-sm font-medium text-foreground truncate">{sp.first_name} {sp.last_name}</p>
+              <span className="w-20 text-xs text-muted-foreground truncate">{sp.role}</span>
+              <div className="w-20 shrink-0" />
             </div>
           ))}
           <div className="flex justify-end px-4 py-3 border-t border-border">

--- a/src/pages/admin/SharedUI.tsx
+++ b/src/pages/admin/SharedUI.tsx
@@ -6,9 +6,11 @@ import { useState, useEffect } from "react";
 import { createPortal } from "react-dom";
 import {
   MapPin, Plus, Pencil, X,
-  ChevronDown,
+  ChevronDown, Eye, EyeOff,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { supabase } from "@/lib/supabase";
+import { toast } from "@/components/ui/sonner";
 import { Switch } from "@/components/ui/switch";
 import {
   PlacesAutocompleteInput, StaticMapPreview, type PlaceResult,
@@ -155,10 +157,11 @@ export function ConfirmModal({
 // ─── StaffProfileModal ────────────────────────────────────────────────────────
 
 export function StaffProfileModal({
-  profile, locations, departments, onClose, onSave,
+  profile, locations, departments, onClose, onSave, isOwner,
 }: {
   profile: StaffProfile | null; locations: Location[]; departments: StaffDepartment[];
   onClose: () => void; onSave: (p: StaffProfile & { rawPin?: string }) => void;
+  isOwner?: boolean;
 }) {
   const isEdit = !!profile;
   const [firstName, setFirstName] = useState(profile?.first_name ?? "");
@@ -168,6 +171,28 @@ export function StaffProfileModal({
   const [email, setEmail] = useState(profile?.email ?? "");
   // New staff: generate a PIN upfront; editing: leave empty (only set if manager enters a new one)
   const [pin, setPin] = useState(() => isEdit ? "" : generatePin());
+  const [revealedPin, setRevealedPin] = useState<string | null>(null);
+  const [showRevealedPin, setShowRevealedPin] = useState(false);
+  const [revealLoading, setRevealLoading] = useState(false);
+
+  const handleRevealPin = async () => {
+    if (!profile?.id) return;
+    setRevealLoading(true);
+    try {
+      const { data, error } = await supabase.rpc("admin_reveal_pin", {
+        p_member_type: "staff_profile",
+        p_member_id: profile.id,
+      });
+      if (error) throw error;
+      setRevealedPin((data as string) ?? "");
+      setShowRevealedPin(true);
+    } catch (err) {
+      const msg = (err as any)?.message ?? "Could not reveal PIN";
+      toast.error(msg);
+    } finally {
+      setRevealLoading(false);
+    }
+  };
 
   const handleSave = (e: React.FormEvent) => {
     e.preventDefault();
@@ -263,6 +288,36 @@ export function StaffProfileModal({
               Generate
             </button>
           </div>
+          {isEdit && isOwner && (
+            <div className="flex items-center gap-2 mt-1.5">
+              {revealedPin !== null ? (
+                <>
+                  <span className="text-xs text-muted-foreground">
+                    Current PIN:&nbsp;
+                    <span className="font-mono font-medium">
+                      {showRevealedPin ? revealedPin : "••••"}
+                    </span>
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => setShowRevealedPin(v => !v)}
+                    className="text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    {showRevealedPin ? <EyeOff size={13} /> : <Eye size={13} />}
+                  </button>
+                </>
+              ) : (
+                <button
+                  type="button"
+                  onClick={handleRevealPin}
+                  disabled={revealLoading}
+                  className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground transition-colors disabled:opacity-50"
+                >
+                  {revealLoading ? "Loading…" : "View current PIN"}
+                </button>
+              )}
+            </div>
+          )}
         </FormField>
         <SaveButton disabled={!firstName.trim() || !locationId || (!isEdit && !pin)} label={isEdit ? "Save changes" : "Add profile"} />
       </form>
@@ -273,10 +328,11 @@ export function StaffProfileModal({
 // ─── TeamMemberModal ──────────────────────────────────────────────────────────
 
 export function TeamMemberModal({
-  member, locations, onClose, onSave,
+  member, locations, onClose, onSave, isOwner,
 }: {
   member: TeamMember | null; locations: Location[];
   onClose: () => void; onSave: (m: TeamMember & { rawPin?: string }) => void;
+  isOwner?: boolean;
 }) {
   const [name, setName] = useState(member?.name ?? "");
   const [email, setEmail] = useState(member?.email ?? "");
@@ -284,6 +340,28 @@ export function TeamMemberModal({
   const [locationIds, setLocationIds] = useState<string[]>(member?.location_ids ?? []);
   const [perms, setPerms] = useState<ManagerPermissions>(member?.permissions ?? { ...DEFAULT_PERMISSIONS });
   const [pin, setPin] = useState(() => member?.id ? "" : generatePin());
+  const [revealedPin, setRevealedPin] = useState<string | null>(null);
+  const [showRevealedPin, setShowRevealedPin] = useState(false);
+  const [revealLoading, setRevealLoading] = useState(false);
+
+  const handleRevealPin = async () => {
+    if (!member?.id) return;
+    setRevealLoading(true);
+    try {
+      const { data, error } = await supabase.rpc("admin_reveal_pin", {
+        p_member_type: "team_member",
+        p_member_id: member.id,
+      });
+      if (error) throw error;
+      setRevealedPin((data as string) ?? "");
+      setShowRevealedPin(true);
+    } catch (err) {
+      const msg = (err as any)?.message ?? "Could not reveal PIN";
+      toast.error(msg);
+    } finally {
+      setRevealLoading(false);
+    }
+  };
 
   useEffect(() => {
     if (member?.id) return;
@@ -377,6 +455,36 @@ export function TeamMemberModal({
               Generate
             </button>
           </div>
+          {member?.id && isOwner && (
+            <div className="flex items-center gap-2 mt-1.5">
+              {revealedPin !== null ? (
+                <>
+                  <span className="text-xs text-muted-foreground">
+                    Current PIN:&nbsp;
+                    <span className="font-mono font-medium">
+                      {showRevealedPin ? revealedPin : "••••"}
+                    </span>
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => setShowRevealedPin(v => !v)}
+                    className="text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    {showRevealedPin ? <EyeOff size={13} /> : <Eye size={13} />}
+                  </button>
+                </>
+              ) : (
+                <button
+                  type="button"
+                  onClick={handleRevealPin}
+                  disabled={revealLoading}
+                  className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground transition-colors disabled:opacity-50"
+                >
+                  {revealLoading ? "Loading…" : "View current PIN"}
+                </button>
+              )}
+            </div>
+          )}
         </FormField>
         <FormField label="Location(s)">
           <div className="flex gap-2 flex-wrap">

--- a/src/test/pages/Admin.helpers.test.tsx
+++ b/src/test/pages/Admin.helpers.test.tsx
@@ -38,6 +38,7 @@ vi.mock("@/lib/supabase", () => ({
       onAuthStateChange: vi.fn().mockReturnValue({ data: { subscription: { unsubscribe: vi.fn() } } }),
       updateUser: vi.fn().mockResolvedValue({ data: { user: { id: "u1" } }, error: null }),
     },
+    rpc: vi.fn().mockResolvedValue({ data: null, error: null }),
     from: vi.fn().mockReturnValue({
       select: vi.fn().mockReturnThis(),
       order: vi.fn().mockReturnThis(),


### PR DESCRIPTION
## Summary

- Removes the Eye icon from the team member list rows (it errored for members whose PINs pre-date the vault, and it cluttered the row)
- Adds a **"View current PIN"** link inside the Edit team member and Edit staff profile bottom sheets, just below the Generate button
- Only visible to Owners; only when editing (not creating)
- Clicking calls `admin_reveal_pin` and shows the PIN inline with an Eye/EyeOff toggle

## Test plan

- [ ] Open Admin → edit a team member as Owner → see "View current PIN" under Generate
- [ ] Click it → current PIN appears masked; Eye reveals digits
- [ ] Open Admin → edit a staff profile as Owner → same behaviour
- [ ] Log in as Manager → "View current PIN" link not shown
- [ ] All 1281 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)