### PR TITLE
fix: checklist validation error persists after answering required questions

### DIFF
--- a/src/pages/kiosk/ChecklistRunner.tsx
+++ b/src/pages/kiosk/ChecklistRunner.tsx
@@ -115,6 +115,12 @@ export function ChecklistRunner({
   }, [answers, currentQuestionId, questions, persistDraft]);
 
   useEffect(() => {
+    if (!completionError) return;
+    const missing = questions.filter(q => q.required && q.type !== "instruction" && isBlankAnswer(answers[q.id]));
+    if (missing.length === 0) setCompletionError(null);
+  }, [answers, questions, completionError]);
+
+  useEffect(() => {
     if (!lightboxImage) return;
     const handler = (e: KeyboardEvent) => { if (e.key === "Escape") setLightboxImage(null); };
     window.addEventListener("keydown", handler);


### PR DESCRIPTION
## Summary
- The \"N required questions still need an answer\" error appeared correctly when clicking Complete Checklist with unanswered required questions
- But the error never cleared even after the user answered all required questions
- Added a `useEffect` in `ChecklistRunner` that watches `answers` and clears `completionError` as soon as no required questions remain blank

## Root cause
`completionError` was set once on button click and had no mechanism to re-evaluate when answers changed.

## Test plan
- [ ] Go through a checklist, skip required questions, click Complete — error appears
- [ ] Answer the previously skipped required questions — error disappears automatically
- [ ] Click Complete again with all answered — checklist completes successfully
- [ ] Verify the error still appears correctly if you skip required questions and click Complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)