### PR TITLE
Fix sticky Publish timestamp alignment/scrollbar overlap and horizontal scroll in checklist builder

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -77,7 +77,7 @@ export function Layout({ children, title, subtitle, headerRight, headerLeft }: L
           <SidebarNav />
 
           {/* Only this column scrolls */}
-          <main ref={mainRef} className="flex-1 min-w-0 overflow-y-auto pb-24 pt-5 animate-fade-in md:pb-8">
+          <main ref={mainRef} className="flex-1 min-w-0 overflow-y-auto overflow-x-hidden pb-24 pt-5 animate-fade-in md:pb-8">
             <div className={cn(contentWidthClass, "min-w-0 space-y-4")}>
               {children}
             </div>

--- a/src/pages/checklists/ChecklistBuilderModal.tsx
+++ b/src/pages/checklists/ChecklistBuilderModal.tsx
@@ -1402,9 +1402,14 @@ export function ChecklistBuilderModal({
         {discardConfirmDialog}
         {createPortal(
           <div className={cn(
-            "fixed top-20 right-4 z-30 flex flex-col items-end gap-1 transition-all duration-150",
+            "fixed top-20 right-4 z-30 flex flex-row items-center gap-2 transition-all duration-150",
             footerPublishVisible ? "opacity-0 pointer-events-none" : "opacity-100",
           )}>
+            {lastPublishedAt && (
+              <span className="text-[10px] text-muted-foreground bg-card/90 backdrop-blur-sm px-2.5 py-1 rounded-full border border-border/50 whitespace-nowrap">
+                Saved {format(lastPublishedAt, "h:mm a")}
+              </span>
+            )}
             <button
               disabled={isSaving || !title.trim() || (locationMode === "specific" && selectedLocationIds.length === 0)}
               onClick={handleCreate}
@@ -1417,11 +1422,6 @@ export function ChecklistBuilderModal({
             >
               {isSaving ? "Publishing…" : "Publish"}
             </button>
-            {lastPublishedAt && (
-              <span className="text-[10px] text-muted-foreground">
-                Saved {format(lastPublishedAt, "h:mm a")}
-              </span>
-            )}
           </div>,
           document.body
         )}


### PR DESCRIPTION
## Summary

Closes #522 #523 #524

- **#522 + #523 — Sticky button timestamp**: Moved the "Saved HH:MM" label to the **left** of the Publish button (row layout) instead of below it. This centers the label vertically with the button, keeps it away from the iOS scroll indicator that lives at the right viewport edge, and adds a frosted-glass pill background so it stays readable even if the scroll indicator passes over it.
- **#524 — Horizontal scroll**: Added `overflow-x: hidden` to the `main` scroll container in `Layout.tsx`. The checklist builder's `-mx-4` negative margin was extending content beyond the container bounds without anything clipping it.

## Test plan

- [ ] Open a checklist, publish it → "Saved HH:MM AM" pill appears to the LEFT of the Publish sticky button, vertically centered
- [ ] Scroll the checklist form up and down → scroll indicator does not obscure the timestamp pill
- [ ] Scroll the checklist builder page horizontally → should not be possible (no horizontal scroll)

🤖 Generated with [Claude Code](https://claude.com/claude-code)