### PR TITLE
Fix dirty check to cover start date, schedule, visibility, and location changes

### DIFF
--- a/src/pages/checklists/ChecklistBuilderModal.tsx
+++ b/src/pages/checklists/ChecklistBuilderModal.tsx
@@ -126,7 +126,27 @@ export function ChecklistBuilderModal({
   const footerPublishRef = useRef<HTMLButtonElement>(null);
   const [footerPublishVisible, setFooterPublishVisible] = useState(false);
 
-  const hasContent = !!(title.trim() || description.trim() || sections.some(s => s.name.trim() || s.questions.some(q => q.text.trim())));
+  // Serialise all schedule/location/visibility settings into one comparable string
+  const settingsSnapshot = () => JSON.stringify({
+    startDate: startDate ? format(startDate, "yyyy-MM-dd") : null,
+    schedule,
+    customRecurrence: schedule === "custom" ? customRecurrence : null,
+    visibilityWindowEnabled,
+    visibilityFrom: visibilityWindowEnabled ? visibilityFrom : null,
+    visibilityUntil: visibilityWindowEnabled ? visibilityUntil : null,
+    locationMode,
+    selectedLocationIds: locationMode === "specific" ? [...selectedLocationIds].sort() : [],
+  });
+
+  const hasContent = !!(
+    title.trim() ||
+    description.trim() ||
+    sections.some(s => s.name.trim() || s.questions.some(q => q.text.trim())) ||
+    startDate != null ||
+    schedule !== "none" ||
+    visibilityWindowEnabled ||
+    locationMode === "specific"
+  );
 
   // Snapshot the actual initial state values (not the raw props) so that
   // null/undefined initialSections that fall back to the default section
@@ -134,6 +154,7 @@ export function ChecklistBuilderModal({
   const initialTitleRef = useRef(title);
   const initialDescriptionRef = useRef(description);
   const initialSectionsRef = useRef(JSON.stringify(sections));
+  const initialSettingsRef = useRef(settingsSnapshot());
 
   // Intercept Exit/X when there's unsaved content — show a confirmation first
   const handleRequestClose = () => {
@@ -141,7 +162,8 @@ export function ChecklistBuilderModal({
     const warnForEdit = !!savedId && (
       title !== initialTitleRef.current ||
       description !== initialDescriptionRef.current ||
-      JSON.stringify(sections) !== initialSectionsRef.current
+      JSON.stringify(sections) !== initialSectionsRef.current ||
+      settingsSnapshot() !== initialSettingsRef.current
     );
     if (warnForNew || warnForEdit) {
       setShowDiscardConfirm(true);
@@ -172,10 +194,16 @@ export function ChecklistBuilderModal({
   useEffect(() => {
     if (!onDirtyChange) return;
     const dirty = !savedId
-      ? !!(title.trim() || description.trim() || sections.some(s => s.name.trim() || s.questions.some(q => q.text.trim())))
-      : title !== initialTitleRef.current || description !== initialDescriptionRef.current || JSON.stringify(sections) !== initialSectionsRef.current;
+      ? hasContent
+      : (title !== initialTitleRef.current ||
+         description !== initialDescriptionRef.current ||
+         JSON.stringify(sections) !== initialSectionsRef.current ||
+         settingsSnapshot() !== initialSettingsRef.current);
     onDirtyChange(dirty);
-  }, [title, description, sections, savedId, onDirtyChange]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [title, description, sections, startDate, schedule, customRecurrence,
+      visibilityWindowEnabled, visibilityFrom, visibilityUntil,
+      locationMode, selectedLocationIds, savedId, onDirtyChange]);
 
   useEffect(() => {
     if (insertDropdown === null) return;
@@ -412,6 +440,7 @@ export function ChecklistBuilderModal({
       initialTitleRef.current = title;
       initialDescriptionRef.current = description;
       initialSectionsRef.current = JSON.stringify(sections);
+      initialSettingsRef.current = settingsSnapshot();
       onDirtyChange?.(false);
       setLastPublishedAt(new Date());
       toast.success(isFirstPublish ? "Checklist published!" : "Changes saved!");


### PR DESCRIPTION
## Summary

Closes #539

### Root cause

\`handleRequestClose\` and the \`onDirtyChange\` effect compared only \`title\`, \`description\`, and \`sections\`. All other payload fields — \`startDate\`, \`schedule\`, \`customRecurrence\`, \`visibilityWindowEnabled\`, \`visibilityFrom\`, \`visibilityUntil\`, \`locationMode\`, \`selectedLocationIds\` — were completely invisible to the dirty check. Changing any of these and clicking Exit (or a nav tab) silently discarded the changes with no warning.

### Fix

- **\`settingsSnapshot()\`** — a small inline helper that serialises all non-text fields into one comparable JSON string (sorted \`selectedLocationIds\` for stable comparison)
- **\`initialSettingsRef\`** — snapped at mount alongside the existing \`initialTitle/Description/SectionsRef\`; reset to \`settingsSnapshot()\` after each successful publish
- **\`hasContent\`** — now also returns \`true\` if \`startDate\` is set, \`schedule !== "none"\`, \`visibilityWindowEnabled\`, or \`locationMode === "specific"\`; covers new-checklist dirty detection for settings
- **\`handleRequestClose\` \`warnForEdit\`** — includes \`settingsSnapshot() !== initialSettingsRef.current\`
- **\`onDirtyChange\` effect** — deps extended to include all settings state variables; dirty computation uses \`settingsSnapshot()\` for the edit-mode branch

## Test plan

- [ ] Edit a checklist, change start date only → click Exit → discard dialog appears ✓
- [ ] Edit a checklist, change schedule only → click sidebar tab → discard dialog appears ✓
- [ ] Edit a checklist, toggle visibility window → click Exit → discard dialog appears ✓
- [ ] Edit a checklist, change locations → click Exit → discard dialog appears ✓
- [ ] Publish changes → click sidebar tab → no dialog (clean) ✓
- [ ] Edit, change settings, Publish, change settings again → click Exit → dialog appears ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)