### PR TITLE
Show expired invites instead of letting them vanish from Users tab

### DIFF
--- a/src/hooks/useTeamMembers.ts
+++ b/src/hooks/useTeamMembers.ts
@@ -149,11 +149,14 @@ export function useTeamMemberInvites() {
   return useQuery({
     queryKey: ["team_member_invites", teamMember?.organization_id ?? null],
     queryFn: async () => {
+      // No expires_at filter here — an expired-but-unaccepted invite still
+      // needs to show up (as "expired", with a resend option) rather than
+      // silently vanishing from the Users tab with no way to tell "expired"
+      // from "never invited".
       const { data, error } = await supabase
         .from("team_member_invites")
         .select("id, team_member_id, email, accepted_at, expires_at, created_at")
         .is("accepted_at", null)
-        .gt("expires_at", new Date().toISOString())
         .order("created_at", { ascending: false });
       if (error) throw error;
       return (data ?? []) as { id: string; team_member_id: string; email: string; accepted_at: string | null; expires_at: string; created_at: string }[];

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -390,7 +390,9 @@ export default function Admin() {
               onDeleteLocation: deleteLocation,
               onSaveActiveLocations: (locationIds: any) => saveActiveLocationsMut.mutateAsync(locationIds),
               savingActiveLocations: saveActiveLocationsMut.isPending,
-              pendingInviteIds: new Set(pendingInvites.map(i => i.team_member_id)),
+              pendingInviteStatus: new Map(
+                pendingInvites.map(i => [i.team_member_id, new Date(i.expires_at) <= new Date()]),
+              ),
               onInviteMember: () => setMemberModal("new"),
               onEditMember: (m: any) => setMemberModal(m),
               onDeleteMember: deleteMember,

--- a/src/pages/admin/AccountTab.tsx
+++ b/src/pages/admin/AccountTab.tsx
@@ -52,7 +52,8 @@ export interface AccountTabProps {
   onDeleteLocation: (id: string) => void;
   onSaveActiveLocations: (locationIds: string[]) => Promise<unknown>;
   savingActiveLocations: boolean;
-  pendingInviteIds: Set<string>;
+  /** team_member_id -> whether their outstanding invite has expired */
+  pendingInviteStatus: Map<string, boolean>;
   onInviteMember: () => void;
   onEditMember: (m: TeamMember) => void;
   onDeleteMember: (m: TeamMember) => void;
@@ -84,7 +85,7 @@ export function AccountTab({
   onSaveAccount, departments, setDepartments, auditLog, authAccount, authMemberId, authUserEmail, authUserName,
   billingUnavailable, locationLimit, isLocationOverLimit, locationGraceEndsAt, isGraceActive, isGraceExpired,
   onAddLocation, onLocationLimitReached, onEditLocation, onDeleteLocation, onSaveActiveLocations, savingActiveLocations,
-  pendingInviteIds, onInviteMember, onEditMember, onDeleteMember, section,
+  pendingInviteStatus, onInviteMember, onEditMember, onDeleteMember, section,
 }: AccountTabProps) {
   const navigate = useNavigate();
   const { plan, planStatus, isActive } = usePlan();
@@ -660,6 +661,8 @@ export function AccountTab({
           {[...teamMembers].sort((a, b) => a.role === "Owner" ? -1 : b.role === "Owner" ? 1 : 0).map(member => {
             const isExpanded = expandedMemberId === member.id;
             const mp = pendingPerms[member.id] ?? member.permissions;
+            const inviteExpired = pendingInviteStatus.get(member.id);
+            const hasPendingInvite = inviteExpired !== undefined;
             return (
               <div key={member.id}>
                 <div className="flex items-center gap-3 px-4 py-3">
@@ -669,10 +672,10 @@ export function AccountTab({
                   <div className="flex-1 min-w-0">
                     <p className="text-sm font-medium text-foreground">{member.name}</p>
                     <p className="text-xs text-muted-foreground">{member.email}</p>
-                    {pendingInviteIds.has(member.id) ? (
-                      <p className="text-xs text-status-warn flex items-center gap-1">
+                    {hasPendingInvite ? (
+                      <p className={cn("text-xs flex items-center gap-1", inviteExpired ? "text-muted-foreground" : "text-status-warn")}>
                         <MailCheck size={11} />
-                        Invite pending
+                        {inviteExpired ? "Invite expired" : "Invite pending"}
                       </p>
                     ) : member.last_seen_at ? (
                       <p className="text-xs text-muted-foreground/60" title={daysAgoTooltip(member.last_seen_at)}>
@@ -686,7 +689,7 @@ export function AccountTab({
                   )}>
                     {member.role}
                   </span>
-                  {pendingInviteIds.has(member.id) && (
+                  {hasPendingInvite && (
                     <button
                       onClick={() => {
                         sendInvite.mutate(member.id, {

--- a/src/test/pages/Admin.test.tsx
+++ b/src/test/pages/Admin.test.tsx
@@ -119,6 +119,9 @@ const { mockSaveTeamMember } = vi.hoisted(() => ({
     mutateAsync: vi.fn().mockResolvedValue({}),
   },
 }));
+const { mockUseTeamMemberInvites } = vi.hoisted(() => ({
+  mockUseTeamMemberInvites: vi.fn(() => ({ data: [] as unknown[], isLoading: false })),
+}));
 mockUseLocations.mockReturnValue({
   data: mockLocations,
   allLocations: mockLocations,
@@ -151,7 +154,7 @@ vi.mock("@/hooks/useTeamMembers", () => ({
   useSaveTeamMember: () => mockSaveTeamMember,
   useDeleteTeamMember: () => ({ mutate: vi.fn() }),
   useSaveAdminPin: () => ({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false }),
-  useTeamMemberInvites: () => ({ data: [], isLoading: false }),
+  useTeamMemberInvites: () => mockUseTeamMemberInvites(),
   useSendInvite: () => ({ mutate: vi.fn(), mutateAsync: vi.fn().mockResolvedValue({}), isPending: false }),
 }));
 
@@ -408,6 +411,62 @@ describe("Admin page", () => {
     await waitFor(() => {
       expect(screen.getAllByText("Sarah Owner").length).toBeGreaterThanOrEqual(1);
       expect(screen.getAllByText("Mike Manager").length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  // 23a. Users tab distinguishes a pending invite from an expired one
+  describe("Users tab — pending vs expired invite status", () => {
+    afterEach(() => {
+      // renderWithProviders re-renders across async data loads, so a plain
+      // hook mock (not *Once) must be used and reset back to the file's
+      // default afterward or later tests in this suite lose their invites.
+      mockUseTeamMemberInvites.mockReturnValue({ data: [], isLoading: false });
+    });
+
+    it("shows 'Invite expired' (not 'pending') for a past-due invite, with resend still available", async () => {
+      mockUseTeamMemberInvites.mockReturnValue({
+        data: [
+          {
+            id: "inv-expired",
+            team_member_id: "tm2",
+            email: "mike@example.com",
+            accepted_at: null,
+            expires_at: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+            created_at: new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString(),
+          },
+        ],
+        isLoading: false,
+      });
+      renderWithProviders(<Admin />, { initialEntries: ["/admin/users"] });
+
+      await waitFor(() => {
+        expect(screen.getByText("Invite expired")).toBeInTheDocument();
+      });
+      expect(screen.queryByText("Invite pending")).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /Resend invite to Mike Manager/i })).toBeInTheDocument();
+    });
+
+    it("shows 'Invite pending' for an outstanding, non-expired invite", async () => {
+      mockUseTeamMemberInvites.mockReturnValue({
+        data: [
+          {
+            id: "inv-pending",
+            team_member_id: "tm2",
+            email: "mike@example.com",
+            accepted_at: null,
+            expires_at: new Date(Date.now() + 6 * 24 * 60 * 60 * 1000).toISOString(),
+            created_at: new Date().toISOString(),
+          },
+        ],
+        isLoading: false,
+      });
+      renderWithProviders(<Admin />, { initialEntries: ["/admin/users"] });
+
+      await waitFor(() => {
+        expect(screen.getByText("Invite pending")).toBeInTheDocument();
+      });
+      expect(screen.queryByText("Invite expired")).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /Resend invite to Mike Manager/i })).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary
- `useTeamMemberInvites()` no longer filters out expired invites (still unaccepted-only)
- `pendingInviteIds: Set<string>` → `pendingInviteStatus: Map<string, boolean>` (team_member_id → isExpired)
- Users tab shows "Invite pending" vs "Invite expired" accurately; resend button available for both

Fixes #558

## Test plan
- [x] New tests: expired invite shows "Invite expired" + resend button; non-expired shows "Invite pending" + resend button
- [x] `bun run test -- src/test/pages/Admin.test.tsx` — 75/75 pass
- [x] Full suite: `bun run test` — 1327/1327 pass
- [x] `bun run lint` — 0 errors