### PR TITLE
Point first-time invitees back to their invite instead of a dead end

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -26,7 +26,12 @@ function isMissingAccount(message: string | null | undefined) {
 
 function getFriendlyAuthError(message: string | null | undefined) {
   if (isMissingAccount(message)) {
-    return "No Olia account was found for that email yet. Please create one first.";
+    // A first-time invitee lands here if they sign in before ever accepting
+    // their invite (no auth account exists yet). Point them back to the
+    // invite email rather than just "create one" — creating a new account
+    // here would spin up an unrelated organisation instead of joining the
+    // team they were invited to.
+    return "No Olia account was found for that email yet. If someone invited you to their team, use the invite link from that email instead — or create your own account below.";
   }
 
   return message ?? "Something went wrong. Please try again.";

--- a/src/test/pages/Login.test.tsx
+++ b/src/test/pages/Login.test.tsx
@@ -169,7 +169,9 @@ describe("Login page", () => {
 
     await waitFor(() => {
       expect(screen.getByText(/No Olia account was found/i)).toBeInTheDocument();
-      expect(screen.getByText(/create one first/i)).toBeInTheDocument();
+      // Points invitees back to their invite email instead of just "create one" —
+      // creating a new account here would spin up an unrelated organisation.
+      expect(screen.getByText(/use the invite link from that email instead/i)).toBeInTheDocument();
       expect(screen.queryByText(/signups not allowed for otp/i)).not.toBeInTheDocument();
     });
   });


### PR DESCRIPTION
## Summary
Login.tsx's "no account found" message for a first-time invitee now points back to the invite email instead of suggesting generic signup (which would create an unrelated org). Keeps `shouldCreateUser: false` — only the copy changes.

Fixes #556

## Test plan
- [x] `bun run test -- src/test/pages/Login.test.tsx` — 8/8 pass (updated assertion for new copy)
- [x] `bun run test` full suite — 1325/1325 pass
- [x] `bun run lint` — 0 errors