### PR TITLE
Stop telling invited users to create a new account on setup failure

### DIFF
--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -11,7 +11,11 @@ export function ProtectedRoute({ children }: { children: React.ReactNode }) {
   // <Navigate to="/login"> before this redirect can happen.
   useEffect(() => {
     if (setupError) {
-      navigate("/signup?reason=account-reset", { replace: true });
+      // Carry the specific reason through so Signup.tsx can show accurate
+      // copy instead of a generic message that tells every failure mode
+      // (including a broken invite) to "create a new account".
+      const detail = encodeURIComponent(setupError);
+      navigate(`/signup?reason=account-reset&detail=${detail}`, { replace: true });
       void signOut();
     }
   }, [setupError, navigate, signOut]);

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -20,6 +20,13 @@ export default function Signup() {
   const [searchParams] = useSearchParams();
   const accountReset = searchParams.get("reason") === "account-reset";
   const accountDeleted = searchParams.get("reason") === "account-deleted";
+  const resetDetail = searchParams.get("detail");
+  // Invite failures must never tell the user to "create a new account" — doing
+  // so creates an unrelated new organisation instead of joining the one they
+  // were invited to. Detect this case from the specific setupError reason
+  // (see AuthContext's accept_invite failure message) and show a distinct
+  // recovery path instead of the generic signup form.
+  const isInviteFailure = accountReset && !!resetDetail && /invit/i.test(resetDetail);
   const { user } = useAuth();
   const [step, setStep] = useState<Step>("form");
   const [businessName, setBusinessName] = useState("");
@@ -156,6 +163,28 @@ export default function Signup() {
     }
   };
 
+  if (isInviteFailure) {
+    return (
+      <div className="min-h-screen bg-background flex flex-col items-center justify-center px-6 py-12 text-center">
+        <div className="w-full max-w-sm space-y-4">
+          <img src="/brand/logo/olia-app-icon.svg" alt="Olia" className="w-14 h-14 mx-auto" />
+          <h1 className="font-display text-2xl text-foreground">We couldn't verify your invitation</h1>
+          <p className="text-sm text-muted-foreground leading-relaxed">{resetDetail}</p>
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            Ask the person who invited you to resend it from Admin → Users, then open the new link they send —
+            or try signing in again if you've accepted an invite before.
+          </p>
+          <Link
+            to="/login"
+            className="inline-block text-sm text-sage font-medium underline underline-offset-2"
+          >
+            Sign in instead
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
   if (step === "code") {
     return (
       <div className="min-h-screen bg-background flex flex-col items-center justify-center px-6">
@@ -243,11 +272,15 @@ export default function Signup() {
   return (
     <div className="min-h-screen bg-background flex flex-col items-center justify-center px-6 py-12">
       <div className="w-full max-w-sm space-y-8">
-        {/* Account-reset notice — shown when redirected from a broken auth state */}
+        {/* Account-reset notice — shown when redirected from a broken auth state.
+            isInviteFailure returns its own screen above, so this only covers
+            genuine setup failures (e.g. a new owner's org creation didn't finish). */}
         {accountReset && (
           <div className="rounded-xl bg-status-warn/10 border border-status-warn/20 px-4 py-3 text-sm text-foreground leading-relaxed">
-            <p className="font-medium mb-0.5">Your account data was not found.</p>
-            <p className="text-muted-foreground text-xs">Please create a new account to get started.</p>
+            <p className="font-medium mb-0.5">Your account setup didn't finish.</p>
+            <p className="text-muted-foreground text-xs">
+              {resetDetail ?? "Please create your account again to get started."}
+            </p>
           </div>
         )}
 

--- a/src/test/components/ProtectedRoute.test.tsx
+++ b/src/test/components/ProtectedRoute.test.tsx
@@ -1,5 +1,5 @@
 import { screen, render } from "@testing-library/react";
-import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { MemoryRouter, Routes, Route, useLocation } from "react-router-dom";
 import { ProtectedRoute } from "@/components/ProtectedRoute";
 import { renderWithProviders } from "../test-utils";
 
@@ -81,5 +81,29 @@ describe("ProtectedRoute", () => {
     expect(screen.queryByText("Protected content")).not.toBeInTheDocument();
     expect(screen.queryByText("Signup screen")).toBeInTheDocument();
     expect(mockSignOut).toHaveBeenCalled();
+  });
+
+  it("carries the setupError reason through as a URL-encoded detail param", () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: "user-1" },
+      loading: false,
+      setupError: "Your invitation link is invalid or has already been used.",
+      signOut: vi.fn().mockResolvedValue(undefined),
+    });
+    function SignupProbe() {
+      return <p>search:{useLocation().search}</p>;
+    }
+    render(
+      <MemoryRouter initialEntries={["/dashboard"]}>
+        <Routes>
+          <Route path="/dashboard" element={<ProtectedRoute><p>Protected content</p></ProtectedRoute>} />
+          <Route path="/signup" element={<SignupProbe />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(screen.getByText(/reason=account-reset/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/detail=Your%20invitation%20link%20is%20invalid/),
+    ).toBeInTheDocument();
   });
 });

--- a/src/test/pages/Signup.test.tsx
+++ b/src/test/pages/Signup.test.tsx
@@ -377,3 +377,51 @@ describe("Signup page — account-deleted guard", () => {
     expect(mockNavigate).not.toHaveBeenCalledWith("/admin", expect.anything());
   });
 });
+
+describe("Signup page — invite failure vs generic setup failure", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAuth.mockReturnValue({ user: null, session: null, teamMember: null, loading: false, signOut: vi.fn() });
+  });
+
+  it("shows a dedicated invite-recovery screen instead of the signup form when the reason is invite-related", () => {
+    const detail = encodeURIComponent(
+      "Your invitation link is invalid or has already been used. Please ask your admin to send a new invitation.",
+    );
+    render(
+      <MemoryRouter initialEntries={[`/signup?reason=account-reset&detail=${detail}`]} future={routerFutureFlags}>
+        <Signup />
+      </MemoryRouter>
+    );
+    expect(screen.getByText("We couldn't verify your invitation")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Your invitation link is invalid or has already been used/i),
+    ).toBeInTheDocument();
+    // Must never suggest creating a new account — that creates an unrelated org.
+    expect(screen.queryByText(/Create your account/i)).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Sign in instead/i })).toHaveAttribute("href", "/login");
+  });
+
+  it("shows the generic setup-failure banner (and the signup form) for a non-invite reason", () => {
+    const detail = encodeURIComponent("Your account setup is not complete. Please refresh the page and try again.");
+    render(
+      <MemoryRouter initialEntries={[`/signup?reason=account-reset&detail=${detail}`]} future={routerFutureFlags}>
+        <Signup />
+      </MemoryRouter>
+    );
+    expect(screen.getByText("Your account setup didn't finish.")).toBeInTheDocument();
+    expect(screen.getByText("Your account setup is not complete. Please refresh the page and try again.")).toBeInTheDocument();
+    // The signup form should still be usable — this genuinely is the correct recovery path.
+    expect(screen.getByText("Create your account")).toBeInTheDocument();
+  });
+
+  it("falls back to default copy when no detail param is present", () => {
+    render(
+      <MemoryRouter initialEntries={["/signup?reason=account-reset"]} future={routerFutureFlags}>
+        <Signup />
+      </MemoryRouter>
+    );
+    expect(screen.getByText("Your account setup didn't finish.")).toBeInTheDocument();
+    expect(screen.getByText("Please create your account again to get started.")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- ProtectedRoute now passes the specific `setupError` reason through as a URL-encoded `detail` param when redirecting to `/signup?reason=account-reset`
- Signup.tsx shows a dedicated "We couldn't verify your invitation" recovery screen for invite-related failures (ask the inviter to resend, or sign in again) instead of the generic create-account form — creating a new account there would spin up an unrelated org
- Non-invite setup failures still show the signup form (genuinely the right recovery) with more accurate copy and the specific reason surfaced

Fixes #552

## Test plan
- [x] `bun run lint` — 0 errors
- [x] New tests: ProtectedRoute passes the encoded detail param; Signup shows the invite-recovery screen for invite reasons and the (updated) generic form otherwise
- [x] Full suite: `bun run test` — 1324/1324 pass