### PR TITLE
fix: replace Google Static Maps with Embed API iframe

### DIFF
--- a/src/components/PlacesAutocompleteInput.tsx
+++ b/src/components/PlacesAutocompleteInput.tsx
@@ -254,20 +254,19 @@ interface StaticMapPreviewProps {
 export function StaticMapPreview({ lat, lng, className }: StaticMapPreviewProps) {
   if (!API_KEY) return null;
 
-  // Midnight Blue marker (#1A2A47) encoded as 0x1A2A47
-  const src =
-    `https://maps.googleapis.com/maps/api/staticmap` +
-    `?center=${lat},${lng}&zoom=15&size=600x200&scale=2` +
-    `&markers=color:0x1A2A47%7C${lat},${lng}` +
-    `&key=${API_KEY}`;
-
   return (
-    <div className={cn("rounded-xl overflow-hidden border border-border", className)}>
-      <img
-        src={src}
-        alt="Location map preview"
-        className="w-full h-auto block"
+    <div className={cn("rounded-xl overflow-hidden border border-border", className)} style={{ height: 160 }}>
+      <iframe
+        title="Location map preview"
+        src={
+          `https://www.google.com/maps/embed/v1/view` +
+          `?key=${API_KEY}` +
+          `&center=${lat},${lng}` +
+          `&zoom=15&maptype=roadmap`
+        }
+        className="w-full h-full border-0"
         loading="lazy"
+        referrerPolicy="no-referrer-when-downgrade"
       />
     </div>
   );

--- a/src/pages/admin/MyLocationTab.tsx
+++ b/src/pages/admin/MyLocationTab.tsx
@@ -1,6 +1,6 @@
 // ─── MyLocationTab ────────────────────────────────────────────────────────────
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import {
   MapPin, Mail, Phone, Plus, Pencil, Trash2, Archive, RotateCcw,
   ChevronDown, Search, Tablet,
@@ -52,10 +52,6 @@ export function MyLocationTab({
   const [thresholdDraft, setThresholdDraft] = useState<string | null>(null);
 
   const currentLocation = locations.find(l => l.id === currentLocationId) ?? locations[0];
-  const [mapError, setMapError] = useState(false);
-
-  // Reset map error when switching locations so the new map gets a fresh attempt
-  useEffect(() => { setMapError(false); }, [currentLocationId]);
 
   const canEditLocation = !permissions || permissions.edit_location_details;
   const canEditThreshold = !permissions || permissions.override_inactivity_threshold;
@@ -167,41 +163,43 @@ export function MyLocationTab({
 
         {/* Right — map thumbnail + kiosk CTA */}
         <div className="flex flex-col justify-between w-[35%] shrink-0 gap-2 h-full">
-          {currentLocation.lat != null && currentLocation.lng != null && MAPS_API_KEY && !mapError ? (
-            <a
-              href={`https://www.google.com/maps/search/?api=1&query=${currentLocation.lat},${currentLocation.lng}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="rounded-2xl overflow-hidden border border-border shadow-sm hover:opacity-80 transition-opacity block"
+          {currentLocation.lat != null && currentLocation.lng != null ? (
+            <div
+              className="rounded-2xl overflow-hidden border border-border shadow-sm"
               style={{ height: 120 }}
-              title="Open in Google Maps"
             >
-              <img
-                src={
-                  `https://maps.googleapis.com/maps/api/staticmap` +
-                  `?center=${currentLocation.lat},${currentLocation.lng}&zoom=15&size=300x300&scale=2` +
-                  `&markers=color:0x1A2A47%7C${currentLocation.lat},${currentLocation.lng}` +
-                  `&key=${MAPS_API_KEY}`
-                }
-                alt="Open in Google Maps"
-                className="w-full h-full object-cover block"
-                loading="lazy"
-                onError={() => setMapError(true)}
-              />
-            </a>
+              {MAPS_API_KEY ? (
+                <iframe
+                  title="Location map"
+                  src={
+                    `https://www.google.com/maps/embed/v1/view` +
+                    `?key=${MAPS_API_KEY}` +
+                    `&center=${currentLocation.lat},${currentLocation.lng}` +
+                    `&zoom=15&maptype=roadmap`
+                  }
+                  className="w-full h-full border-0"
+                  loading="lazy"
+                  referrerPolicy="no-referrer-when-downgrade"
+                />
+              ) : (
+                <a
+                  href={`https://www.google.com/maps/search/?api=1&query=${currentLocation.lat},${currentLocation.lng}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="w-full h-full flex items-center justify-center bg-muted hover:opacity-80 transition-opacity"
+                  title="Open in Google Maps"
+                >
+                  <MapPin size={18} className="text-muted-foreground" />
+                </a>
+              )}
+            </div>
           ) : (
-            <a
-              href={currentLocation.lat != null && currentLocation.lng != null
-                ? `https://www.google.com/maps/search/?api=1&query=${currentLocation.lat},${currentLocation.lng}`
-                : "#"}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="rounded-2xl border border-border bg-muted flex items-center justify-center hover:opacity-80 transition-opacity"
+            <div
+              className="rounded-2xl border border-border bg-muted flex items-center justify-center"
               style={{ height: 120 }}
-              title="Open in Google Maps"
             >
               <MapPin size={18} className="text-muted-foreground" />
-            </a>
+            </div>
           )}
           <button
             onClick={onLaunchKiosk}

--- a/src/test/components/PlacesAutocompleteInput.test.tsx
+++ b/src/test/components/PlacesAutocompleteInput.test.tsx
@@ -145,10 +145,10 @@ describe("PlacesAutocompleteInput", () => {
 });
 
 describe("StaticMapPreview", () => {
-  it("renders a map preview image for the selected coordinates", () => {
+  it("renders a map preview iframe for the selected coordinates", () => {
     render(<StaticMapPreview lat={45.7608} lng={4.8597} />);
 
-    const preview = screen.getByAltText("Location map preview");
+    const preview = screen.getByTitle("Location map preview");
     expect(preview).toBeInTheDocument();
     expect(preview).toHaveAttribute("src", expect.stringContaining("center=45.7608,4.8597"));
   });

--- a/src/test/pages/Admin.test.tsx
+++ b/src/test/pages/Admin.test.tsx
@@ -502,7 +502,7 @@ describe("Admin page", () => {
     fireEvent.click(editButtons[0] as HTMLElement);
 
     await waitFor(() => {
-      expect(screen.getByAltText("Location map preview")).toBeInTheDocument();
+      expect(screen.getByTitle("Location map preview")).toBeInTheDocument();
       expect(screen.getByText("Official place selected from maps")).toBeInTheDocument();
     });
   });


### PR DESCRIPTION
## Root cause

The Static Maps API (`maps.googleapis.com/maps/api/staticmap`) is a separate API from Maps JavaScript API. It needs to be **explicitly enabled** in GCP Console → APIs & Services → Enabled APIs. It was almost certainly never enabled — only Maps JavaScript API and Places API were enabled when the key was set up.

Additionally, GCP recommends adding HTTP referrer restrictions. If the key was restricted to `oliahq.com` but the static map request arrived with the wrong referrer, it would also fail.

## Fix

Replaced both static map `<img>` usages with **Maps Embed API `<iframe>`** (`maps/embed/v1/view`):
- Different API endpoint — much more likely to already be enabled
- Added `referrerPolicy="no-referrer-when-downgrade"` so domain-restricted keys work correctly
- Falls back to the MapPin placeholder when there's no API key or no coordinates
- Cleaned up the now-unnecessary `mapError` state and `useEffect` from MyLocationTab

## If the embed iframe also fails

That would mean the Maps Embed API is also not enabled. In that case, enable it in GCP Console:
1. Go to [APIs & Services → Library](https://console.cloud.google.com/apis/library)
2. Search "Maps Embed API" → Enable
3. While there, also enable "Maps Static API" (for future use)

🤖 Generated with [Claude Code](https://claude.com/claude-code)