### PR TITLE
fix: register /admin/notifications route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,6 +78,7 @@ const router = createBrowserRouter(
         { path: "/admin/location", element: <ProtectedRoute><Admin /></ProtectedRoute> },
         { path: "/admin/users", element: <ProtectedRoute><Admin /></ProtectedRoute> },
         { path: "/admin/account", element: <ProtectedRoute><Admin /></ProtectedRoute> },
+        { path: "/admin/notifications", element: <ProtectedRoute><Admin /></ProtectedRoute> },
         { path: "/admin/billing", element: <ProtectedRoute><Admin /></ProtectedRoute> },
         { path: "/billing", element: <ProtectedRoute><Billing /></ProtectedRoute> },
         { path: "*", element: <NotFound /> },


### PR DESCRIPTION
## Summary

`/admin/notifications` was not registered in `App.tsx` so clicking the Notifications tab navigated to an unmatched route and hit the `*` → `<NotFound />` handler.

One line fix: added the route alongside the other admin sub-routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)