### PR TITLE
Add email-based fallback for invite acceptance

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -78,27 +78,50 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       return;
     }
 
-    // Step 3: First-time invite acceptance — token stored in localStorage by AcceptInvite page
+    // Step 3: Invite acceptance.
+    // Prefer the token AcceptInvite.tsx stashes in localStorage right before the
+    // OTP round trip, but that token only survives if the same browser/tab/app
+    // completes the whole flow — it's lost across devices, across an in-app
+    // browser hop (WhatsApp, etc.), or if the invitee signs in via /login or
+    // /signup instead of /accept-invite. So always fall back to resolving any
+    // open invite by the caller's own email (accept_invite with no token) —
+    // this makes acceptance work no matter how the invitee got here.
     const pendingInviteToken = localStorage.getItem("olia_pending_invite_token");
-    if (pendingInviteToken) {
-      localStorage.removeItem("olia_pending_invite_token");
-      const { data: acceptResult } = await supabase.rpc("accept_invite", {
-        p_token: pendingInviteToken,
-      });
-      if (acceptResult?.success) {
-        const { data: linked } = await supabase
-          .from("team_members")
-          .select("*")
-          .eq("auth_user_id", userId)
-          .single();
-        if (linked) {
-          setTeamMember(linked as TeamMemberProfile);
-          setLoading(false);
-          supabase.from("team_members").update({ last_seen_at: new Date().toISOString() }).eq("auth_user_id", userId);
-          return;
-        }
+    if (pendingInviteToken) localStorage.removeItem("olia_pending_invite_token");
+
+    let acceptResult: { success?: boolean } | null = null;
+    try {
+      if (pendingInviteToken) {
+        const { data } = await supabase.rpc("accept_invite", { p_token: pendingInviteToken });
+        acceptResult = data;
       }
-      // Token was invalid or email mismatch — fall through to show setupError below
+      if (!acceptResult?.success) {
+        const { data } = await supabase.rpc("accept_invite");
+        acceptResult = data;
+      }
+    } catch (err) {
+      // A network/RPC failure here should not crash the whole lookup — treat
+      // it as "no invite found" and fall through to the branches below.
+      console.error("[AuthContext] accept_invite RPC threw:", err);
+      acceptResult = null;
+    }
+
+    if (acceptResult?.success) {
+      const { data: linked } = await supabase
+        .from("team_members")
+        .select("*")
+        .eq("auth_user_id", userId)
+        .single();
+      if (linked) {
+        setTeamMember(linked as TeamMemberProfile);
+        setLoading(false);
+        supabase.from("team_members").update({ last_seen_at: new Date().toISOString() }).eq("auth_user_id", userId);
+        return;
+      }
+    }
+
+    if (pendingInviteToken) {
+      // A token was present but neither it nor an email-based match worked.
       setSetupError(
         "Your invitation link is invalid or has already been used. Please ask your admin to send a new invitation.",
       );
@@ -106,6 +129,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setLoading(false);
       return;
     }
+    // No token and no open invite for this email — fall through to Step 4
+    // (treat as a brand-new owner signup).
 
     // Step 4: Row does not exist — resolve setup data for new owner signup
     let businessName: string | undefined;

--- a/src/test/contexts/AuthContext.extended.test.tsx
+++ b/src/test/contexts/AuthContext.extended.test.tsx
@@ -188,7 +188,11 @@ describe("AuthContext extended — RPC error path", () => {
   });
 
   it("sets setupError when setup_new_organization RPC throws", async () => {
-    mockRpc.mockRejectedValueOnce(new Error("RPC function not found"));
+    // Keyed by function name since accept_invite (invite fallback) runs first.
+    mockRpc.mockImplementation(async (fn: string) => {
+      if (fn === "setup_new_organization") throw new Error("RPC function not found");
+      return { data: {}, error: null };
+    });
 
     localStorage.setItem(
       "olia_pending_onboarding",
@@ -217,7 +221,13 @@ describe("AuthContext extended — RPC error path", () => {
   it("sets setupError when setup_new_organization RPC returns an error object (non-throwing)", async () => {
     // Supabase JS v2 returns { data: null, error: {...} } for PostgreSQL RAISE EXCEPTION — it does NOT throw.
     // Before this fix, the error was silently ignored and the re-fetch returned null with no setupError set.
-    mockRpc.mockResolvedValueOnce({ data: null, error: { message: "duplicate key value violates unique constraint" } });
+    // Keyed by function name since accept_invite (invite fallback) runs first.
+    mockRpc.mockImplementation(async (fn: string) => {
+      if (fn === "setup_new_organization") {
+        return { data: null, error: { message: "duplicate key value violates unique constraint" } };
+      }
+      return { data: {}, error: null };
+    });
 
     localStorage.setItem(
       "olia_pending_onboarding",
@@ -248,21 +258,27 @@ describe("AuthContext extended — RPC error path", () => {
     );
 
     // RPC now returns the team_member row directly — no re-fetch needed.
-    mockRpc.mockResolvedValueOnce({
-      data: {
-        team_member: {
-          id: "user-ok",
-          organization_id: "org-ok",
-          name: "Happy User",
-          email: "happy@test.com",
-          role: "Owner",
-          location_ids: [],
-          permissions: {},
-          pin_reset_required: false,
-        },
-        existed: false,
-      },
-      error: null,
+    // Keyed by function name since accept_invite (invite fallback) runs first.
+    mockRpc.mockImplementation(async (fn: string) => {
+      if (fn === "setup_new_organization") {
+        return {
+          data: {
+            team_member: {
+              id: "user-ok",
+              organization_id: "org-ok",
+              name: "Happy User",
+              email: "happy@test.com",
+              role: "Owner",
+              location_ids: [],
+              permissions: {},
+              pin_reset_required: false,
+            },
+            existed: false,
+          },
+          error: null,
+        };
+      }
+      return { data: {}, error: null };
     });
 
     const { result } = renderHook(() => useAuth(), { wrapper });
@@ -318,7 +334,10 @@ describe("AuthContext extended — missing ownerName branch", () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.setupError).toMatch(/could not be completed safely/i);
     expect(result.current.teamMember).toBeNull();
-    expect(mockRpc).not.toHaveBeenCalled();
+    // accept_invite is always tried first (email-based invite fallback), but
+    // setup_new_organization must never be reached without an owner name.
+    expect(mockRpc).toHaveBeenCalledWith("accept_invite");
+    expect(mockRpc).not.toHaveBeenCalledWith("setup_new_organization", expect.anything());
   });
 });
 
@@ -414,6 +433,132 @@ describe("AuthContext extended — malformed localStorage JSON", () => {
       p_business_name: "Meta Corp",
       p_owner_name: "Meta User",
     });
+  });
+});
+
+describe("AuthContext extended — invite acceptance fallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authStateCallback = null;
+    teamMemberRow = null;
+    mockOnAuthStateChange.mockImplementation((callback) => {
+      authStateCallback = callback;
+      callback("INITIAL_SESSION", null);
+      return { data: { subscription: { unsubscribe: vi.fn() } } };
+    });
+    localStorage.clear();
+  });
+
+  it("links the team member via the localStorage token when present", async () => {
+    localStorage.setItem("olia_pending_invite_token", "token-abc");
+    mockRpc.mockImplementation(async (fn: string, args?: Record<string, unknown>) => {
+      if (fn === "accept_invite" && args?.p_token === "token-abc") {
+        return { data: { success: true }, error: null };
+      }
+      return { data: {}, error: null };
+    });
+    mockTeamMemberSingle
+      .mockResolvedValueOnce({ data: null, error: null }) // Step 1: by id
+      .mockResolvedValueOnce({ data: null, error: null }) // Step 2: by auth_user_id
+      .mockResolvedValueOnce({
+        data: {
+          id: "tm-1",
+          organization_id: "org-1",
+          name: "Bárbara",
+          email: "barbara@example.com",
+          role: "Manager",
+          location_ids: [],
+          permissions: {},
+        },
+        error: null,
+      }); // re-fetch after accept_invite success
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      authStateCallback?.("SIGNED_IN", { user: { id: "user-invited", user_metadata: {} } });
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.teamMember?.name).toBe("Bárbara");
+    expect(result.current.setupError).toBeNull();
+    expect(localStorage.getItem("olia_pending_invite_token")).toBeNull();
+    expect(mockRpc).toHaveBeenCalledWith("accept_invite", { p_token: "token-abc" });
+  });
+
+  it("links the team member by email when no localStorage token exists (cross-device/cross-browser acceptance)", async () => {
+    // No olia_pending_invite_token set — e.g. invitee signed in via /login
+    // or on a different device than the one that opened /accept-invite.
+    mockRpc.mockImplementation(async (fn: string) => {
+      if (fn === "accept_invite") return { data: { success: true }, error: null };
+      return { data: {}, error: null };
+    });
+    mockTeamMemberSingle
+      .mockResolvedValueOnce({ data: null, error: null }) // Step 1
+      .mockResolvedValueOnce({ data: null, error: null }) // Step 2
+      .mockResolvedValueOnce({
+        data: {
+          id: "tm-2",
+          organization_id: "org-2",
+          name: "Bárbara",
+          email: "barbara@example.com",
+          role: "Manager",
+          location_ids: [],
+          permissions: {},
+        },
+        error: null,
+      });
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      authStateCallback?.("SIGNED_IN", { user: { id: "user-cross-device", user_metadata: {} } });
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.teamMember?.name).toBe("Bárbara");
+    expect(result.current.setupError).toBeNull();
+    expect(mockRpc).toHaveBeenCalledWith("accept_invite");
+  });
+
+  it("sets a specific setupError when the localStorage token exists but neither it nor the email match", async () => {
+    localStorage.setItem("olia_pending_invite_token", "stale-token");
+    mockRpc.mockResolvedValue({ data: { success: false, reason: "Invalid or expired invite token" }, error: null });
+    mockTeamMemberSingle.mockResolvedValue({ data: null, error: null });
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      authStateCallback?.("SIGNED_IN", { user: { id: "user-stale", user_metadata: {} } });
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.setupError).toMatch(/invitation link is invalid/i);
+    expect(result.current.teamMember).toBeNull();
+  });
+
+  it("falls through to Step 4 without crashing when accept_invite throws", async () => {
+    mockRpc.mockImplementation(async (fn: string) => {
+      if (fn === "accept_invite") throw new Error("network error");
+      return { data: {}, error: null };
+    });
+    mockTeamMemberSingle.mockResolvedValue({ data: null, error: null });
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      authStateCallback?.("SIGNED_IN", { user: { id: "user-rpc-down", user_metadata: {} } });
+    });
+
+    // No pending onboarding data either — should fail closed via Step 4,
+    // not hang or throw an unhandled rejection.
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.setupError).toMatch(/could not be completed safely/i);
+    expect(result.current.teamMember).toBeNull();
   });
 });
 

--- a/src/test/contexts/AuthContext.test.tsx
+++ b/src/test/contexts/AuthContext.test.tsx
@@ -173,7 +173,9 @@ describe("AuthContext", () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.setupError).toMatch(/could not be completed safely/i);
     expect(result.current.teamMember).toBeNull();
-    expect(mockRpc).not.toHaveBeenCalled();
+    // accept_invite is always tried first (email-based invite fallback), but
+    // setup_new_organization must never be reached without onboarding data.
+    expect(mockRpc).not.toHaveBeenCalledWith("setup_new_organization", expect.anything());
   });
 
   it("uses stored onboarding data when creating the org for a fresh sign-in", async () => {
@@ -184,22 +186,28 @@ describe("AuthContext", () => {
 
     // No existing row — triggers setup.
     mockTeamMemberSingle.mockResolvedValue({ data: null, error: null });
-    // RPC returns the team_member row directly (no re-fetch needed).
-    mockRpc.mockResolvedValueOnce({
-      data: {
-        team_member: {
-          id: "user-1",
-          organization_id: "org-new-1",
-          name: "Sarah Johnson",
-          email: "sarah@acme.com",
-          role: "Owner",
-          location_ids: [],
-          permissions: {},
-          pin_reset_required: true,
-        },
-        existed: false,
-      },
-      error: null,
+    // RPC returns the team_member row directly (no re-fetch needed). Keyed by
+    // function name since accept_invite (invite fallback) is called first.
+    mockRpc.mockImplementation(async (fn: string) => {
+      if (fn === "setup_new_organization") {
+        return {
+          data: {
+            team_member: {
+              id: "user-1",
+              organization_id: "org-new-1",
+              name: "Sarah Johnson",
+              email: "sarah@acme.com",
+              role: "Owner",
+              location_ids: [],
+              permissions: {},
+              pin_reset_required: true,
+            },
+            existed: false,
+          },
+          error: null,
+        };
+      }
+      return { data: {}, error: null };
     });
 
     const { result } = renderHook(() => useAuth(), { wrapper });

--- a/supabase/migrations/20260728000001_accept_invite_by_email_fallback.sql
+++ b/supabase/migrations/20260728000001_accept_invite_by_email_fallback.sql
@@ -1,0 +1,79 @@
+-- ================================================================
+-- Invite acceptance: server-side email fallback
+--
+-- Problem: accept_invite() previously required the token that
+-- AcceptInvite.tsx stashes in localStorage right before the OTP round
+-- trip. That token only survives if the same browser/tab/app completes
+-- the whole flow — it's lost if the invitee switches devices, switches
+-- out of an in-app browser (WhatsApp, etc.), or simply signs in via
+-- /login or /signup instead of clicking through /accept-invite. When
+-- the token is missing, AuthContext had no way to find the pending
+-- invite at all and fell straight to "treat as brand-new owner",
+-- producing a confusing "account data not found" error for a real
+-- invitee.
+--
+-- Fix: make p_token optional. When omitted, resolve the invite by the
+-- authenticated caller's own email address instead — this makes
+-- acceptance work regardless of which page/device/browser the invitee
+-- ends up authenticating from.
+-- ================================================================
+
+CREATE OR REPLACE FUNCTION public.accept_invite(p_token UUID DEFAULT NULL)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_caller_id    UUID := auth.uid();
+  v_caller_email TEXT;
+  v_invite       RECORD;
+BEGIN
+  IF v_caller_id IS NULL THEN
+    RETURN json_build_object('success', false, 'reason', 'Not authenticated');
+  END IF;
+
+  SELECT email INTO v_caller_email FROM auth.users WHERE id = v_caller_id;
+
+  IF p_token IS NOT NULL THEN
+    SELECT i.id, i.team_member_id, tm.email AS tm_email
+    INTO   v_invite
+    FROM   team_member_invites i
+    JOIN   team_members         tm ON tm.id = i.team_member_id
+    WHERE  i.token       = p_token
+      AND  i.accepted_at IS NULL
+      AND  i.expires_at  > now();
+
+    IF NOT FOUND THEN
+      RETURN json_build_object('success', false, 'reason', 'Invalid or expired invite token');
+    END IF;
+
+    -- Prevent one user from accepting another user's invite
+    IF lower(v_caller_email) != lower(v_invite.tm_email) THEN
+      RETURN json_build_object('success', false, 'reason', 'Email mismatch');
+    END IF;
+  ELSE
+    -- Fallback: most recent open invite for this email, regardless of token.
+    SELECT i.id, i.team_member_id, tm.email AS tm_email
+    INTO   v_invite
+    FROM   team_member_invites i
+    JOIN   team_members         tm ON tm.id = i.team_member_id
+    WHERE  lower(i.email)  = lower(v_caller_email)
+      AND  i.accepted_at IS NULL
+      AND  i.expires_at  > now()
+    ORDER BY i.created_at DESC
+    LIMIT 1;
+
+    IF NOT FOUND THEN
+      RETURN json_build_object('success', false, 'reason', 'No pending invite found for this email');
+    END IF;
+  END IF;
+
+  UPDATE team_members        SET auth_user_id = v_caller_id WHERE id = v_invite.team_member_id;
+  UPDATE team_member_invites SET accepted_at  = now()       WHERE id = v_invite.id;
+
+  RETURN json_build_object('success', true);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.accept_invite(UUID) TO authenticated;


### PR DESCRIPTION
## Summary
- `accept_invite(p_token)`'s token param is now optional — when omitted it resolves the caller's most recent open invite by their own authenticated email instead of by token
- `AuthContext.fetchTeamMember` always tries the localStorage token first (if present), then falls back to the email-based lookup, before treating a first-time sign-in as a brand-new owner signup
- Wrapped in try/catch so an RPC failure degrades to "no invite found" instead of crashing the lookup

This fixes the root architectural fragility behind the "Your account data was not found" error a real invitee could hit: the old flow only recognized an invite via a token stashed in localStorage right before the OTP round trip, which is lost across devices, in-app browser hops (WhatsApp, etc.), or if the invitee uses /login or /signup instead of /accept-invite.

Migration `20260728000001_accept_invite_by_email_fallback.sql` already applied to prod and smoke-tested via curl (anon caller correctly gets `{"success":false,"reason":"Not authenticated"}` for both the token and no-token call shapes, confirming the new optional-param signature deployed cleanly).

Fixes #546

## Test plan
- [x] `bun run lint` — 0 errors
- [x] `bun run test` on AuthContext.test.tsx + AuthContext.extended.test.tsx — 26/26 pass, including 4 new tests covering: token-based linking, email-fallback linking (no token), stale-token error message, and graceful handling of an RPC throw
- [x] Migration applied to prod via `supabase db push`, RPC smoke-tested via curl against prod