### PR TITLE
Fix checklist description not saving, restore discard popup, close builder on nav tab click

### DIFF
--- a/src/hooks/useChecklists.ts
+++ b/src/hooks/useChecklists.ts
@@ -114,17 +114,18 @@ export function useSaveChecklist() {
   return useMutation({
     mutationFn: async (checklist: Partial<ChecklistItem> & { id?: string }) => {
       const { data, error } = await supabase.rpc("save_checklist", {
-        p_id:              checklist.id || null,
-        p_title:           checklist.title ?? "",
-        p_folder_id:       checklist.folder_id ?? null,
-        p_location_id:     checklist.location_id ?? null,
-        p_location_ids:    checklist.location_ids ?? null,
-        p_start_date:      checklist.start_date ?? null,
-        p_schedule:        checklist.schedule ?? null,
-        p_sections:        checklist.sections ?? [],
-        p_time_of_day:     "anytime",
-        p_due_time:        checklist.due_time ?? null,
-        p_visibility_from: checklist.visibility_from ?? null,
+        p_id:               checklist.id || null,
+        p_title:            checklist.title ?? "",
+        p_description:      checklist.description ?? null,
+        p_folder_id:        checklist.folder_id ?? null,
+        p_location_id:      checklist.location_id ?? null,
+        p_location_ids:     checklist.location_ids ?? null,
+        p_start_date:       checklist.start_date ?? null,
+        p_schedule:         checklist.schedule ?? null,
+        p_sections:         checklist.sections ?? [],
+        p_time_of_day:      "anytime",
+        p_due_time:         checklist.due_time ?? null,
+        p_visibility_from:  checklist.visibility_from ?? null,
         p_visibility_until: checklist.visibility_until ?? null,
       });
       if (error) throw error;

--- a/src/pages/checklists/ChecklistBuilderModal.tsx
+++ b/src/pages/checklists/ChecklistBuilderModal.tsx
@@ -29,7 +29,7 @@ import { linkableInfohubResources } from "@/lib/infohub-catalog";
 
 const DRAFT_KEY = "olia_checklist_draft";
 
-function loadDraft(): { title: string; sections: SectionDef[] } | null {
+function loadDraft(): { title: string; description?: string; sections: SectionDef[] } | null {
   try {
     const raw = sessionStorage.getItem(DRAFT_KEY);
     return raw ? JSON.parse(raw) : null;
@@ -59,6 +59,7 @@ interface ChecklistBuilderModalProps {
   onUpdate?: (id: string, item: Partial<ChecklistItem>) => Promise<void>;
   initialTitle?: string;
   initialSections?: SectionDef[];
+  initialDescription?: string;
   initialLocationIds?: string[] | null;
   initialSchedule?: string | null;
   initialStartDate?: string | null;
@@ -73,7 +74,7 @@ interface ChecklistBuilderModalProps {
 }
 
 export function ChecklistBuilderModal({
-  onClose, onAdd, onUpdate, initialTitle, initialSections, initialLocationIds,
+  onClose, onAdd, onUpdate, initialTitle, initialDescription, initialSections, initialLocationIds,
   initialSchedule, initialStartDate, initialVisibilityFrom, initialVisibilityUntil, editId, asPage = false, onDirtyChange,
 }: ChecklistBuilderModalProps) {
   const createAlert = useCreateAlert();
@@ -88,7 +89,7 @@ export function ChecklistBuilderModal({
   const draft = isNewChecklist ? loadDraft() : null;
 
   const [title, setTitle] = useState(draft?.title ?? initialTitle ?? "");
-  const [description, setDescription] = useState("");
+  const [description, setDescription] = useState(draft?.description ?? initialDescription ?? "");
   const [startDate, setStartDate] = useState<Date | undefined>(
     initialStartDate ? new Date(`${initialStartDate}T00:00:00`) : undefined,
   );
@@ -125,12 +126,13 @@ export function ChecklistBuilderModal({
   const footerPublishRef = useRef<HTMLButtonElement>(null);
   const [footerPublishVisible, setFooterPublishVisible] = useState(false);
 
-  const hasContent = !!(title.trim() || sections.some(s => s.name.trim() || s.questions.some(q => q.text.trim())));
+  const hasContent = !!(title.trim() || description.trim() || sections.some(s => s.name.trim() || s.questions.some(q => q.text.trim())));
 
   // Snapshot the actual initial state values (not the raw props) so that
   // null/undefined initialSections that fall back to the default section
   // still compare equal to the state React actually initialised.
   const initialTitleRef = useRef(title);
+  const initialDescriptionRef = useRef(description);
   const initialSectionsRef = useRef(JSON.stringify(sections));
 
   // Intercept Exit/X when there's unsaved content — show a confirmation first
@@ -138,6 +140,7 @@ export function ChecklistBuilderModal({
     const warnForNew = !savedId && hasContent;
     const warnForEdit = !!savedId && (
       title !== initialTitleRef.current ||
+      description !== initialDescriptionRef.current ||
       JSON.stringify(sections) !== initialSectionsRef.current
     );
     if (warnForNew || warnForEdit) {
@@ -150,8 +153,8 @@ export function ChecklistBuilderModal({
   // Autosave draft to sessionStorage while editing a new checklist
   useEffect(() => {
     if (!isNewChecklist) return;
-    try { sessionStorage.setItem(DRAFT_KEY, JSON.stringify({ title, sections })); } catch { /* ignore */ }
-  }, [title, sections, isNewChecklist]);
+    try { sessionStorage.setItem(DRAFT_KEY, JSON.stringify({ title, description, sections })); } catch { /* ignore */ }
+  }, [title, description, sections, isNewChecklist]);
 
   // Hide the top Publish button when the footer Publish button scrolls into view
   useEffect(() => {
@@ -169,10 +172,10 @@ export function ChecklistBuilderModal({
   useEffect(() => {
     if (!onDirtyChange) return;
     const dirty = !savedId
-      ? !!(title.trim() || sections.some(s => s.name.trim() || s.questions.some(q => q.text.trim())))
-      : title !== initialTitleRef.current || JSON.stringify(sections) !== initialSectionsRef.current;
+      ? !!(title.trim() || description.trim() || sections.some(s => s.name.trim() || s.questions.some(q => q.text.trim())))
+      : title !== initialTitleRef.current || description !== initialDescriptionRef.current || JSON.stringify(sections) !== initialSectionsRef.current;
     onDirtyChange(dirty);
-  }, [title, sections, savedId, onDirtyChange]);
+  }, [title, description, sections, savedId, onDirtyChange]);
 
   useEffect(() => {
     if (insertDropdown === null) return;
@@ -407,6 +410,7 @@ export function ChecklistBuilderModal({
       }
       clearChecklistDraft();
       initialTitleRef.current = title;
+      initialDescriptionRef.current = description;
       initialSectionsRef.current = JSON.stringify(sections);
       setLastPublishedAt(new Date());
       toast.success(isFirstPublish ? "Checklist published!" : "Changes saved!");

--- a/src/pages/checklists/ChecklistsTab.tsx
+++ b/src/pages/checklists/ChecklistsTab.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect, lazy, Suspense } from "react";
+import { useState, useEffect, useRef, useCallback, lazy, Suspense } from "react";
 import { createPortal } from "react-dom";
-import { useSearchParams, useBlocker } from "react-router-dom";
+import { useSearchParams, useBlocker, useLocation } from "react-router-dom";
 import { Plus, Search, ChevronDown, X, GripVertical, MoreVertical, FolderPlus, ClipboardList, Eye, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { FolderItem, ChecklistItem, SectionDef } from "./types";
@@ -144,6 +144,33 @@ export function ChecklistsTab() {
 
   const isEmpty = visibleFolders.length === 0 && visibleChecklists.length === 0 && !normalizedSearch;
 
+  // Hoist discardAndClose so it can be used both in the builder branch and in effects below
+  const discardAndClose = useCallback(() => {
+    try { sessionStorage.removeItem("olia_checklist_draft"); } catch { /* ignore */ }
+    setShowBuilder(false);
+    setPrefillTitle("");
+    setPrefillSections(undefined);
+    setPrefillLocationIds(undefined);
+    setEditingChecklistId(null);
+    setIsBuilderDirty(false);
+  }, []);
+
+  // Show a discard-confirm when the user clicks any nav tab while the builder has unsaved changes.
+  // useBlocker handles cross-route navigation; this state handles same-route (Checklists tab) clicks.
+  const [showNavExitConfirm, setShowNavExitConfirm] = useState(false);
+  const location = useLocation();
+  const prevLocationKeyRef = useRef(location.key);
+  useEffect(() => {
+    if (prevLocationKeyRef.current === location.key) return;
+    prevLocationKeyRef.current = location.key;
+    if (!showBuilder) return;
+    if (isBuilderDirty) {
+      setShowNavExitConfirm(true);
+    } else {
+      discardAndClose();
+    }
+  }, [location.key, showBuilder, isBuilderDirty, discardAndClose]);
+
   const blocker = useBlocker(showBuilder && isBuilderDirty);
 
   // Warn the browser when the user tries to leave the tab/app entirely while the builder has unsaved changes
@@ -205,16 +232,6 @@ export function ChecklistsTab() {
 
   // ── Page-mode builder: takes over the whole content area ──────────────────
   if (showBuilder) {
-    const discardAndClose = () => {
-      try { sessionStorage.removeItem("olia_checklist_draft"); } catch { /* ignore */ }
-      setShowBuilder(false);
-      setPrefillTitle("");
-      setPrefillSections(undefined);
-      setPrefillLocationIds(undefined);
-      setEditingChecklistId(null);
-      setIsBuilderDirty(false);
-    };
-
     return (
       <>
       <Suspense fallback={<div className="flex items-center justify-center py-20"><div className="w-8 h-8 rounded-xl bg-sage animate-pulse" /></div>}>
@@ -224,6 +241,7 @@ export function ChecklistsTab() {
         onAdd={async item => {
           const data = await saveChecklistMut.mutateAsync({
             title: item.title,
+            description: item.description ?? null,
             folder_id: currentFolder,
             location_id: item.location_id ?? null,
             location_ids: item.location_ids ?? null,
@@ -243,6 +261,7 @@ export function ChecklistsTab() {
           await saveChecklistMut.mutateAsync({
             ...orig,
             title: updates.title ?? orig.title,
+            description: updates.description !== undefined ? updates.description : (orig as any).description ?? null,
             sections: updates.sections ?? orig.sections,
             schedule: updates.schedule ?? orig.schedule,
             location_id: updates.location_id !== undefined ? updates.location_id : orig.location_id,
@@ -255,6 +274,7 @@ export function ChecklistsTab() {
           });
         }}
         initialTitle={prefillTitle}
+        initialDescription={(editingChecklist as any)?.description ?? undefined}
         initialSections={prefillSections}
         initialLocationIds={prefillLocationIds}
         initialSchedule={editingChecklist?.schedule ?? null}
@@ -265,20 +285,20 @@ export function ChecklistsTab() {
         onDirtyChange={setIsBuilderDirty}
       />
       </Suspense>
-      {blocker.state === "blocked" && createPortal(
+      {(blocker.state === "blocked" || showNavExitConfirm) && createPortal(
         <div className="fixed inset-0 z-[80] flex items-center justify-center bg-foreground/30 backdrop-blur-sm">
           <div className="bg-card rounded-2xl p-6 mx-4 max-w-sm w-full shadow-xl space-y-4">
             <h3 className="font-display text-lg text-foreground">Leave without saving?</h3>
-            <p className="text-sm text-muted-foreground">Your unsaved changes will be lost if you leave this page.</p>
+            <p className="text-sm text-muted-foreground">Your unsaved changes will be lost if you exit.</p>
             <div className="flex gap-3">
               <button
-                onClick={() => blocker.reset()}
+                onClick={() => { setShowNavExitConfirm(false); if (blocker.state === "blocked") blocker.reset(); }}
                 className="flex-1 py-2.5 rounded-xl border border-border text-sm font-medium text-foreground hover:bg-muted transition-colors"
               >
                 Keep editing
               </button>
               <button
-                onClick={() => { discardAndClose(); blocker.proceed(); }}
+                onClick={() => { discardAndClose(); setShowNavExitConfirm(false); if (blocker.state === "blocked") blocker.proceed(); }}
                 className="flex-1 py-2.5 rounded-xl bg-status-error text-white text-sm font-medium hover:opacity-90 transition-opacity"
               >
                 Discard changes

--- a/supabase/migrations/20260726000001_checklists_description_column.sql
+++ b/supabase/migrations/20260726000001_checklists_description_column.sql
@@ -1,0 +1,107 @@
+-- Add description column to checklists and update save_checklist RPC to persist it.
+-- The description textarea existed in the UI but was never wired to the DB.
+
+ALTER TABLE public.checklists
+  ADD COLUMN IF NOT EXISTS description text;
+
+-- Drop old function signature (parameter list changed — can't use CREATE OR REPLACE for this)
+DROP FUNCTION IF EXISTS public.save_checklist(uuid, text, uuid, uuid, uuid[], date, jsonb, jsonb, text, time, time, time);
+
+CREATE OR REPLACE FUNCTION public.save_checklist(
+  p_id               uuid,
+  p_title            text,
+  p_description      text,
+  p_folder_id        uuid,
+  p_location_id      uuid,
+  p_location_ids     uuid[],
+  p_start_date       date,
+  p_schedule         jsonb,
+  p_sections         jsonb,
+  p_time_of_day      text,
+  p_due_time         time,
+  p_visibility_from  time,
+  p_visibility_until time
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_org_id    uuid;
+  v_result_id uuid;
+BEGIN
+  v_org_id := public.current_org_id();
+
+  IF v_org_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated or no organization found';
+  END IF;
+
+  IF p_id IS NOT NULL THEN
+    UPDATE public.checklists
+    SET
+      title            = p_title,
+      description      = p_description,
+      folder_id        = p_folder_id,
+      location_id      = p_location_id,
+      location_ids     = p_location_ids,
+      start_date       = p_start_date,
+      schedule         = p_schedule,
+      sections         = p_sections,
+      time_of_day      = COALESCE(p_time_of_day, 'anytime'),
+      due_time         = p_due_time,
+      visibility_from  = p_visibility_from,
+      visibility_until = p_visibility_until,
+      updated_at       = now()
+    WHERE id = p_id
+      AND organization_id = v_org_id;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Checklist not found or does not belong to your organization';
+    END IF;
+
+    v_result_id := p_id;
+
+  ELSE
+    IF NOT public.check_plan_limit(v_org_id, 'checklists', 'maxChecklists') THEN
+      RAISE EXCEPTION 'You have reached the checklist limit for your plan. Delete unused checklists or upgrade to create more.';
+    END IF;
+
+    INSERT INTO public.checklists (
+      organization_id,
+      title,
+      description,
+      folder_id,
+      location_id,
+      location_ids,
+      start_date,
+      schedule,
+      sections,
+      time_of_day,
+      due_time,
+      visibility_from,
+      visibility_until
+    ) VALUES (
+      v_org_id,
+      p_title,
+      p_description,
+      p_folder_id,
+      p_location_id,
+      p_location_ids,
+      p_start_date,
+      p_schedule,
+      COALESCE(p_sections, '[]'::jsonb),
+      COALESCE(p_time_of_day, 'anytime'),
+      p_due_time,
+      p_visibility_from,
+      p_visibility_until
+    )
+    RETURNING id INTO v_result_id;
+  END IF;
+
+  RETURN jsonb_build_object('id', v_result_id);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.save_checklist(uuid, text, text, uuid, uuid, uuid[], date, jsonb, jsonb, text, time, time, time) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.save_checklist(uuid, text, text, uuid, uuid, uuid[], date, jsonb, jsonb, text, time, time, time) TO authenticated;


### PR DESCRIPTION
## Summary

Closes #526 #527 #528

### #526 — Description field never saved
- **Migration** adds `description text` column to `checklists` table (already applied to production)
- `save_checklist` RPC updated to accept `p_description` and persist it on both INSERT and UPDATE
- `useSaveChecklist` passes `p_description` to the RPC
- `ChecklistBuilderModal` gets an `initialDescription` prop so the textarea is pre-filled when reopening an existing checklist; description is also saved in the sessionStorage draft

### #527 — Discard popup not appearing
- `hasContent`, `warnForNew`, `warnForEdit`, and the `onDirtyChange` effect now all include `description`
- An `initialDescriptionRef` tracks the last-saved description value and is reset after each Publish, so description-only changes correctly trigger the exit warning

### #528 — Clicking nav tab does nothing
- `discardAndClose` moved to component level (`useCallback`) so it is accessible outside the `showBuilder` conditional branch
- `useLocation()` tracks `location.key`; on every key change while the builder is open, it either calls `discardAndClose()` (if clean) or shows `showNavExitConfirm` dialog (if dirty)
- A unified exit-confirm dialog covers both same-route nav tab clicks and cross-route React Router blocker events

## Test plan

- [ ] Create a checklist, fill in the description, publish → exit and reopen → description is pre-filled ✓
- [ ] Edit a checklist, change only the description → click **Exit** → discard dialog appears ✓
- [ ] Edit a checklist, change the title → click the **Checklists** bottom nav tab → discard dialog appears ✓
- [ ] Edit a checklist, change the title → click the **Checklists** bottom nav tab → click **Keep editing** → stays in builder ✓
- [ ] Edit a checklist, publish (clean), click **Checklists** nav tab → builder closes cleanly ✓
- [ ] Navigating to Dashboard tab while builder is dirty → discard dialog appears ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)