### PR TITLE
Fix broken GitHub Pages build (leaked ThemePreviewToggle reference)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,6 @@ import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { RouteErrorBoundary } from "@/components/RouteErrorBoundary";
 import { routerFutureFlags } from "@/lib/router-future-flags";
 import { CookieBanner } from "@/components/CookieBanner";
-import { ThemePreviewToggle } from "@/components/ThemePreviewToggle";
 import { isNewDesignPath } from "@/lib/legal-theme";
 import { shouldRedirectToKiosk } from "@/lib/kiosk-guard";
 import { restoreGitHubPagesRoute } from "@/lib/github-pages-routing";
@@ -72,7 +71,6 @@ function RootLayout() {
     <>
       <Outlet />
       <CookieBanner />
-      {import.meta.env.DEV && !isNewDesignPath(location.pathname) && <ThemePreviewToggle />}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- PR #579 accidentally committed a reference to `ThemePreviewToggle` (an in-progress, never-committed spike component from an unrelated branch) into `src/App.tsx`, because that file's working tree already had the uncommitted spike edit mixed in when the legal-page fix was authored. The component was never added to the repo, so the GitHub Pages build broke with `ENOENT`.
- This removes the two leaked lines only — the legal-page routing fix from #579 is untouched.

Fixes #580

## Test plan
- [x] `bun run build` — succeeds (previously failed with `[vite:load-fallback] ENOENT ... ThemePreviewToggle`)
- [x] Diffed against the pre-#579 base to confirm only the two leaked lines are removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)