### PR TITLE
Fix description never persisting — add it to useChecklists SELECT column list

### DIFF
--- a/src/hooks/useChecklists.ts
+++ b/src/hooks/useChecklists.ts
@@ -14,6 +14,7 @@ export interface ChecklistItem {
   id: string;
   organization_id?: string;
   title: string;
+  description?: string | null;
   folder_id: string | null;
   location_id: string | null;
   location_ids?: string[] | null;
@@ -98,7 +99,7 @@ export function useChecklists() {
     queryFn: async () => {
       const { data, error } = await supabase
         .from("checklists")
-        .select("id, organization_id, title, folder_id, location_id, location_ids, start_date, schedule, sections, time_of_day, due_time, visibility_from, visibility_until, created_at, updated_at")
+        .select("id, organization_id, title, description, folder_id, location_id, location_ids, start_date, schedule, sections, time_of_day, due_time, visibility_from, visibility_until, created_at, updated_at")
         .order("title");
       if (error) throw error;
       return ((data ?? []) as ChecklistItem[]).filter(

--- a/src/pages/checklists/ChecklistsTab.tsx
+++ b/src/pages/checklists/ChecklistsTab.tsx
@@ -274,7 +274,7 @@ export function ChecklistsTab({ onBuilderTitleChange }: { onBuilderTitleChange?:
           await saveChecklistMut.mutateAsync({
             ...orig,
             title: updates.title ?? orig.title,
-            description: updates.description ?? (orig as any).description ?? null,
+            description: updates.description ?? orig.description ?? null,
             sections: updates.sections ?? orig.sections,
             schedule: updates.schedule ?? orig.schedule,
             location_id: updates.location_id !== undefined ? updates.location_id : orig.location_id,
@@ -287,7 +287,7 @@ export function ChecklistsTab({ onBuilderTitleChange }: { onBuilderTitleChange?:
           });
         }}
         initialTitle={prefillTitle}
-        initialDescription={(editingChecklist as any)?.description ?? undefined}
+        initialDescription={editingChecklist?.description ?? undefined}
         initialSections={prefillSections}
         initialLocationIds={prefillLocationIds}
         initialSchedule={editingChecklist?.schedule ?? null}


### PR DESCRIPTION
## Summary

Closes #537

### Root cause

\`useChecklists\` uses an **explicit column list** in its SELECT, not \`select("*")\`:

\`\`\`
.select("id, organization_id, title, folder_id, ..., updated_at")
\`\`\`

\`description\` was never included. The RPC was correctly writing description to the database, but every \`invalidateQueries\` refetch (which fires after every save) overwrote the React Query cache with rows that had no \`description\` field. So \`editingChecklist.description\` was always \`undefined\` when reopening the builder, and the textarea always appeared empty — even though the data was in the DB.

### Fix
- Add \`description\` to the SELECT column list in \`useChecklists\`
- Add \`description?: string | null\` to the \`ChecklistItem\` interface (no more \`as any\` casts needed)
- Remove \`(orig as any).description\` and \`(editingChecklist as any)?.description\` — both are now properly typed

## Test plan

- [ ] Edit a checklist, add a description, Publish → exit → reopen → description is shown ✓
- [ ] Edit description, Publish again → exit → reopen → updated description shown ✓
- [ ] Clear description, Publish → exit → reopen → description empty ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)