### PR TITLE
feat: wire audit log — reads from DB, writes on every admin action (#548)

### DIFF
--- a/src/hooks/useAuditLog.ts
+++ b/src/hooks/useAuditLog.ts
@@ -1,0 +1,55 @@
+import { useQuery } from "@tanstack/react-query";
+import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/contexts/AuthContext";
+
+export interface AuditLogRow {
+  id: string;
+  action: string;
+  entity_type: string | null;
+  entity_id: string | null;
+  details: Record<string, any> | null;
+  created_at: string;
+  actor_name: string | null;
+}
+
+export function useAuditLog() {
+  const { teamMember } = useAuth();
+  return useQuery({
+    queryKey: ["audit_log", teamMember?.organization_id ?? null],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("audit_log")
+        .select("id, action, entity_type, entity_id, details, created_at, performed_by:team_members(name)")
+        .order("created_at", { ascending: false })
+        .limit(50);
+      if (error) throw error;
+      return ((data ?? []) as any[]).map((row) => ({
+        id: row.id as string,
+        action: row.action as string,
+        entity_type: (row.entity_type ?? null) as string | null,
+        entity_id: (row.entity_id ?? null) as string | null,
+        details: (row.details ?? null) as Record<string, any> | null,
+        created_at: row.created_at as string,
+        actor_name: (row.performed_by?.name ?? null) as string | null,
+      })) as AuditLogRow[];
+    },
+    enabled: !!teamMember?.organization_id,
+  });
+}
+
+/** Fire-and-forget audit write. Never throws — failures are silent by design. */
+export function writeAuditLog(
+  entry: { action: string; entity_type: string; entity_id?: string | null; details?: Record<string, any> },
+  member: { id: string; organization_id: string },
+) {
+  try {
+    void supabase.from("audit_log").insert({
+      organization_id: member.organization_id,
+      performed_by: member.id,
+      action: entry.action,
+      entity_type: entry.entity_type,
+      entity_id: entry.entity_id ?? null,
+      details: entry.details ?? null,
+    });
+  } catch { /* audit writes are non-critical and must not break any caller */ }
+}

--- a/src/hooks/useStaffProfiles.ts
+++ b/src/hooks/useStaffProfiles.ts
@@ -2,6 +2,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/contexts/AuthContext";
 import type { StaffProfile } from "@/lib/admin-repository";
+import { writeAuditLog } from "@/hooks/useAuditLog";
 
 /** Hash a raw PIN using SHA-256 via the Web Crypto API. */
 export async function hashPin(raw: string): Promise<string> {
@@ -73,6 +74,11 @@ export function useSaveStaffProfile() {
         if (sp.rawPin) {
           await supabase.rpc("vault_staff_pin", { p_profile_id: sp.id, p_pin: sp.rawPin });
         }
+        writeAuditLog(
+          { action: "update_staff_profile", entity_type: "staff_profile", entity_id: sp.id,
+            details: { first_name: sp.first_name, last_name: sp.last_name, role: sp.role } },
+          teamMember,
+        );
       } else {
         // ── Creating a new profile: explicit INSERT ─────────────────────────
         if (!sp.rawPin) {
@@ -93,6 +99,11 @@ export function useSaveStaffProfile() {
         const newId = inserted?.[0]?.id as string | undefined;
         if (newId) {
           await supabase.rpc("vault_staff_pin", { p_profile_id: newId, p_pin: sp.rawPin });
+          writeAuditLog(
+            { action: "create_staff_profile", entity_type: "staff_profile", entity_id: newId,
+              details: { first_name: sp.first_name, last_name: sp.last_name, role: sp.role } },
+            teamMember,
+          );
         }
       }
     },
@@ -102,6 +113,7 @@ export function useSaveStaffProfile() {
 
 export function useArchiveStaffProfile() {
   const qc = useQueryClient();
+  const { teamMember } = useAuth();
   return useMutation({
     mutationFn: async (id: string) => {
       // Use .select("id") so we can detect the silent 0-row case (RLS blocked
@@ -115,6 +127,7 @@ export function useArchiveStaffProfile() {
       if (!updated || updated.length === 0) {
         throw new Error("Could not archive this profile. Please refresh and try again.");
       }
+      if (teamMember) writeAuditLog({ action: "archive_staff_profile", entity_type: "staff_profile", entity_id: id }, teamMember);
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ["staff_profiles"] }),
   });
@@ -122,6 +135,7 @@ export function useArchiveStaffProfile() {
 
 export function useRestoreStaffProfile() {
   const qc = useQueryClient();
+  const { teamMember } = useAuth();
   return useMutation({
     mutationFn: async (id: string) => {
       const { data: updated, error } = await supabase
@@ -133,6 +147,7 @@ export function useRestoreStaffProfile() {
       if (!updated || updated.length === 0) {
         throw new Error("Could not restore this profile. Please refresh and try again.");
       }
+      if (teamMember) writeAuditLog({ action: "restore_staff_profile", entity_type: "staff_profile", entity_id: id }, teamMember);
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ["staff_profiles"] }),
   });
@@ -140,10 +155,12 @@ export function useRestoreStaffProfile() {
 
 export function useDeleteStaffProfile() {
   const qc = useQueryClient();
+  const { teamMember } = useAuth();
   return useMutation({
     mutationFn: async (id: string) => {
       const { error } = await supabase.from("staff_profiles").delete().eq("id", id);
       if (error) throw error;
+      if (teamMember) writeAuditLog({ action: "delete_staff_profile", entity_type: "staff_profile", entity_id: id }, teamMember);
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ["staff_profiles"] }),
   });

--- a/src/hooks/useTeamMembers.ts
+++ b/src/hooks/useTeamMembers.ts
@@ -3,6 +3,7 @@ import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/contexts/AuthContext";
 import type { TeamMember, ManagerPermissions } from "@/lib/admin-repository";
 import { DEFAULT_PERMISSIONS, getInitials } from "@/lib/admin-repository";
+import { writeAuditLog } from "@/hooks/useAuditLog";
 
 export function useTeamMembers() {
   const { teamMember } = useAuth();
@@ -63,6 +64,11 @@ export function useSaveTeamMember() {
         if (!updated || updated.length === 0) {
           throw new Error("Account update failed. Please refresh the page and try again.");
         }
+        writeAuditLog(
+          { action: "update_team_member", entity_type: "team_member", entity_id: tm.id,
+            details: { name: tm.name, role: tm.role } },
+          teamMember,
+        );
         return;
       }
 
@@ -85,7 +91,15 @@ export function useSaveTeamMember() {
         .select("id")
         .single();
       if (error) throw error;
-      return inserted?.id as string | undefined;
+      const newId = inserted?.id as string | undefined;
+      if (newId) {
+        writeAuditLog(
+          { action: "create_team_member", entity_type: "team_member", entity_id: newId,
+            details: { name: tm.name, role: tm.role } },
+          teamMember,
+        );
+      }
+      return newId;
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ["team_members"] }),
   });
@@ -116,6 +130,7 @@ export function useSaveAdminPin() {
 
 export function useDeleteTeamMember() {
   const qc = useQueryClient();
+  const { teamMember } = useAuth();
   return useMutation({
     mutationFn: async (id: string) => {
       const { data: deleted, error } = await supabase.from("team_members").delete().eq("id", id).select("id");
@@ -123,6 +138,7 @@ export function useDeleteTeamMember() {
       if (!deleted || deleted.length === 0) {
         throw new Error("Could not remove this team member. Please refresh and try again.");
       }
+      if (teamMember) writeAuditLog({ action: "delete_team_member", entity_type: "team_member", entity_id: id }, teamMember);
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ["team_members"] }),
   });

--- a/src/lib/admin-repository.ts
+++ b/src/lib/admin-repository.ts
@@ -102,11 +102,12 @@ export interface TeamMember {
 
 export interface AuditLogEntry {
   id: string;
-  user: string;
   action: string;
-  location_id: string | null;
-  location_name: string | null;
-  timestamp: string;
+  entity_type: string | null;
+  entity_id: string | null;
+  details: Record<string, any> | null;
+  created_at: string;
+  actor_name: string | null;
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -5,10 +5,10 @@ import { MapPin, ArrowLeft } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
   type Location, type StaffProfile, type TeamMember, type ManagerPermissions,
-  type AuditLogEntry,
   staffDisplayName, getInitials,
 } from "@/lib/admin-repository";
 import { useAuth } from "@/contexts/AuthContext";
+import { useAuditLog } from "@/hooks/useAuditLog";
 import { usePlan, useSaveActiveLocationsSelection } from "@/hooks/usePlan";
 import { PLAN_LABELS, PLAN_PRICES, PLAN_FEATURES } from "@/lib/plan-features";
 import { useLocations, useSaveLocation, useDeleteLocation } from "@/hooks/useLocations";
@@ -98,7 +98,7 @@ export default function Admin() {
   // Local state (not persisted to DB yet)
   const { departments, setDepartments } = useDepartments();
   const staffRoleOptions = departments.map(d => d.name);
-  const auditLog: AuditLogEntry[] = [];
+  const { data: auditLog = [] } = useAuditLog();
 
   // UI state
   const routeTab: "location" | "users" | "account" | "billing" | "notifications" =

--- a/src/pages/admin/AccountTab.tsx
+++ b/src/pages/admin/AccountTab.tsx
@@ -11,10 +11,11 @@ import { Switch } from "@/components/ui/switch";
 import { toast } from "@/components/ui/sonner";
 import {
   type Location, type StaffProfile, type TeamMember, type ManagerPermissions,
-  type AuditLogEntry, type StaffDepartment,
+  type StaffDepartment,
   DEFAULT_ADMIN_PIN, DEFAULT_PERMISSIONS,
   getInitials, daysAgoTooltip,
 } from "@/lib/admin-repository";
+import type { AuditLogRow } from "@/hooks/useAuditLog";
 import { usePlan } from "@/hooks/usePlan";
 import { PLAN_LABELS, PLAN_PRICES } from "@/lib/plan-features";
 import { useIsNativeApp } from "@/hooks/useIsNativeApp";
@@ -34,7 +35,7 @@ export interface AccountTabProps {
   onSaveAccount: (member: Partial<TeamMember> & { id: string; rawPin?: string }) => Promise<unknown>;
   departments: StaffDepartment[];
   setDepartments: React.Dispatch<React.SetStateAction<StaffDepartment[]>>;
-  auditLog: AuditLogEntry[];
+  auditLog: AuditLogRow[];
   authAccount: TeamMember | null;
   authMemberId: string | undefined;
   authUserEmail: string | undefined;
@@ -57,6 +58,25 @@ export interface AccountTabProps {
   onDeleteMember: (m: TeamMember) => void;
   /** Which section to display. Defaults to showing all (legacy). */
   section?: "account" | "locations" | "users" | "billing";
+}
+
+const ACTION_LABELS: Record<string, string> = {
+  create_staff_profile: "Added staff member",
+  update_staff_profile: "Updated staff member",
+  archive_staff_profile: "Archived staff member",
+  restore_staff_profile: "Restored staff member",
+  delete_staff_profile: "Deleted staff member",
+  create_team_member: "Added team member",
+  update_team_member: "Updated team member",
+  delete_team_member: "Removed team member",
+};
+
+function formatAuditAction(action: string, details: Record<string, any> | null): string {
+  const label = ACTION_LABELS[action] ?? action.replace(/_/g, " ");
+  const name = details?.first_name
+    ? `${details.first_name} ${details.last_name ?? ""}`.trim()
+    : (details?.name ?? null);
+  return name ? `${label}: ${name}` : label;
 }
 
 export function AccountTab({
@@ -867,6 +887,30 @@ export function AccountTab({
               </button>
             )}
           </div>
+        </div>
+      </section>}
+
+      {/* Activity log */}
+      {show("account") && <section>
+        <p className="section-label mb-3">Activity log</p>
+        <div className="card-surface divide-y divide-border">
+          {auditLog.length === 0 ? (
+            <p className="px-4 py-4 text-sm text-muted-foreground">No activity recorded yet.</p>
+          ) : (
+            auditLog.map(entry => (
+              <div key={entry.id} className="px-4 py-3 flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="text-sm text-foreground truncate">{formatAuditAction(entry.action, entry.details)}</p>
+                  {entry.actor_name && (
+                    <p className="text-xs text-muted-foreground mt-0.5">{entry.actor_name}</p>
+                  )}
+                </div>
+                <p className="text-xs text-muted-foreground shrink-0">
+                  {new Date(entry.created_at).toLocaleDateString("en-GB", { day: "numeric", month: "short", hour: "2-digit", minute: "2-digit" })}
+                </p>
+              </div>
+            ))
+          )}
         </div>
       </section>}
 

--- a/src/pages/checklists/ChecklistsTab.tsx
+++ b/src/pages/checklists/ChecklistsTab.tsx
@@ -89,7 +89,7 @@ export function ChecklistsTab({ onBuilderTitleChange }: { onBuilderTitleChange?:
     });
   };
 
-  // Local drag-drop order state (visual only — no DB ordering column yet)
+  // Local drag-drop order state — mirrors DB sort_order, persisted via useReorderFolders on drop
   const [folderOrder, setFolderOrder] = useState<string[]>([]);
   useEffect(() => { setFolderOrder(dbFolders.map(f => f.id)); }, [dbFolders]);
 

--- a/src/test/hooks/useStaffProfiles.test.tsx
+++ b/src/test/hooks/useStaffProfiles.test.tsx
@@ -143,7 +143,8 @@ describe("useSaveStaffProfile — INSERT (new profile)", () => {
       } as any);
     });
 
-    expect(insertFn).toHaveBeenCalledTimes(1);
+    // insertFn is called twice: once for staff_profiles, once for audit_log (fire-and-forget)
+    expect(insertFn).toHaveBeenCalledTimes(2);
     const payload = insertFn.mock.calls[0][0];
     // Pin must be stored hashed, not as the raw "1234"
     expect(payload.pin).toBeTruthy();


### PR DESCRIPTION
## Summary

- New `useAuditLog` hook reads last 50 entries from `audit_log` table with actor name join
- `writeAuditLog` fire-and-forget utility (never throws — audit writes are non-critical)
- Writes added to all staff profile mutations (create/update/archive/restore/delete) and team member mutations (create/update/delete)
- `AccountTab` now shows a live **Activity log** section — was accepting the prop but not rendering it
- `AuditLogEntry` interface updated to match actual DB schema
- Fixed stale comment in `ChecklistsTab` claiming drag-to-reorder was "visual only"

## Test plan

- [x] `bun run lint` — 0 errors
- [x] `bun run test` — 1320 tests pass
- [ ] Manual: create/edit/delete a staff profile → confirm entry appears in Admin → Account → Activity log

Closes #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)