### PR TITLE
Fix legal page deep links landing on the homepage on GitHub Pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,8 +11,23 @@ import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { RouteErrorBoundary } from "@/components/RouteErrorBoundary";
 import { routerFutureFlags } from "@/lib/router-future-flags";
 import { CookieBanner } from "@/components/CookieBanner";
+import { ThemePreviewToggle } from "@/components/ThemePreviewToggle";
 import { isNewDesignPath } from "@/lib/legal-theme";
 import { shouldRedirectToKiosk } from "@/lib/kiosk-guard";
+import { restoreGitHubPagesRoute } from "@/lib/github-pages-routing";
+
+// Must run before `createBrowserRouter` below reads window.location. GitHub
+// Pages' 404.html fallback redirects deep links (e.g. /privacy) to
+// `/?p=/privacy` before this module ever loads, so the router would otherwise
+// snapshot the wrong path and render the landing page instead.
+const restoredGitHubPagesPath = restoreGitHubPagesRoute(
+  window.location.search,
+  import.meta.env.BASE_URL,
+  window.location.hash,
+);
+if (restoredGitHubPagesPath) {
+  window.history.replaceState(null, "", restoredGitHubPagesPath);
+}
 
 const SundayRemixSite = lazy(() => import("./pages/experiments/SundayRemixSite"));
 const Dashboard = lazy(() => import("./pages/Dashboard"));
@@ -57,6 +72,7 @@ function RootLayout() {
     <>
       <Outlet />
       <CookieBanner />
+      {import.meta.env.DEV && !isNewDesignPath(location.pathname) && <ThemePreviewToggle />}
     </>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,24 +10,13 @@ import { StatusBar, Style } from "@capacitor/status-bar";
 import { SplashScreen } from "@capacitor/splash-screen";
 import { Keyboard } from "@capacitor/keyboard";
 import { Capacitor } from "@capacitor/core";
-import { restoreGitHubPagesRoute as restoreGitHubPagesRoutePath } from "@/lib/github-pages-routing";
 
 // ── Sentry error monitoring ───────────────────────────────────────────────────
 // Only initialises when VITE_SENTRY_DSN is set AND the user has accepted cookies.
 initSentryIfConsented();
 
-function restoreGitHubPagesRoute() {
-  const targetRoute = restoreGitHubPagesRoutePath(
-    window.location.search,
-    import.meta.env.BASE_URL,
-    window.location.hash,
-  );
-  if (targetRoute) {
-    window.history.replaceState(null, "", targetRoute);
-  }
-}
-
-restoreGitHubPagesRoute();
+// GitHub Pages deep-link restoration now happens in App.tsx, before the
+// router is created (see comment there) — importing App below already runs it.
 
 if (Capacitor.isNativePlatform()) {
   // Status bar: light background (alabaster) with dark icons

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -24,7 +24,7 @@ export default function Terms() {
         {/* Header */}
         <div className="space-y-2">
           <h1 className="font-display text-4xl text-foreground">Terms of Service</h1>
-          <p className="text-sm text-muted-foreground">Last updated: 21 July 2026</p>
+          <p className="text-sm text-muted-foreground">Last updated: 21 July 2026 (Section 9 updated 6 August 2026)</p>
         </div>
 
         <p className="text-sm text-muted-foreground leading-relaxed">
@@ -119,7 +119,33 @@ export default function Terms() {
           </p>
         </Section>
 
-        <Section title="9. Limitation of liability">
+        <Section title="9. Software &quot;as is&quot;; assumption of risk; limitation of liability">
+          <p className="font-semibold text-foreground">9.1 As Is</p>
+          <p>
+            Olia is provided "as is" and "as available." Software of any kind may contain bugs,
+            errors, or defects. We do not guarantee uninterrupted, error-free, or fully accurate
+            operation of the Service, including checklists, reminders, notifications, alerts, or
+            any other automated feature.
+          </p>
+          <p className="font-semibold text-foreground">9.2 Assumption of Risk</p>
+          <p>
+            By using Olia, you acknowledge that you are using an automated software tool to
+            support, not replace, your own operational, compliance, food safety, and regulatory
+            processes. You remain solely responsible for your business's compliance with
+            applicable laws, health and safety regulations, and industry standards, regardless of
+            whether Olia's checklists, alerts, or notifications function as expected at any given
+            time.
+          </p>
+          <p className="font-semibold text-foreground">9.3 Waiver of Claims</p>
+          <p>
+            To the maximum extent permitted by applicable law, you waive and release Olia, its
+            founders, employees, and affiliates from any claim, cause of action, or right to bring
+            legal proceedings against us arising from software bugs, errors, downtime, missed or
+            failed notifications, or data inaccuracies. This waiver does not apply to claims
+            arising from our gross negligence, willful misconduct, or fraud, or where a waiver is
+            not permitted under mandatory consumer protection law applicable to you.
+          </p>
+          <p className="font-semibold text-foreground">9.4 Limitation of Liability</p>
           <p>
             To the maximum extent permitted by law, Olia is not liable for indirect, incidental,
             special, or consequential damages arising from your use of the service, including loss


### PR DESCRIPTION
## Summary
- `App.tsx` created the router as a module-level `createBrowserRouter(...)` call that reads `window.location` at import time — but `main.tsx` imported `App` (which runs that call) *before* calling `restoreGitHubPagesRoute()`. ES module imports always evaluate before the importing file's own code, so on a GitHub Pages deep link (e.g. `oliahq.com/privacy`), the router snapshotted the pre-redirect URL `/?p=%2Fprivacy`, matched route `/`, and rendered the landing page — the address bar then silently "fixed itself" via `history.replaceState`, but the already-rendered page never changed. Moved the restore call into `App.tsx`, before the router is constructed, so it always reads the corrected path.
- Updated `Terms.tsx` Section 9 with the expanded "as is / assumption of risk / waiver of claims / limitation of liability" language from the 6 Aug 2026 legal doc revision. `Privacy.tsx`, `Cookies.tsx`, and `AvisoLegal.tsx` already matched the latest doc.

Fixes #578

## Test plan
- [x] `bun run test` — all Privacy/Terms/Cookies/AvisoLegal/github-pages-routing/AcceptInvite tests pass
- [x] `bun run lint` — no new errors
- [x] `bun run build` — succeeds
- [x] Served `dist/` as a plain static host (replicating GitHub Pages' 404.html fallback) and drove it with Playwright: `/privacy`, `/terms`, `/cookies`, `/aviso-legal` each now render their own page (verified via H1) instead of the landing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)