### PR TITLE
Fix false discard popup after publishing (reset dirty flag immediately on save)

### DIFF
--- a/src/pages/checklists/ChecklistBuilderModal.tsx
+++ b/src/pages/checklists/ChecklistBuilderModal.tsx
@@ -412,6 +412,7 @@ export function ChecklistBuilderModal({
       initialTitleRef.current = title;
       initialDescriptionRef.current = description;
       initialSectionsRef.current = JSON.stringify(sections);
+      onDirtyChange?.(false);
       setLastPublishedAt(new Date());
       toast.success(isFirstPublish ? "Checklist published!" : "Changes saved!");
     } catch (err) {


### PR DESCRIPTION
## Summary

Closes #533

### Root cause

After a successful publish, `handleCreate` updates `initialTitleRef`, `initialDescriptionRef`, and `initialSectionsRef` synchronously — but these are **refs**, not state. The `onDirtyChange` effect has `[title, description, sections, savedId]` as deps and only re-runs when one of those changes. Because nothing in state changed, `isBuilderDirty` in `ChecklistsTab` stayed `true` even though there were no unsaved changes, causing the "Leave without saving?" dialog to fire on the next nav-tab click.

### Fix

Call `onDirtyChange?.(false)` explicitly in `handleCreate` immediately after a successful save (one line). If the user then makes further changes, the next state-dep change will re-fire the effect and set dirty back to `true` correctly.

## Test plan

- [ ] Make changes → Publish → click Checklists sidebar tab → builder closes cleanly, **no dialog** ✓
- [ ] Make changes → Publish → make more changes → click Checklists tab → discard dialog appears ✓
- [ ] Make changes → click Exit WITHOUT publishing → discard dialog appears ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)