### PR TITLE
Fix false discard popup — use ref for dirty state to eliminate blocker race condition

### DIFF
--- a/src/pages/checklists/ChecklistsTab.tsx
+++ b/src/pages/checklists/ChecklistsTab.tsx
@@ -144,9 +144,18 @@ export function ChecklistsTab({ onBuilderTitleChange }: { onBuilderTitleChange?:
 
   const isEmpty = visibleFolders.length === 0 && visibleChecklists.length === 0 && !normalizedSearch;
 
+  // Mirror isBuilderDirty into a ref so useBlocker and the location-key effect
+  // always read the *current* value synchronously — no render cycle needed.
+  const isBuilderDirtyRef = useRef(false);
+  const handleDirtyChange = useCallback((dirty: boolean) => {
+    isBuilderDirtyRef.current = dirty;
+    setIsBuilderDirty(dirty);
+  }, []);
+
   // Hoist discardAndClose so it can be used both in the builder branch and in effects below
   const discardAndClose = useCallback(() => {
     try { sessionStorage.removeItem("olia_checklist_draft"); } catch { /* ignore */ }
+    isBuilderDirtyRef.current = false;
     setShowBuilder(false);
     setPrefillTitle("");
     setPrefillSections(undefined);
@@ -165,14 +174,16 @@ export function ChecklistsTab({ onBuilderTitleChange }: { onBuilderTitleChange?:
     if (prevLocationKeyRef.current === location.key) return;
     prevLocationKeyRef.current = location.key;
     if (!showBuilder) return;
-    if (isBuilderDirty) {
+    // Read from ref — always the live value, never stale from a render closure
+    if (isBuilderDirtyRef.current) {
       setShowNavExitConfirm(true);
     } else {
       discardAndClose();
     }
-  }, [location.key, showBuilder, isBuilderDirty, discardAndClose]);
+  }, [location.key, showBuilder, discardAndClose]);
 
-  const blocker = useBlocker(showBuilder && isBuilderDirty);
+  // Function form so the router always reads the live ref value, not a render-time snapshot
+  const blocker = useBlocker(() => showBuilder && isBuilderDirtyRef.current);
 
   // Warn the browser when the user tries to leave the tab/app entirely while the builder has unsaved changes
   useEffect(() => {
@@ -284,7 +295,7 @@ export function ChecklistsTab({ onBuilderTitleChange }: { onBuilderTitleChange?:
         initialVisibilityFrom={editingChecklist?.visibility_from ?? null}
         initialVisibilityUntil={editingChecklist?.visibility_until ?? null}
         editId={editingChecklistId || undefined}
-        onDirtyChange={setIsBuilderDirty}
+        onDirtyChange={handleDirtyChange}
       />
       </Suspense>
       {(blocker.state === "blocked" || showNavExitConfirm) && createPortal(


### PR DESCRIPTION
## Summary

Closes #535

### Root cause (deeper than #533)

The previous fix (`onDirtyChange(false)` after publish) was insufficient because **both `useBlocker` and the `location.key` effect read `isBuilderDirty` from React state** — a value captured at render time. React Router registers its blocker callback via `useEffect`, which runs *after* the commit phase. There is therefore a window between `setState(false)` being queued and the router actually having the updated value. During that window, clicking the sidebar still reads the old `true` and fires the dialog.

### Fix

- Add `isBuilderDirtyRef` (`useRef`) that mirrors `isBuilderDirty` state — updated **synchronously** in `handleDirtyChange` and in `discardAndClose`.
- Pass a **function** to `useBlocker(() => showBuilder && isBuilderDirtyRef.current)` so the router reads the live ref value at navigation time, not a stale render snapshot.
- The `location.key` effect now reads `isBuilderDirtyRef.current` directly and no longer has `isBuilderDirty` in its deps — a stale closure can never cause a false positive.

## Test plan

- [ ] Make changes → Publish (see "Changes saved!" toast) → click Checklists sidebar tab → builder closes **without dialog** ✓
- [ ] Make changes → Publish → make more changes → click sidebar → discard dialog appears ✓  
- [ ] Make changes (don't publish) → click sidebar → discard dialog appears ✓
- [ ] Make changes (don't publish) → click Dashboard tab → discard dialog appears ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)