### PR TITLE
Fix discard popup for Checklists tab click — intercept same-route nav at DOM level

### DIFF
--- a/src/pages/checklists/ChecklistsTab.tsx
+++ b/src/pages/checklists/ChecklistsTab.tsx
@@ -165,24 +165,35 @@ export function ChecklistsTab({ onBuilderTitleChange }: { onBuilderTitleChange?:
     onBuilderTitleChange?.(null);
   }, [onBuilderTitleChange]);
 
-  // Show a discard-confirm when the user clicks any nav tab while the builder has unsaved changes.
-  // useBlocker handles cross-route navigation; this state handles same-route (Checklists tab) clicks.
+  // Show a discard-confirm when the user navigates away with unsaved changes.
+  // We use two complementary mechanisms:
+  //   1. A capture-phase click listener intercepts same-route nav clicks (Checklists tab) that
+  //      React Router treats as no-ops and therefore never triggers useBlocker for.
+  //   2. useBlocker handles genuine cross-route navigation (Dashboard, Admin, etc.).
   const [showNavExitConfirm, setShowNavExitConfirm] = useState(false);
   const location = useLocation();
-  const prevLocationKeyRef = useRef(location.key);
-  useEffect(() => {
-    if (prevLocationKeyRef.current === location.key) return;
-    prevLocationKeyRef.current = location.key;
-    if (!showBuilder) return;
-    // Read from ref — always the live value, never stale from a render closure
-    if (isBuilderDirtyRef.current) {
-      setShowNavExitConfirm(true);
-    } else {
-      discardAndClose();
-    }
-  }, [location.key, showBuilder, discardAndClose]);
 
-  // Function form so the router always reads the live ref value, not a render-time snapshot
+  useEffect(() => {
+    if (!showBuilder) return;
+    const handleNavClick = (e: MouseEvent) => {
+      const anchor = (e.target as HTMLElement).closest("a[href]") as HTMLAnchorElement | null;
+      if (!anchor) return;
+      const href = anchor.getAttribute("href") ?? "";
+      // Only intercept internal same-route links — cross-route is handled by useBlocker
+      if (!href.startsWith("/") || href !== location.pathname) return;
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      if (isBuilderDirtyRef.current) {
+        setShowNavExitConfirm(true);
+      } else {
+        discardAndClose();
+      }
+    };
+    window.addEventListener("click", handleNavClick, true);
+    return () => window.removeEventListener("click", handleNavClick, true);
+  }, [showBuilder, location.pathname, discardAndClose]);
+
+  // useBlocker handles cross-route navigation; reads from ref so the check is always current
   const blocker = useBlocker(() => showBuilder && isBuilderDirtyRef.current);
 
   // Warn the browser when the user tries to leave the tab/app entirely while the builder has unsaved changes


### PR DESCRIPTION
## Summary

Closes #541

### Root cause

React Router v6.30 treats a \`NavLink\` click to the **current pathname** as a no-op — it neither pushes to history nor invokes the \`useBlocker\` callback. So clicking the Checklists tab while in the builder never changed \`location.key\` and never fired the blocker, regardless of dirty state.

### Fix

While the builder is open, a **capture-phase \`click\` listener** on \`window\` watches for clicks on internal anchors whose \`href\` matches the current pathname:

- **Dirty**: \`preventDefault()\` + \`stopImmediatePropagation()\` → show discard dialog (React Router never sees the click)  
- **Clean**: \`preventDefault()\` + \`discardAndClose()\` (navigating to the same route is a no-op anyway, so preventing it is harmless)

Cross-route navigation (Dashboard, Admin, etc.) still goes through React Router and is handled by \`useBlocker(() => showBuilder && isBuilderDirtyRef.current)\`, which fires correctly for genuine route transitions.

## Test plan

- [ ] In builder with unsaved changes → click Checklists sidebar tab → discard dialog appears ✓
- [ ] In builder with unsaved changes → click Dashboard tab → discard dialog appears (via useBlocker) ✓
- [ ] In builder, Publish → click Checklists sidebar tab → builder closes, no dialog ✓
- [ ] In builder with unsaved changes → change start date only → click Checklists tab → discard dialog ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)