### PR TITLE
fix: square folder grid, unified PIN shell, single back nav

### DIFF
--- a/src/pages/kiosk/KioskLibrary.tsx
+++ b/src/pages/kiosk/KioskLibrary.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { BookOpen, ChevronLeft, FileText, Folder } from "lucide-react";
+import { BookOpen, FileText, Folder } from "lucide-react";
 import { supabase } from "@/lib/supabase";
 import { ensureKioskToken } from "./PinEntryModal";
 import { useInactivityTimer } from "./hooks";
@@ -120,17 +120,15 @@ export function KioskLibrary({
   return (
     <div className="min-h-screen bg-background flex flex-col w-full min-[900px]:max-w-none mx-auto">
       {/* Header */}
-      <div className="px-5 pt-6 pb-4 border-b border-border flex items-center gap-3">
-        <button
-          data-testid="library-back-btn"
-          onClick={handleBack}
-          className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-muted transition-colors shrink-0"
-          aria-label="Back"
-        >
-          <ChevronLeft size={20} className="text-muted-foreground" />
-        </button>
+      <div className="px-5 pt-6 pb-4 border-b border-border flex items-center justify-between">
         <div className="flex-1 min-w-0">
-          <p className="text-xs text-muted-foreground uppercase tracking-widest">← {backLabel}</p>
+          <button
+            data-testid="library-back-btn"
+            onClick={handleBack}
+            className="text-xs text-muted-foreground uppercase tracking-widest hover:text-foreground transition-colors"
+          >
+            ← {backLabel}
+          </button>
           <h1 className="font-display text-xl italic text-foreground leading-tight truncate">
             {selectedDoc
               ? selectedDoc.title
@@ -139,7 +137,7 @@ export function KioskLibrary({
                 : "Staff Library"}
           </h1>
         </div>
-        <p className="text-xs text-muted-foreground shrink-0">{memberName}</p>
+        <p className="text-xs text-muted-foreground shrink-0 pl-3">{memberName}</p>
       </div>
 
       {/* Content */}
@@ -192,7 +190,7 @@ function RootFolders({
     );
   }
   return (
-    <>
+    <div className="grid grid-cols-2 gap-3">
       {folders.map(folder => {
         const count = docsInFolder(folder.id).length;
         return (
@@ -200,21 +198,21 @@ function RootFolders({
             key={folder.id}
             data-testid={`library-folder-${folder.id}`}
             onClick={() => onFolderSelect(folder.id)}
-            className="w-full text-left card-surface p-4 flex items-center gap-3 hover:border-sage/30 transition-colors active:scale-[0.99]"
+            className="card-surface aspect-square flex flex-col items-center justify-center gap-2 p-4 text-center hover:border-sage/30 transition-colors active:scale-[0.99]"
           >
-            <div className="w-10 h-10 rounded-xl bg-sage-light flex items-center justify-center shrink-0">
-              <Folder size={18} className="text-sage-deep" />
+            <div className="w-12 h-12 rounded-xl bg-sage-light flex items-center justify-center shrink-0">
+              <Folder size={20} className="text-sage-deep" />
             </div>
-            <div className="flex-1 min-w-0">
-              <p className="text-sm font-medium text-foreground">{folder.name}</p>
-              <p className="text-xs text-muted-foreground">
+            <div className="w-full">
+              <p className="text-sm font-medium text-foreground leading-tight line-clamp-2">{folder.name}</p>
+              <p className="text-xs text-muted-foreground mt-0.5">
                 {count} document{count !== 1 ? "s" : ""}
               </p>
             </div>
           </button>
         );
       })}
-    </>
+    </div>
   );
 }
 
@@ -234,19 +232,23 @@ function FolderContents({
   }
   return (
     <>
-      {subFolders.map(folder => (
-        <button
-          key={folder.id}
-          data-testid={`library-folder-${folder.id}`}
-          onClick={() => onFolderSelect(folder.id)}
-          className="w-full text-left card-surface p-4 flex items-center gap-3 hover:border-sage/30 transition-colors active:scale-[0.99]"
-        >
-          <div className="w-10 h-10 rounded-xl bg-sage-light flex items-center justify-center shrink-0">
-            <Folder size={18} className="text-sage-deep" />
-          </div>
-          <p className="text-sm font-medium text-foreground">{folder.name}</p>
-        </button>
-      ))}
+      {subFolders.length > 0 && (
+        <div className="grid grid-cols-2 gap-3">
+          {subFolders.map(folder => (
+            <button
+              key={folder.id}
+              data-testid={`library-folder-${folder.id}`}
+              onClick={() => onFolderSelect(folder.id)}
+              className="card-surface aspect-square flex flex-col items-center justify-center gap-2 p-4 text-center hover:border-sage/30 transition-colors active:scale-[0.99]"
+            >
+              <div className="w-12 h-12 rounded-xl bg-sage-light flex items-center justify-center shrink-0">
+                <Folder size={20} className="text-sage-deep" />
+              </div>
+              <p className="text-sm font-medium text-foreground leading-tight line-clamp-2">{folder.name}</p>
+            </button>
+          ))}
+        </div>
+      )}
       {docs.map(doc => (
         <button
           key={doc.id}

--- a/src/pages/kiosk/PinEntryModal.tsx
+++ b/src/pages/kiosk/PinEntryModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, type ReactNode } from "react";
 import { useNavigate } from "react-router-dom";
 import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -78,7 +78,96 @@ export async function verifyKioskToken(locationId: string, kioskToken: string | 
   return Boolean(data);
 }
 
-// ─── AdminLoginModal (centered) ───────────────────────────────────────────────
+// ─── KioskPinShell ────────────────────────────────────────────────────────────
+// Shared visual wrapper used by all three PIN dialogs. Matches Admin PIN style.
+interface KioskPinShellProps {
+  title: string;
+  onClose: () => void;
+  pin: string;
+  error?: string;
+  validating?: boolean;
+  lockedUntil?: number | null;
+  lockSecondsLeft?: number;
+  onDigit: (d: string) => void;
+  onBackspace: () => void;
+  ctaLabel?: string;
+  ctaId?: string;
+  ctaTestId?: string;
+  ctaDisabled?: boolean;
+  onCta?: () => void;
+  secondsLeft?: number | null;
+  onCancelCountdown?: () => void;
+  footer?: ReactNode;
+}
+
+export function KioskPinShell({
+  title, onClose, pin, error, validating, lockedUntil, lockSecondsLeft = 0,
+  onDigit, onBackspace, ctaLabel, ctaId, ctaTestId, ctaDisabled, onCta,
+  secondsLeft, onCancelCountdown, footer,
+}: KioskPinShellProps) {
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-foreground/20 backdrop-blur-sm"
+      onClick={e => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className="bg-card w-full max-w-sm mx-4 rounded-2xl p-6 space-y-5 animate-fade-in">
+        <div className="flex items-center justify-between">
+          <h2 className="font-display text-lg text-foreground">{title}</h2>
+          <button onClick={onClose} className="btn-icon" aria-label="Close">
+            <X size={18} className="text-muted-foreground" />
+          </button>
+        </div>
+
+        <PinDots count={pin.length} />
+
+        {error && !validating && (
+          <p className="text-center text-xs text-status-error">{error}</p>
+        )}
+        {validating && (
+          <p className="text-center text-xs text-muted-foreground">Checking PIN…</p>
+        )}
+
+        {lockedUntil ? (
+          <div className="text-center py-4">
+            <p className="text-sm text-muted-foreground">
+              Try again in <span className="font-bold text-foreground">{lockSecondsLeft}s</span>
+            </p>
+          </div>
+        ) : (
+          <NumberPad onDigit={onDigit} onBackspace={onBackspace} />
+        )}
+
+        {ctaLabel && (
+          <button
+            id={ctaId}
+            data-testid={ctaTestId}
+            onClick={onCta}
+            disabled={ctaDisabled}
+            className={cn(
+              "w-full py-3.5 rounded-2xl font-bold tracking-widest text-sm transition-colors active:scale-[0.98]",
+              !ctaDisabled
+                ? "bg-sage text-white hover:bg-sage-deep"
+                : "bg-muted text-muted-foreground cursor-not-allowed",
+            )}
+          >
+            {ctaLabel}
+          </button>
+        )}
+
+        {footer}
+      </div>
+
+      {secondsLeft !== null && secondsLeft !== undefined && (
+        <div className="fixed bottom-0 left-0 right-0 bg-foreground/90 text-background px-5 py-3 flex items-center justify-between z-[70]">
+          <p className="text-sm">Returning to home in {secondsLeft}s…</p>
+          <button onClick={onCancelCountdown} className="text-sm font-semibold underline">Stay</button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── AdminLoginModal ───────────────────────────────────────────────────────────
 export function AdminLoginModal({ onClose, kioskLocationId }: { onClose: () => void; kioskLocationId?: string | null }) {
   const navigate = useNavigate();
   const { teamMember } = useAuth();
@@ -211,25 +300,15 @@ export function AdminLoginModal({ onClose, kioskLocationId }: { onClose: () => v
   };
 
   return (
-    <div
-      className="fixed inset-0 z-[60] flex items-center justify-center bg-foreground/20 backdrop-blur-sm"
-      onClick={e => { if (e.target === e.currentTarget) onClose(); }}
-    >
-      <div className="bg-card w-full max-w-sm mx-4 rounded-2xl p-6 space-y-5 animate-fade-in">
-        <div className="flex items-center justify-between">
-          <h2 className="font-display text-lg text-foreground">Admin PIN</h2>
-          <button onClick={onClose} className="btn-icon">
-            <X size={18} className="text-muted-foreground" />
-          </button>
-        </div>
-
-        <PinDots count={pin.length} />
-
-        {error && <p className="text-center text-xs text-status-error">{error}</p>}
-        {loading && <p className="text-center text-xs text-muted-foreground">Checking…</p>}
-
-        <NumberPad onDigit={handleDigit} onBackspace={handleBackspace} />
-
+    <KioskPinShell
+      title="Admin PIN"
+      onClose={onClose}
+      pin={pin}
+      error={error}
+      validating={loading}
+      onDigit={handleDigit}
+      onBackspace={handleBackspace}
+      footer={
         <p className="text-center text-xs text-muted-foreground pt-1">
           Forgot your PIN?{" "}
           <button
@@ -239,8 +318,8 @@ export function AdminLoginModal({ onClose, kioskLocationId }: { onClose: () => v
             Log out and sign in again
           </button>
         </p>
-      </div>
-    </div>
+      }
+    />
   );
 }
 
@@ -420,66 +499,23 @@ export function PinEntryModal({
   const canStart = pin.length >= 4 && !validating && !lockedUntil;
 
   return (
-    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-foreground/30 backdrop-blur-md">
-      <div className="bg-white w-full max-w-[320px] mx-4 rounded-3xl p-6 space-y-4 animate-fade-in shadow-xl relative">
-        {/* Close button */}
-        <button
-          onClick={onCancel}
-          className="absolute top-4 right-4 w-8 h-8 flex items-center justify-center rounded-full bg-muted hover:bg-muted/80 transition-colors text-muted-foreground"
-          aria-label="Close"
-        >
-          <X size={16} />
-        </button>
-
-        {/* Title */}
-        <div className="text-center pt-1 space-y-1">
-          <h2 className="font-display text-3xl italic text-foreground">Insert PIN</h2>
-          <p className="text-xs text-muted-foreground">You're doing great — let's get started.</p>
-        </div>
-
-        <PinDots count={pin.length} />
-
-        {error && !validating && (
-          <p className="text-xs text-center text-status-error font-medium">{error}</p>
-        )}
-        {validating && (
-          <p className="text-xs text-center text-muted-foreground">Checking PIN…</p>
-        )}
-
-        {lockedUntil ? (
-          <div className="text-center py-4">
-            <p className="text-sm text-muted-foreground">
-              Try again in <span className="font-bold text-foreground">{lockSecondsLeft}s</span>
-            </p>
-          </div>
-        ) : (
-          <NumberPad onDigit={handleDigit} onBackspace={handleBackspace} />
-        )}
-
-        <button
-          id="pin-start-btn"
-          onClick={() => canStart && validate(pin)}
-          disabled={!canStart}
-          className={cn(
-            "w-full py-3.5 rounded-2xl font-bold tracking-widest text-sm transition-colors active:scale-[0.98]",
-            canStart
-              ? "bg-sage text-white hover:bg-sage-deep"
-              : "bg-muted text-muted-foreground cursor-not-allowed",
-          )}
-        >
-          START
-        </button>
-      </div>
-
-      {secondsLeft !== null && (
-        <div className="fixed bottom-0 left-0 right-0 bg-foreground/90 text-background px-5 py-3 flex items-center justify-between z-[70]">
-          <p className="text-sm">Returning to home in {secondsLeft}s…</p>
-          <button onClick={cancelCountdown} className="text-sm font-semibold underline">
-            Stay
-          </button>
-        </div>
-      )}
-    </div>
+    <KioskPinShell
+      title="Insert PIN"
+      onClose={onCancel}
+      pin={pin}
+      error={error}
+      validating={validating}
+      lockedUntil={lockedUntil}
+      lockSecondsLeft={lockSecondsLeft}
+      onDigit={handleDigit}
+      onBackspace={handleBackspace}
+      ctaLabel="START"
+      ctaId="pin-start-btn"
+      ctaDisabled={!canStart}
+      onCta={() => canStart && validate(pin)}
+      secondsLeft={secondsLeft}
+      onCancelCountdown={cancelCountdown}
+    />
   );
 }
 
@@ -610,61 +646,22 @@ export function LibraryPinModal({
   const canSubmit = pin.length >= 4 && !validating && !lockedUntil;
 
   return (
-    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-foreground/30 backdrop-blur-md">
-      <div className="bg-white w-full max-w-[320px] mx-4 rounded-3xl p-6 space-y-4 animate-fade-in shadow-xl relative">
-        <button
-          onClick={onCancel}
-          className="absolute top-4 right-4 w-8 h-8 flex items-center justify-center rounded-full bg-muted hover:bg-muted/80 transition-colors text-muted-foreground"
-          aria-label="Close"
-        >
-          <X size={16} />
-        </button>
-
-        <div className="text-center pt-1 space-y-1">
-          <h2 className="font-display text-3xl italic text-foreground">Staff Library</h2>
-          <p className="text-xs text-muted-foreground">Enter your PIN to access training documents.</p>
-        </div>
-
-        <PinDots count={pin.length} />
-
-        {error && !validating && (
-          <p className="text-xs text-center text-status-error font-medium">{error}</p>
-        )}
-        {validating && (
-          <p className="text-xs text-center text-muted-foreground">Checking PIN…</p>
-        )}
-
-        {lockedUntil ? (
-          <div className="text-center py-4">
-            <p className="text-sm text-muted-foreground">
-              Try again in <span className="font-bold text-foreground">{lockSecondsLeft}s</span>
-            </p>
-          </div>
-        ) : (
-          <NumberPad onDigit={handleDigit} onBackspace={handleBackspace} />
-        )}
-
-        <button
-          data-testid="library-pin-access-btn"
-          onClick={() => canSubmit && validate(pin)}
-          disabled={!canSubmit}
-          className={cn(
-            "w-full py-3.5 rounded-2xl font-bold tracking-widest text-sm transition-colors active:scale-[0.98]",
-            canSubmit
-              ? "bg-sage text-white hover:bg-sage-deep"
-              : "bg-muted text-muted-foreground cursor-not-allowed",
-          )}
-        >
-          ACCESS
-        </button>
-      </div>
-
-      {secondsLeft !== null && (
-        <div className="fixed bottom-0 left-0 right-0 bg-foreground/90 text-background px-5 py-3 flex items-center justify-between z-[70]">
-          <p className="text-sm">Returning to home in {secondsLeft}s…</p>
-          <button onClick={cancelCountdown} className="text-sm font-semibold underline">Stay</button>
-        </div>
-      )}
-    </div>
+    <KioskPinShell
+      title="Staff Library"
+      onClose={onCancel}
+      pin={pin}
+      error={error}
+      validating={validating}
+      lockedUntil={lockedUntil}
+      lockSecondsLeft={lockSecondsLeft}
+      onDigit={handleDigit}
+      onBackspace={handleBackspace}
+      ctaLabel="ACCESS"
+      ctaTestId="library-pin-access-btn"
+      ctaDisabled={!canSubmit}
+      onCta={() => canSubmit && validate(pin)}
+      secondsLeft={secondsLeft}
+      onCancelCountdown={cancelCountdown}
+    />
   );
 }

--- a/src/test/pages/Kiosk.test.tsx
+++ b/src/test/pages/Kiosk.test.tsx
@@ -782,10 +782,11 @@ describe("Kiosk — PIN Entry Modal", () => {
     expect(screen.getByText("Insert PIN")).toBeInTheDocument();
   });
 
-  it("PIN modal shows the current helper subtitle", async () => {
+  it("PIN modal uses unified shell style with no subtitle", async () => {
     const opened = await openPinModal();
     if (!opened) return;
-    expect(screen.getByText(/You're doing great/i)).toBeInTheDocument();
+    expect(screen.queryByText(/You're doing great/i)).not.toBeInTheDocument();
+    expect(screen.getByText("Insert PIN")).toBeInTheDocument();
   });
 
   it("PIN modal shows numpad with digit '1'", async () => {


### PR DESCRIPTION
Closes #515, closes #516, closes #517

## Summary

- **#515 — Folder cards go square:** `RootFolders` and `FolderContents` in `KioskLibrary.tsx` now use a `grid grid-cols-2 gap-3` layout with `aspect-square` tiles (centred Folder icon + name/count), matching the checklist card grid on the kiosk home screen. Document cards inside a folder stay as full-width rows.

- **#516 — Unified PIN shell:** New `KioskPinShell` component in `PinEntryModal.tsx` is the single visual wrapper for all three PIN dialogs. Matches Admin PIN style: left-aligned `font-display text-lg` title, `btn-icon` close button, `bg-card rounded-2xl` card, lighter `backdrop-blur-sm`. The centred italic headline and tagline subtitle are gone from the checklist and library PIN modals.

- **#517 — Single back affordance:** Removed the redundant circular `←` icon button from the `KioskLibrary` header. The `← Kiosk / ← [folder name]` breadcrumb text above the page title is now the sole back control and carries `data-testid="library-back-btn"` so all existing navigation tests continue to pass.

## Test plan

- [ ] All 1315 unit tests pass (`bun run test`)
- [ ] Lint: 0 errors (`bun run lint`)
- [ ] Build: clean (`bun run build`)
- [ ] Kiosk library: folders render as 2-col square grid at root and inside folders
- [ ] Kiosk library: breadcrumb `← Kiosk` / `← [folder]` is the only back affordance (no circular button)
- [ ] PIN entry modal: matches Admin PIN card style (no subtitle, left-aligned title)
- [ ] Library PIN modal: same unified shell, title reads "Staff Library"
- [ ] Admin PIN modal: unchanged behaviour, same shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)