### PR TITLE
Fix stale-chunk crash when clicking a notification after a deploy

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { queryClient } from "@/lib/query-client";
 import { AuthProvider } from "@/contexts/AuthContext";
 import { ProtectedRoute } from "@/components/ProtectedRoute";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { RouteErrorBoundary } from "@/components/RouteErrorBoundary";
 import { routerFutureFlags } from "@/lib/router-future-flags";
 import { CookieBanner } from "@/components/CookieBanner";
 
@@ -54,6 +55,7 @@ const router = createBrowserRouter(
   [
     {
       element: <RootLayout />,
+      errorElement: <RouteErrorBoundary />,
       children: [
         { path: "/", element: <Landing /> },
         { path: "/privacy", element: <Privacy /> },

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import { Component, ErrorInfo, ReactNode } from "react";
-import { AlertTriangle } from "lucide-react";
+import { ErrorFallbackCard } from "@/components/ErrorFallbackCard";
+import { isChunkLoadError } from "@/lib/chunk-error";
 
 interface Props {
   children: ReactNode;
@@ -34,12 +35,7 @@ export class ErrorBoundary extends Component<Props, State> {
     // while an old version of the app is still open in a browser tab.
     // Detect this and do one hard reload to pick up the new asset manifest.
     // A sessionStorage flag prevents an infinite reload loop.
-    const isChunkError =
-      error?.message?.includes("Failed to fetch dynamically imported module") ||
-      error?.message?.includes("Importing a module script failed") ||
-      error?.name === "ChunkLoadError";
-
-    if (isChunkError && !sessionStorage.getItem("chunk_reload_attempted")) {
+    if (isChunkLoadError(error) && !sessionStorage.getItem("chunk_reload_attempted")) {
       sessionStorage.setItem("chunk_reload_attempted", "1");
       window.location.reload();
     }
@@ -54,27 +50,7 @@ export class ErrorBoundary extends Component<Props, State> {
     if (this.state.hasError) {
       if (this.props.fallback) return this.props.fallback;
 
-      return (
-        <div className="min-h-screen bg-background flex items-center justify-center p-6">
-          <div className="bg-card border border-border rounded-2xl p-8 max-w-sm w-full text-center space-y-4 shadow-sm">
-            <div className="w-14 h-14 rounded-full bg-status-error/10 flex items-center justify-center mx-auto">
-              <AlertTriangle size={24} className="text-status-error" />
-            </div>
-            <div>
-              <h2 className="font-display text-xl text-foreground">Something went wrong</h2>
-              <p className="text-sm text-muted-foreground mt-2">
-                An unexpected error occurred. Try refreshing the page.
-              </p>
-            </div>
-            <button
-              onClick={this.handleReset}
-              className="w-full py-3 rounded-xl bg-sage text-white text-sm font-semibold hover:bg-sage-deep transition-colors"
-            >
-              Try again
-            </button>
-          </div>
-        </div>
-      );
+      return <ErrorFallbackCard onRetry={this.handleReset} />;
     }
 
     return this.props.children;

--- a/src/components/ErrorFallbackCard.tsx
+++ b/src/components/ErrorFallbackCard.tsx
@@ -1,0 +1,26 @@
+import { AlertTriangle } from "lucide-react";
+
+/** Shared recovery-screen UI for both the render-phase and route-level error boundaries. */
+export function ErrorFallbackCard({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center p-6">
+      <div className="bg-card border border-border rounded-2xl p-8 max-w-sm w-full text-center space-y-4 shadow-sm">
+        <div className="w-14 h-14 rounded-full bg-status-error/10 flex items-center justify-center mx-auto">
+          <AlertTriangle size={24} className="text-status-error" />
+        </div>
+        <div>
+          <h2 className="font-display text-xl text-foreground">Something went wrong</h2>
+          <p className="text-sm text-muted-foreground mt-2">
+            An unexpected error occurred. Try refreshing the page.
+          </p>
+        </div>
+        <button
+          onClick={onRetry}
+          className="w-full py-3 rounded-xl bg-sage text-white text-sm font-semibold hover:bg-sage-deep transition-colors"
+        >
+          Try again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/RouteErrorBoundary.tsx
+++ b/src/components/RouteErrorBoundary.tsx
@@ -1,0 +1,31 @@
+import { useRouteError } from "react-router-dom";
+import { ErrorFallbackCard } from "@/components/ErrorFallbackCard";
+import { isChunkLoadError } from "@/lib/chunk-error";
+
+/**
+ * `createBrowserRouter` catches render errors per-route internally and
+ * never lets them bubble up to a React error boundary wrapping
+ * `RouterProvider` — it needs its own `errorElement`. Without this, a
+ * stale-chunk failure (route lazy-import 404s after a new deploy) shows
+ * React Router's generic "Unexpected Application Error!" screen instead of
+ * the auto-reload recovery `ErrorBoundary` provides everywhere else.
+ */
+export function RouteErrorBoundary() {
+  const error = useRouteError();
+  console.error("[RouteErrorBoundary] Caught error:", error);
+
+  if (isChunkLoadError(error) && !sessionStorage.getItem("chunk_reload_attempted")) {
+    sessionStorage.setItem("chunk_reload_attempted", "1");
+    window.location.reload();
+    return null;
+  }
+
+  return (
+    <ErrorFallbackCard
+      onRetry={() => {
+        sessionStorage.removeItem("chunk_reload_attempted");
+        window.location.reload();
+      }}
+    />
+  );
+}

--- a/src/lib/chunk-error.ts
+++ b/src/lib/chunk-error.ts
@@ -1,0 +1,13 @@
+/**
+ * True when `error` is a lazy-loaded module chunk failing to fetch — the
+ * classic case of a browser tab left open across a deploy, still holding
+ * old asset-hash URLs that the new build no longer serves.
+ */
+export function isChunkLoadError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.includes("Failed to fetch dynamically imported module") ||
+    message.includes("Importing a module script failed") ||
+    (error instanceof Error && error.name === "ChunkLoadError")
+  );
+}

--- a/src/test/components/RouteErrorBoundary.test.tsx
+++ b/src/test/components/RouteErrorBoundary.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { RouteErrorBoundary } from "@/components/RouteErrorBoundary";
+
+const mockUseRouteError = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useRouteError: () => mockUseRouteError(),
+  };
+});
+
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  sessionStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("RouteErrorBoundary", () => {
+  it("reloads once on a chunk-load error instead of rendering the fallback", () => {
+    mockUseRouteError.mockReturnValue(new Error("Failed to fetch dynamically imported module: /assets/Notifications-abc123.js"));
+    const reloadSpy = vi.fn();
+    Object.defineProperty(window, "location", { value: { reload: reloadSpy }, writable: true });
+
+    render(<RouteErrorBoundary />);
+
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+    expect(sessionStorage.getItem("chunk_reload_attempted")).toBe("1");
+    expect(screen.queryByText("Something went wrong")).not.toBeInTheDocument();
+  });
+
+  it("does not reload again if a chunk error already triggered one this session", () => {
+    sessionStorage.setItem("chunk_reload_attempted", "1");
+    mockUseRouteError.mockReturnValue(new Error("Failed to fetch dynamically imported module: /assets/Notifications-abc123.js"));
+    const reloadSpy = vi.fn();
+    Object.defineProperty(window, "location", { value: { reload: reloadSpy }, writable: true });
+
+    render(<RouteErrorBoundary />);
+
+    expect(reloadSpy).not.toHaveBeenCalled();
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+  });
+
+  it("renders the fallback card for a non-chunk error", () => {
+    mockUseRouteError.mockReturnValue(new Error("Some other render error"));
+
+    render(<RouteErrorBoundary />);
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+  });
+
+  it("retry button reloads and clears the reload flag", () => {
+    sessionStorage.setItem("chunk_reload_attempted", "1");
+    mockUseRouteError.mockReturnValue(new Error("Some other render error"));
+    const reloadSpy = vi.fn();
+    Object.defineProperty(window, "location", { value: { reload: reloadSpy }, writable: true });
+
+    render(<RouteErrorBoundary />);
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+    expect(sessionStorage.getItem("chunk_reload_attempted")).toBeNull();
+  });
+});

--- a/src/test/lib/chunk-error.test.ts
+++ b/src/test/lib/chunk-error.test.ts
@@ -1,0 +1,26 @@
+import { isChunkLoadError } from "@/lib/chunk-error";
+
+describe("isChunkLoadError", () => {
+  it("matches 'Failed to fetch dynamically imported module' errors", () => {
+    expect(isChunkLoadError(new Error("Failed to fetch dynamically imported module: https://oliahq.com/assets/Notifications-kS2lyu6P.js"))).toBe(true);
+  });
+
+  it("matches 'Importing a module script failed' errors", () => {
+    expect(isChunkLoadError(new Error("Importing a module script failed"))).toBe(true);
+  });
+
+  it("matches errors named ChunkLoadError", () => {
+    const error = new Error("boom");
+    error.name = "ChunkLoadError";
+    expect(isChunkLoadError(error)).toBe(true);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(isChunkLoadError(new Error("Network request failed"))).toBe(false);
+  });
+
+  it("returns false for non-Error values", () => {
+    expect(isChunkLoadError("some string")).toBe(false);
+    expect(isChunkLoadError(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Root cause: `createBrowserRouter` (data router) catches route render errors internally and never lets them reach the `<ErrorBoundary>` wrapping `<RouterProvider>` unless a route defines `errorElement`. So the existing chunk-load auto-reload logic in `ErrorBoundary.tsx` never fired for route-level failures — users hit React Router's generic "Unexpected Application Error!" screen instead of an automatic reload.
- Added `RouteErrorBoundary` wired as `errorElement` on the root route, giving route-level failures (like a stale hashed chunk after a deploy) the same one-time auto-reload recovery as render-phase failures.
- Extracted `isChunkLoadError` (`src/lib/chunk-error.ts`) and the recovery UI (`src/components/ErrorFallbackCard.tsx`) so both boundaries share the same detection and fallback.

Fixes #564

## Test plan
- [x] `bun run lint` — no new errors
- [x] `bun run test` — 1336 tests pass (including new tests for `isChunkLoadError` and `RouteErrorBoundary`)
- [x] `bun run build` — production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)