### PR TITLE
Keep a configured kiosk device locked to /kiosk, never landing/login

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,9 @@
-import { Suspense, lazy, useEffect } from "react";
+import { Suspense, lazy, useEffect, useLayoutEffect } from "react";
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { createBrowserRouter, RouterProvider, Navigate, Outlet, useLocation } from "react-router-dom";
+import { createBrowserRouter, RouterProvider, Navigate, Outlet, useLocation, useNavigate } from "react-router-dom";
 import { queryClient } from "@/lib/query-client";
 import { AuthProvider } from "@/contexts/AuthContext";
 import { ProtectedRoute } from "@/components/ProtectedRoute";
@@ -12,6 +12,7 @@ import { RouteErrorBoundary } from "@/components/RouteErrorBoundary";
 import { routerFutureFlags } from "@/lib/router-future-flags";
 import { CookieBanner } from "@/components/CookieBanner";
 import { isNewDesignPath } from "@/lib/legal-theme";
+import { shouldRedirectToKiosk } from "@/lib/kiosk-guard";
 
 const SundayRemixSite = lazy(() => import("./pages/experiments/SundayRemixSite"));
 const Dashboard = lazy(() => import("./pages/Dashboard"));
@@ -34,6 +35,7 @@ const AvisoLegal = lazy(() => import("./pages/AvisoLegal"));
 
 function RootLayout() {
   const location = useLocation();
+  const navigate = useNavigate();
 
   // iOS Safari paints the plain <body> background in the elastic-overscroll
   // area above fixed content (and behind the notch/status bar with
@@ -42,6 +44,14 @@ function RootLayout() {
   useEffect(() => {
     document.body.style.backgroundColor = isNewDesignPath(location.pathname) ? "#ffffff" : "";
   }, [location.pathname]);
+
+  // Runs before paint (see kiosk-guard.ts) so a configured kiosk device
+  // never actually flashes the landing/login page it's being redirected away from.
+  useLayoutEffect(() => {
+    if (shouldRedirectToKiosk(location.pathname, Boolean(localStorage.getItem("kiosk_location_id")))) {
+      navigate("/kiosk", { replace: true });
+    }
+  }, [location.pathname, navigate]);
 
   return (
     <>

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,10 +1,12 @@
 import { useEffect } from "react";
-import { Navigate, useNavigate } from "react-router-dom";
+import { Navigate, useLocation, useNavigate } from "react-router-dom";
 import { useAuth } from "@/contexts/AuthContext";
+import { hasActiveKioskAdminSession } from "@/lib/kiosk-admin-session";
 
 export function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { user, loading, setupError, signOut } = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
 
   // Navigate first, then sign out. Calling signOut first fires SIGNED_OUT
   // synchronously, which sets user=null and causes ProtectedRoute to render
@@ -19,6 +21,20 @@ export function ProtectedRoute({ children }: { children: React.ReactNode }) {
       void signOut();
     }
   }, [setupError, navigate, signOut]);
+
+  // A wall-mounted kiosk device intentionally keeps the setup admin's
+  // Supabase session alive (see kiosk-guard.ts) so its own PIN-gated hop
+  // into /admin (AdminLoginModal -> grantKioskAdminSession) can reach this
+  // protected route at all. Without this check, that same lingering session
+  // would let anyone at the kiosk reach /dashboard, /admin, etc. directly —
+  // no PIN, no credentials — just by navigating to the URL. Only the
+  // sanctioned PIN hop is allowed through; everything else on a configured
+  // kiosk device bounces back to /kiosk.
+  const isKioskDevice = Boolean(localStorage.getItem("kiosk_location_id"));
+  const isSanctionedKioskAdminHop = location.pathname.startsWith("/admin") && hasActiveKioskAdminSession();
+  if (isKioskDevice && !isSanctionedKioskAdminHop) {
+    return <Navigate to="/kiosk" replace />;
+  }
 
   if (loading) {
     return (

--- a/src/lib/kiosk-admin-session.ts
+++ b/src/lib/kiosk-admin-session.ts
@@ -1,0 +1,48 @@
+// The kiosk's "Admin PIN" flow (AdminLoginModal in src/pages/kiosk/PinEntryModal.tsx)
+// grants temporary elevated access to /admin from a device that otherwise runs
+// fully unauthenticated. This session token is the ONLY thing that's allowed to
+// stand in for real credentials on a kiosk device (see kiosk-guard.ts and
+// ProtectedRoute.tsx) — so it must survive exactly as long as intended and no
+// longer: it needs to keep working across the admin page's tab navigation
+// (which drops any "?from=kiosk" query param), but must not be reusable once
+// the grant expires or the admin explicitly leaves.
+
+const KIOSK_ADMIN_SESSION_KEY = "kiosk_admin_session";
+const DEFAULT_TTL_MS = 5 * 60 * 1000;
+
+interface KioskAdminSession {
+  userId: string;
+  locationId: string;
+  expiresAt: number;
+}
+
+export function grantKioskAdminSession(userId: string, locationId: string, ttlMs = DEFAULT_TTL_MS): void {
+  const session: KioskAdminSession = { userId, locationId, expiresAt: Date.now() + ttlMs };
+  sessionStorage.setItem(KIOSK_ADMIN_SESSION_KEY, JSON.stringify(session));
+}
+
+// Non-destructive: callers may read this repeatedly (e.g. on every re-render
+// after Admin.tsx's tab-switch remounts) without consuming the grant early.
+export function readKioskAdminSession(): KioskAdminSession | null {
+  const raw = sessionStorage.getItem(KIOSK_ADMIN_SESSION_KEY);
+  if (!raw) return null;
+  try {
+    const session = JSON.parse(raw) as Partial<KioskAdminSession>;
+    if (!session.userId || !session.locationId || !session.expiresAt || Date.now() >= session.expiresAt) {
+      sessionStorage.removeItem(KIOSK_ADMIN_SESSION_KEY);
+      return null;
+    }
+    return session as KioskAdminSession;
+  } catch {
+    sessionStorage.removeItem(KIOSK_ADMIN_SESSION_KEY);
+    return null;
+  }
+}
+
+export function hasActiveKioskAdminSession(): boolean {
+  return readKioskAdminSession() !== null;
+}
+
+export function clearKioskAdminSession(): void {
+  sessionStorage.removeItem(KIOSK_ADMIN_SESSION_KEY);
+}

--- a/src/lib/kiosk-guard.ts
+++ b/src/lib/kiosk-guard.ts
@@ -1,0 +1,15 @@
+// A device that has completed kiosk setup (kiosk_location_id present in
+// localStorage) must never surface the marketing/auth entry points. The
+// kiosk intentionally runs on the anon key (see Kiosk.tsx), but the admin
+// session used to configure it in the first place is left signed in on the
+// device — the in-kiosk Admin PIN flow (AdminLoginModal -> /admin?from=kiosk)
+// depends on that lingering session to work. If the browser ever ends up
+// back on "/" or "/login" (a hard refresh, a GitHub Pages 404 fallback
+// hiccup, etc.), that same lingering session lets anyone tap "Sign In" and
+// land straight in /admin with no credentials at all. Bouncing these routes
+// back to /kiosk keeps the only path into admin the PIN-gated one.
+const KIOSK_ESCAPE_ROUTES = new Set(["/", "/login", "/signup"]);
+
+export function shouldRedirectToKiosk(pathname: string, hasKioskLocation: boolean): boolean {
+  return hasKioskLocation && KIOSK_ESCAPE_ROUTES.has(pathname);
+}

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from "react";
-import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { Layout } from "@/components/Layout";
 import { MapPin, ArrowLeft } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -8,6 +8,7 @@ import {
   staffDisplayName, getInitials,
 } from "@/lib/admin-repository";
 import { useAuth } from "@/contexts/AuthContext";
+import { readKioskAdminSession, clearKioskAdminSession } from "@/lib/kiosk-admin-session";
 import { useAuditLog } from "@/hooks/useAuditLog";
 import { usePlan, useSaveActiveLocationsSelection } from "@/hooks/usePlan";
 import { PLAN_LABELS, PLAN_PRICES, PLAN_FEATURES } from "@/lib/plan-features";
@@ -38,33 +39,19 @@ import {
 export default function Admin() {
   const location = useLocation();
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
-  const fromKiosk = searchParams.get("from") === "kiosk";
   const { user, teamMember: authMember } = useAuth();
 
-  // Resolve the kiosk-authenticated userId from sessionStorage (one-time use token).
-  // If from=kiosk is in the URL but the token is missing or expired, redirect back to kiosk.
-  const [userId] = useState<string | null>(() => {
-    if (!fromKiosk) return null;
-    const raw = sessionStorage.getItem("kiosk_admin_session");
-    if (!raw) return null;
-    try {
-      const session = JSON.parse(raw) as { userId: string; locationId: string; expiresAt: number };
-      sessionStorage.removeItem("kiosk_admin_session");
-      if (!session.userId || Date.now() >= session.expiresAt) return null;
-      return session.userId;
-    } catch {
-      sessionStorage.removeItem("kiosk_admin_session");
-      return null;
-    }
-  });
-
-  // Redirect back to kiosk if session token was invalid or expired
-  useEffect(() => {
-    if (fromKiosk && userId === null) {
-      navigate("/kiosk", { replace: true });
-    }
-  }, [fromKiosk, userId, navigate]);
+  // Resolve the kiosk-authenticated userId from the shared session grant.
+  // Read once at mount (not from the "?from=kiosk" query param, which the
+  // tab-switcher below drops on every navigate) so the PIN-granted session —
+  // and the userId/permission scoping derived from it — survives switching
+  // between My Location / Users / Account / Billing / Notifications.
+  // ProtectedRoute already guarantees a kiosk device can't reach this page
+  // at all without a live grant, so there's no separate "invalid token"
+  // redirect to handle here.
+  const [kioskAdminSession] = useState(() => readKioskAdminSession());
+  const userId = kioskAdminSession?.userId ?? null;
+  const isKioskAdminSession = kioskAdminSession !== null;
   const { plan, billingUnavailable } = usePlan();
   const isNative = useIsNativeApp();
 
@@ -138,13 +125,17 @@ export default function Admin() {
   }, [isOwner, navigate, routeTab]);
   const permissions: ManagerPermissions | null = isOwner ? null : (activeUser?.permissions ?? null);
 
-  // Inactivity timer — when from kiosk, redirect back after 90s idle
+  // Inactivity timer — for a kiosk-PIN admin session, redirect back after 90s
+  // idle and revoke the grant so it can't be replayed by direct navigation.
   const inactivityTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
-    if (!fromKiosk) return;
+    if (!isKioskAdminSession) return;
     const reset = () => {
       if (inactivityTimerRef.current) clearTimeout(inactivityTimerRef.current);
-      inactivityTimerRef.current = setTimeout(() => navigate("/kiosk"), 90000);
+      inactivityTimerRef.current = setTimeout(() => {
+        clearKioskAdminSession();
+        navigate("/kiosk");
+      }, 90000);
     };
     const events = ["mousemove", "keydown", "touchstart", "click"] as const;
     events.forEach(e => window.addEventListener(e, reset));
@@ -153,7 +144,7 @@ export default function Admin() {
       events.forEach(e => window.removeEventListener(e, reset));
       if (inactivityTimerRef.current) clearTimeout(inactivityTimerRef.current);
     };
-  }, [fromKiosk, navigate]);
+  }, [isKioskAdminSession, navigate]);
 
   // Restrict manager to their first assigned location
   useEffect(() => {
@@ -325,9 +316,12 @@ export default function Admin() {
       <Layout
         title="Olia"
         subtitle={userLabel}
-        headerLeft={fromKiosk ? (
+        headerLeft={isKioskAdminSession ? (
           <button
-            onClick={() => navigate("/kiosk")}
+            onClick={() => {
+              clearKioskAdminSession();
+              navigate("/kiosk");
+            }}
             className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
           >
             <ArrowLeft size={14} /> Kiosk

--- a/src/pages/kiosk/PinEntryModal.tsx
+++ b/src/pages/kiosk/PinEntryModal.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils";
 import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/contexts/AuthContext";
 import { useLocations } from "@/hooks/useLocations";
+import { grantKioskAdminSession } from "@/lib/kiosk-admin-session";
 import type { KioskChecklist } from "./types";
 import { useInactivityTimer } from "./hooks";
 
@@ -230,11 +231,7 @@ export function AdminLoginModal({ onClose, kioskLocationId }: { onClose: () => v
       return;
     }
 
-    sessionStorage.setItem("kiosk_admin_session", JSON.stringify({
-      userId: data[0].id,
-      locationId: locationId,
-      expiresAt: Date.now() + 5 * 60 * 1000,
-    }));
+    grantKioskAdminSession(data[0].id, locationId);
     navigate("/admin?from=kiosk");
   };
 
@@ -283,11 +280,7 @@ export function AdminLoginModal({ onClose, kioskLocationId }: { onClose: () => v
         setLoading(false);
         if (rpcError) { setError(rpcError.message?.includes("Too many PIN attempts") ? "Too many failed attempts. Please wait 5 minutes before trying again." : "Could not verify PIN. Please try again."); setPin(""); return; }
         if (!data || data.length === 0) { setError("Invalid PIN."); setPin(""); return; }
-        sessionStorage.setItem("kiosk_admin_session", JSON.stringify({
-          userId: data[0].id,
-          locationId,
-          expiresAt: Date.now() + 5 * 60 * 1000,
-        }));
+        grantKioskAdminSession(data[0].id, locationId);
         navigate("/admin?from=kiosk");
       })();
     }

--- a/src/test/components/ProtectedRoute.test.tsx
+++ b/src/test/components/ProtectedRoute.test.tsx
@@ -1,6 +1,7 @@
 import { screen, render } from "@testing-library/react";
 import { MemoryRouter, Routes, Route, useLocation } from "react-router-dom";
 import { ProtectedRoute } from "@/components/ProtectedRoute";
+import { grantKioskAdminSession } from "@/lib/kiosk-admin-session";
 import { renderWithProviders } from "../test-utils";
 
 vi.mock("@/lib/supabase", () => ({
@@ -27,6 +28,11 @@ vi.mock("@/contexts/AuthContext", () => ({
 }));
 
 describe("ProtectedRoute", () => {
+  afterEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
   it("shows loading spinner text when loading=true", () => {
     mockUseAuth.mockReturnValue({ user: null, loading: true });
     renderWithProviders(
@@ -105,5 +111,68 @@ describe("ProtectedRoute", () => {
     expect(
       screen.getByText(/detail=Your%20invitation%20link%20is%20invalid/),
     ).toBeInTheDocument();
+  });
+
+  describe("on a configured kiosk device", () => {
+    beforeEach(() => {
+      localStorage.setItem("kiosk_location_id", "location-1");
+      // A lingering owner session is exactly what makes the kiosk's own PIN
+      // hop into /admin possible — and exactly what a direct-navigation
+      // exploit would otherwise ride on for every other protected route.
+      mockUseAuth.mockReturnValue({ user: { id: "owner-1" }, loading: false, setupError: null, signOut: vi.fn() });
+    });
+
+    it("redirects /dashboard back to /kiosk even though a live session exists", () => {
+      render(
+        <MemoryRouter initialEntries={["/dashboard"]}>
+          <Routes>
+            <Route path="/dashboard" element={<ProtectedRoute><p>Protected content</p></ProtectedRoute>} />
+            <Route path="/kiosk" element={<p>Kiosk screen</p>} />
+          </Routes>
+        </MemoryRouter>
+      );
+      expect(screen.queryByText("Protected content")).not.toBeInTheDocument();
+      expect(screen.getByText("Kiosk screen")).toBeInTheDocument();
+    });
+
+    it("redirects /admin/location back to /kiosk when there is no PIN-granted session", () => {
+      render(
+        <MemoryRouter initialEntries={["/admin/location"]}>
+          <Routes>
+            <Route path="/admin/location" element={<ProtectedRoute><p>Protected content</p></ProtectedRoute>} />
+            <Route path="/kiosk" element={<p>Kiosk screen</p>} />
+          </Routes>
+        </MemoryRouter>
+      );
+      expect(screen.queryByText("Protected content")).not.toBeInTheDocument();
+      expect(screen.getByText("Kiosk screen")).toBeInTheDocument();
+    });
+
+    it("lets /admin/location through with a live PIN-granted kiosk admin session", () => {
+      grantKioskAdminSession("staff-1", "location-1");
+      render(
+        <MemoryRouter initialEntries={["/admin/location"]}>
+          <Routes>
+            <Route path="/admin/location" element={<ProtectedRoute><p>Protected content</p></ProtectedRoute>} />
+            <Route path="/kiosk" element={<p>Kiosk screen</p>} />
+          </Routes>
+        </MemoryRouter>
+      );
+      expect(screen.getByText("Protected content")).toBeInTheDocument();
+    });
+
+    it("still redirects /dashboard to /kiosk even with a live PIN-granted session (PIN only ever authorizes /admin)", () => {
+      grantKioskAdminSession("staff-1", "location-1");
+      render(
+        <MemoryRouter initialEntries={["/dashboard"]}>
+          <Routes>
+            <Route path="/dashboard" element={<ProtectedRoute><p>Protected content</p></ProtectedRoute>} />
+            <Route path="/kiosk" element={<p>Kiosk screen</p>} />
+          </Routes>
+        </MemoryRouter>
+      );
+      expect(screen.queryByText("Protected content")).not.toBeInTheDocument();
+      expect(screen.getByText("Kiosk screen")).toBeInTheDocument();
+    });
   });
 });

--- a/src/test/lib/kiosk-admin-session.test.ts
+++ b/src/test/lib/kiosk-admin-session.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, afterEach, describe, it, expect, vi } from "vitest";
+import {
+  grantKioskAdminSession,
+  readKioskAdminSession,
+  hasActiveKioskAdminSession,
+  clearKioskAdminSession,
+} from "@/lib/kiosk-admin-session";
+
+beforeEach(() => {
+  sessionStorage.clear();
+});
+
+afterEach(() => {
+  sessionStorage.clear();
+  vi.useRealTimers();
+});
+
+describe("kiosk-admin-session", () => {
+  it("grants a session that reads back with the same userId and locationId", () => {
+    grantKioskAdminSession("user-1", "location-1");
+    expect(readKioskAdminSession()).toMatchObject({ userId: "user-1", locationId: "location-1" });
+    expect(hasActiveKioskAdminSession()).toBe(true);
+  });
+
+  it("reads are non-destructive — the grant survives repeated reads", () => {
+    grantKioskAdminSession("user-1", "location-1");
+    readKioskAdminSession();
+    readKioskAdminSession();
+    expect(readKioskAdminSession()).not.toBeNull();
+  });
+
+  it("reports no active session when nothing was ever granted", () => {
+    expect(readKioskAdminSession()).toBeNull();
+    expect(hasActiveKioskAdminSession()).toBe(false);
+  });
+
+  it("expires the grant after its TTL and clears the stored entry", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    grantKioskAdminSession("user-1", "location-1", 1000);
+
+    vi.setSystemTime(1500);
+    expect(readKioskAdminSession()).toBeNull();
+    expect(sessionStorage.getItem("kiosk_admin_session")).toBeNull();
+  });
+
+  it("treats a malformed stored value as no session and clears it", () => {
+    sessionStorage.setItem("kiosk_admin_session", "not-json");
+    expect(readKioskAdminSession()).toBeNull();
+    expect(sessionStorage.getItem("kiosk_admin_session")).toBeNull();
+  });
+
+  it("clearKioskAdminSession revokes an active grant", () => {
+    grantKioskAdminSession("user-1", "location-1");
+    clearKioskAdminSession();
+    expect(hasActiveKioskAdminSession()).toBe(false);
+  });
+});

--- a/src/test/lib/kiosk-guard.test.ts
+++ b/src/test/lib/kiosk-guard.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { shouldRedirectToKiosk } from "@/lib/kiosk-guard";
+
+describe("shouldRedirectToKiosk", () => {
+  it("redirects the landing page back to the kiosk once kiosk mode is configured", () => {
+    expect(shouldRedirectToKiosk("/", true)).toBe(true);
+  });
+
+  it("redirects /login back to the kiosk once kiosk mode is configured", () => {
+    expect(shouldRedirectToKiosk("/login", true)).toBe(true);
+  });
+
+  it("redirects /signup back to the kiosk once kiosk mode is configured", () => {
+    expect(shouldRedirectToKiosk("/signup", true)).toBe(true);
+  });
+
+  it("does not redirect when the device has no kiosk location configured", () => {
+    expect(shouldRedirectToKiosk("/", false)).toBe(false);
+    expect(shouldRedirectToKiosk("/login", false)).toBe(false);
+    expect(shouldRedirectToKiosk("/signup", false)).toBe(false);
+  });
+
+  it("does not redirect routes outside the escape set, even on a configured kiosk device", () => {
+    expect(shouldRedirectToKiosk("/kiosk", true)).toBe(false);
+    expect(shouldRedirectToKiosk("/privacy", true)).toBe(false);
+    expect(shouldRedirectToKiosk("/admin/location", true)).toBe(false);
+    expect(shouldRedirectToKiosk("/dashboard", true)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Reported by Dora: after the previous kiosk-refresh fix (#563), the kiosk still eventually falls back to the marketing landing page. From there, tapping "Sign In" goes straight to `/admin` with no credentials, because a kiosk device intentionally keeps the setup admin's Supabase session alive (the in-kiosk Admin PIN flow depends on it to reach `/admin?from=kiosk`).
- **Landing/login escape hatch**: Added `src/lib/kiosk-guard.ts`. Once `kiosk_location_id` is present in localStorage (device is a configured kiosk), `/`, `/login`, and `/signup` bounce straight back to `/kiosk`.
- **Direct-navigation escape hatch** (flagged as a follow-up in #574, now fixed here too): the same lingering session also granted full access to `/dashboard`, `/admin/location`, etc. to anyone who typed the URL directly, bypassing the PIN entirely. `ProtectedRoute` now blocks every protected route on a kiosk device except `/admin` while a PIN-granted kiosk admin session is active.
  - That session grant is pulled out of `Admin.tsx`/`PinEntryModal.tsx` into a shared `src/lib/kiosk-admin-session.ts`, because the old sessionStorage token was destructively consumed on first read. That meant the "Back to Kiosk" button, the 90s inactivity auto-return, and the manager's permission scoping all silently died the moment someone tapped a second admin tab (tab nav drops the `?from=kiosk` query param the old code relied on). The new grant is read non-destructively and survives tab switches, fixing that latent bug as part of closing the hole.

Fixes #574

## Test plan
- [x] `bun run test` — all 1352 unit tests pass, including new `kiosk-guard.test.ts`, `kiosk-admin-session.test.ts`, and expanded `ProtectedRoute.test.tsx` coverage
- [x] `bun run lint` — 0 errors (pre-existing warnings only, unrelated files)
- [x] `bun run build` — succeeds
- [ ] Manual: configure a kiosk, refresh on `/`, confirm it lands back on `/kiosk` instead of showing "Sign In"
- [ ] Manual: on a configured kiosk device, type `/dashboard` or `/admin/location` directly into the address bar — confirm it bounces to `/kiosk`
- [ ] Manual: enter the Admin PIN from the kiosk, confirm the "Back to Kiosk" button and tab switching (My Location → Users → Account → Billing) all still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)