### PR TITLE
fix: shrink folder grid tiles to h-36

### DIFF
--- a/src/pages/kiosk/KioskLibrary.tsx
+++ b/src/pages/kiosk/KioskLibrary.tsx
@@ -198,7 +198,7 @@ function RootFolders({
             key={folder.id}
             data-testid={`library-folder-${folder.id}`}
             onClick={() => onFolderSelect(folder.id)}
-            className="card-surface aspect-square flex flex-col items-center justify-center gap-2 p-4 text-center hover:border-sage/30 transition-colors active:scale-[0.99]"
+            className="card-surface h-36 flex flex-col items-center justify-center gap-2 p-4 text-center hover:border-sage/30 transition-colors active:scale-[0.99]"
           >
             <div className="w-12 h-12 rounded-xl bg-sage-light flex items-center justify-center shrink-0">
               <Folder size={20} className="text-sage-deep" />
@@ -239,7 +239,7 @@ function FolderContents({
               key={folder.id}
               data-testid={`library-folder-${folder.id}`}
               onClick={() => onFolderSelect(folder.id)}
-              className="card-surface aspect-square flex flex-col items-center justify-center gap-2 p-4 text-center hover:border-sage/30 transition-colors active:scale-[0.99]"
+              className="card-surface h-36 flex flex-col items-center justify-center gap-2 p-4 text-center hover:border-sage/30 transition-colors active:scale-[0.99]"
             >
               <div className="w-12 h-12 rounded-xl bg-sage-light flex items-center justify-center shrink-0">
                 <Folder size={20} className="text-sage-deep" />


### PR DESCRIPTION
Follow-up to #518.

`aspect-square` sized each tile to match its column width — half the viewport on a kiosk screen, so ~700 px tall. Replaced with `h-36` (144 px fixed height), which is roughly 4× smaller and fits multiple rows on screen without scrolling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)