### PR TITLE
Fix ivory flash in iOS Safari overscroll on new-design pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,9 @@
-import { Suspense, lazy } from "react";
+import { Suspense, lazy, useEffect } from "react";
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { createBrowserRouter, RouterProvider, Navigate, Outlet } from "react-router-dom";
+import { createBrowserRouter, RouterProvider, Navigate, Outlet, useLocation } from "react-router-dom";
 import { queryClient } from "@/lib/query-client";
 import { AuthProvider } from "@/contexts/AuthContext";
 import { ProtectedRoute } from "@/components/ProtectedRoute";
@@ -33,6 +33,16 @@ const Cookies = lazy(() => import("./pages/Cookies"));
 const AvisoLegal = lazy(() => import("./pages/AvisoLegal"));
 
 function RootLayout() {
+  const location = useLocation();
+
+  // iOS Safari paints the plain <body> background in the elastic-overscroll
+  // area above fixed content (and behind the notch/status bar with
+  // viewport-fit=cover) — keep it in sync with whichever design is showing
+  // instead of leaving it on the old app's default ivory.
+  useEffect(() => {
+    document.body.style.backgroundColor = isNewDesignPath(location.pathname) ? "#ffffff" : "";
+  }, [location.pathname]);
+
   return (
     <>
       <Outlet />


### PR DESCRIPTION
Closes #568

## Summary
- `body`'s background is set globally via `@apply bg-background` in `src/index.css`, which still resolves to the old app's ivory token
- On iOS Safari, the elastic-overscroll area above fixed content (and the area behind the notch/status bar with `viewport-fit=cover`) paints straight through to that `body` background — visible as a beige strip above the new white-design pages
- `RootLayout` now syncs `document.body`'s background to white/default based on the same `isNewDesignPath` check already used for `CookieBanner` and the route-loading fallback, so old-design pages are unaffected

## Test plan
- [x] `bun run lint` — 0 errors
- [x] `bun run build` — succeeds
- [x] Verified `document.body` background is white on `/` and `/login`
- [x] Verified `/dashboard` (unauthenticated → redirects to `/login`) also correctly resolves to white, not a stale old-design leftover

🤖 Generated with [Claude Code](https://claude.com/claude-code)