### PR TITLE
Fix kiosk resetting to setup screen when the auth session expires

### DIFF
--- a/src/pages/Kiosk.tsx
+++ b/src/pages/Kiosk.tsx
@@ -126,8 +126,16 @@ export default function Kiosk() {
   const { user, teamMember, loading } = useAuth();
   const { allLocations = [], isFetched: locationsFetched } = useLocations();
 
-  const [locationId, setLocationId] = useState<string | null>(null);
-  const [locationName, setLocationName] = useState<string>("");
+  // Hydrate straight from localStorage on mount so a properly-configured
+  // kiosk keeps working even when there is no live auth session yet (or
+  // ever again) — see the ownership-tracking effect below for why the
+  // session's presence must not gate this.
+  const [locationId, setLocationId] = useState<string | null>(
+    () => localStorage.getItem("kiosk_location_id"),
+  );
+  const [locationName, setLocationName] = useState<string>(
+    () => localStorage.getItem("kiosk_location_name") ?? "",
+  );
   const [screen, setScreen] = useState<KioskScreen>("grid");
   const [selectedChecklist, setSelectedChecklist] = useState<KioskChecklist | null>(null);
   const [selectedStaffId, setSelectedStaffId] = useState<string | null>(null);
@@ -145,26 +153,23 @@ export default function Kiosk() {
   const [libraryMemberName, setLibraryMemberName] = useState("");
 
   useEffect(() => {
+    if (loading) return;
+
+    // No live auth session on this device. That's the normal state for a
+    // kiosk most of the time (it runs on the anon key), and it's also what
+    // a silently expired/failed-to-refresh JWT looks like (Safari ITP
+    // evicting localStorage after ~7 days with no top-level interaction, a
+    // long offline stretch, etc). The kiosk's location binding lives in
+    // kiosk_location_id/kiosk_token, independent of the auth session, so
+    // leave it alone here — only a genuinely re-authenticated owner whose
+    // account doesn't match the stored one (below) should ever reset it.
+    if (!user?.id) return;
+
     const ownerKey = "kiosk_owner_user_id";
     const ownerOrgKey = "kiosk_owner_org_id";
     const storedOwnerId = localStorage.getItem(ownerKey);
     const storedOwnerOrgId = localStorage.getItem(ownerOrgKey);
-    const hasStoredLocation = Boolean(_kioskLocationId ?? localStorage.getItem("kiosk_location_id"));
     const currentOrgId = teamMember?.organization_id ?? null;
-
-    if (loading) return;
-
-    if (!user?.id) {
-      if (storedOwnerId || hasStoredLocation) {
-        clearKioskLocationSelection();
-        clearKioskOwnership();
-        setLocationId(null);
-        setLocationName("");
-        setScreen("grid");
-        setKioskChecklists([]);
-      }
-      return;
-    }
 
     if (
       !storedOwnerId

--- a/src/test/pages/Kiosk.test.tsx
+++ b/src/test/pages/Kiosk.test.tsx
@@ -1,4 +1,4 @@
-import { screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { screen, fireEvent, waitFor, act, cleanup } from "@testing-library/react";
 import Kiosk, { ChecklistRunner } from "@/pages/Kiosk";
 import { renderWithProviders } from "../test-utils";
 
@@ -395,7 +395,8 @@ describe("Kiosk — Grid Screen", () => {
     expect(screen.getByText(/What's on the agenda/i)).toBeInTheDocument();
   });
 
-  it("clears stale kiosk location state when no kiosk owner is stored for the signed-in account", async () => {
+  it("clears stale kiosk location state when a signed-in owner has no kiosk owner stored yet", async () => {
+    mockUseAuth.mockReturnValue({ user: { id: "u1" }, teamMember: { organization_id: "org-1" }, session: null, loading: false, signOut: vi.fn() });
     localStorage.setItem("kiosk_location_id", "00000000-0000-0000-0000-000000000011");
     localStorage.setItem("kiosk_location_name", "Terrace");
     renderWithProviders(<Kiosk />);
@@ -408,7 +409,8 @@ describe("Kiosk — Grid Screen", () => {
     expect(localStorage.getItem("kiosk_location_name")).toBeNull();
   });
 
-  it("does not restore a stored kiosk location from another organization", async () => {
+  it("does not restore a stored kiosk location from another organization once a real owner signs in", async () => {
+    mockUseAuth.mockReturnValue({ user: { id: "u1" }, teamMember: { organization_id: "org-1" }, session: null, loading: false, signOut: vi.fn() });
     localStorage.setItem("kiosk_location_id", "foreign-location");
     localStorage.setItem("kiosk_location_name", "Little Fern Bakery");
     localStorage.setItem("kiosk_owner_user_id", "u1");
@@ -423,6 +425,25 @@ describe("Kiosk — Grid Screen", () => {
     expect(screen.queryByText("Little Fern Bakery")).not.toBeInTheDocument();
     expect(localStorage.getItem("kiosk_location_id")).toBeNull();
     expect(localStorage.getItem("kiosk_location_name")).toBeNull();
+  });
+
+  it("keeps a configured kiosk on the grid screen when the auth session disappears (session expiry, not a sign-out)", async () => {
+    // Simulates the bug Jay reported: the kiosk was configured while an owner
+    // was logged in, then the underlying Supabase session silently expired
+    // (JWT refresh failure, storage eviction, etc). Losing `user` must not
+    // wipe the kiosk's location binding — only a genuinely different signed-in
+    // owner should ever reset it.
+    await renderGridScreen();
+    expect(screen.getByText(/What's on the agenda/i)).toBeInTheDocument();
+    cleanup(); // simulate a full page reload, not just an in-app re-render
+
+    mockUseAuth.mockReturnValue({ user: null, teamMember: null, session: null, loading: false, signOut: vi.fn() });
+    renderWithProviders(<Kiosk />);
+
+    await screen.findByText(/What's on the agenda/i);
+    expect(screen.queryByText(/Select a location to launch/i)).not.toBeInTheDocument();
+    expect(localStorage.getItem("kiosk_location_id")).toBe("00000000-0000-0000-0000-000000000011");
+    expect(localStorage.getItem("kiosk_owner_user_id")).toBe("u1");
   });
 
   it("grid screen shows checklist cards for Terrace location", async () => {


### PR DESCRIPTION
## Summary
- The kiosk is meant to run fully unauthenticated (staff PIN validation, checklist fetching, and alert inserts all go through anon-key RPCs), but `Kiosk.tsx` tied its own location/ownership binding to the live Supabase auth session via `useAuth()`.
- Whenever that session silently disappeared — JWT refresh failure, Safari ITP purging localStorage after ~7 days without a top-level interaction, a long offline stretch — the kiosk wiped `kiosk_location_id`/`kiosk_token`/`kiosk_owner_*` and fell back to the setup screen, even though staff never had login credentials to begin with.
- `locationId`/`locationName` now hydrate from `localStorage` on mount regardless of auth state, and the ownership-tracking effect only resets kiosk config when a genuinely different **authenticated** owner shows up — never as a side effect of the session simply going away.

Fixes #562

## Test plan
- [x] `bun run vitest run src/test/pages/Kiosk.test.tsx` — 62/62 passing, including a new test proving a configured kiosk survives session loss across a simulated reload, and two rewritten tests that now correctly exercise the authenticated ownership-mismatch path they were meant to test
- [x] `bun run milestone` — lint, full test suite (1328 tests) + coverage thresholds, and production build all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)