### PR TITLE
Don't wipe kiosk config on a transient locations-fetch error

### DIFF
--- a/src/pages/Kiosk.tsx
+++ b/src/pages/Kiosk.tsx
@@ -124,7 +124,7 @@ export default function Kiosk() {
   const [searchParams] = useSearchParams();
   const urlLocationId = searchParams.get("locationId");
   const { user, teamMember, loading } = useAuth();
-  const { allLocations = [], isFetched: locationsFetched } = useLocations();
+  const { allLocations = [], isFetched: locationsFetched, isError: locationsErrored } = useLocations();
 
   // Hydrate straight from localStorage on mount so a properly-configured
   // kiosk keeps working even when there is no live auth session yet (or
@@ -196,6 +196,11 @@ export default function Kiosk() {
     if (urlLocationId) {
       const matchedUrlLocation = allLocations.find((location) => location.id === urlLocationId);
       if (!matchedUrlLocation) {
+        // A failed fetch also leaves allLocations empty (isFetched is true on
+        // error too), which looks identical to "this location was deleted."
+        // Treat an errored fetch as "don't know yet" and retry later instead
+        // of wiping a device's kiosk config over a transient network blip.
+        if (locationsErrored) return;
         clearKioskLocationSelection();
         clearKioskOwnership();
         setLocationId(null);
@@ -249,6 +254,9 @@ export default function Kiosk() {
 
     const matchedStoredLocation = allLocations.find((location) => location.id === storedLocationId);
     if (!matchedStoredLocation) {
+      // Same reasoning as the urlLocationId branch above: don't tear down a
+      // working kiosk's configuration just because this one fetch errored.
+      if (locationsErrored) return;
       clearKioskLocationSelection();
       clearKioskOwnership();
       setLocationId(null);
@@ -266,6 +274,7 @@ export default function Kiosk() {
   }, [
     allLocations,
     loading,
+    locationsErrored,
     locationsFetched,
     teamMember?.organization_id,
     urlLocationId,
@@ -273,7 +282,7 @@ export default function Kiosk() {
   ]);
 
   useEffect(() => {
-    if (!locationId || !teamMember?.organization_id || !locationsFetched) return;
+    if (!locationId || !teamMember?.organization_id || !locationsFetched || locationsErrored) return;
 
     const locationStillAccessible = allLocations.some((location) => location.id === locationId);
     if (!locationStillAccessible) {
@@ -284,7 +293,7 @@ export default function Kiosk() {
       setScreen("grid");
       setKioskChecklists([]);
     }
-  }, [allLocations, locationId, locationsFetched, teamMember?.organization_id]);
+  }, [allLocations, locationId, locationsErrored, locationsFetched, teamMember?.organization_id]);
 
   // Load persisted completions for today whenever locationId is resolved
   useEffect(() => {
@@ -393,7 +402,7 @@ export default function Kiosk() {
   const [checklistsError, setChecklistsError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (loading || !user?.id || !locationId) return;
+    if (loading || !user?.id || !locationId || !locationsFetched || locationsErrored) return;
     const matchedLocation = allLocations.find((location) => location.id === locationId);
     if (matchedLocation) {
       if (matchedLocation.name !== locationName) {
@@ -409,7 +418,7 @@ export default function Kiosk() {
     setLocationId(null);
     setLocationName("");
     setKioskChecklists([]);
-  }, [allLocations, loading, locationId, locationName, user?.id]);
+  }, [allLocations, loading, locationId, locationName, locationsErrored, locationsFetched, user?.id]);
 
   useEffect(() => {
     if (loading || user?.id || !locationId) return;
@@ -420,7 +429,7 @@ export default function Kiosk() {
       .select("id, name")
       .eq("id", locationId)
       .maybeSingle()
-      .then(({ data }) => {
+      .then(({ data, error }) => {
         if (cancelled) return;
         if (data?.id) {
           if (data.name && data.name !== locationName) {
@@ -430,6 +439,13 @@ export default function Kiosk() {
           }
           return;
         }
+        // A failed request (network blip, transient Supabase error) surfaces
+        // here as data:null too — indistinguishable from "this location was
+        // really deleted" unless we check `error`. This is the anonymous
+        // kiosk's own periodic re-check (no live session, so it can't rely
+        // on useLocations' org-scoped list), so a wrong guess here silently
+        // logs a real, working kiosk device out to the marketing homepage.
+        if (error) return;
         clearKioskLocationSelection();
         setLocationId(null);
         setLocationName("");

--- a/src/pages/kiosk/PinEntryModal.tsx
+++ b/src/pages/kiosk/PinEntryModal.tsx
@@ -172,7 +172,7 @@ export function KioskPinShell({
 export function AdminLoginModal({ onClose, kioskLocationId }: { onClose: () => void; kioskLocationId?: string | null }) {
   const navigate = useNavigate();
   const { teamMember } = useAuth();
-  const { allLocations = [], isFetched: locationsFetched } = useLocations();
+  const { allLocations = [], isFetched: locationsFetched, isError: locationsErrored } = useLocations();
   const [pin, setPin] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
@@ -189,7 +189,7 @@ export function AdminLoginModal({ onClose, kioskLocationId }: { onClose: () => v
       return;
     }
 
-    if (teamMember?.organization_id && locationsFetched) {
+    if (teamMember?.organization_id && locationsFetched && !locationsErrored) {
       const locationStillAccessible = allLocations.some((location) => location.id === locationId);
       if (!locationStillAccessible) {
         clearKioskLocationSelectionForModal();
@@ -255,7 +255,7 @@ export function AdminLoginModal({ onClose, kioskLocationId }: { onClose: () => v
         setLoading(true);
         const locationId = kioskLocationId ?? localStorage.getItem("kiosk_location_id");
         if (!locationId) { setLoading(false); setError("Select a kiosk location first."); setPin(""); return; }
-        if (teamMember?.organization_id && locationsFetched) {
+        if (teamMember?.organization_id && locationsFetched && !locationsErrored) {
           if (!allLocations.some(l => l.id === locationId)) {
             clearKioskLocationSelectionForModal();
             setLoading(false);

--- a/src/test/pages/Kiosk.test.tsx
+++ b/src/test/pages/Kiosk.test.tsx
@@ -3,8 +3,9 @@ import Kiosk, { ChecklistRunner } from "@/pages/Kiosk";
 import { renderWithProviders } from "../test-utils";
 
 const mockNavigate = vi.fn();
-const { mockUseAuth } = vi.hoisted(() => ({
+const { mockUseAuth, mockUseLocations } = vi.hoisted(() => ({
   mockUseAuth: vi.fn(),
+  mockUseLocations: vi.fn(),
 }));
 
 vi.mock("react-router-dom", async () => {
@@ -149,10 +150,7 @@ vi.mock("@/lib/supabase", () => ({
 }));
 
 vi.mock("@/hooks/useLocations", () => ({
-  useLocations: () => ({
-    allLocations: mockLocations,
-    isFetched: true,
-  }),
+  useLocations: () => mockUseLocations(),
 }));
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -272,6 +270,11 @@ beforeEach(() => {
     session: null,
     loading: false,
     signOut: vi.fn(),
+  });
+  mockUseLocations.mockReturnValue({
+    allLocations: mockLocations,
+    isFetched: true,
+    isError: false,
   });
 });
 
@@ -1696,5 +1699,68 @@ describe("Kiosk — URL param locationId", () => {
     });
     await screen.findByText(/What's on the agenda/i);
     expect(screen.getByText(/What's on the agenda/i)).toBeInTheDocument();
+  });
+});
+
+describe("Kiosk — survives a transient locations-fetch error", () => {
+  // useLocations().isFetched is true after a FAILED fetch too (react-query
+  // marks a query "fetched" on error, not just success), so allLocations
+  // being empty during an errored fetch looks identical to "this location
+  // was deleted." A device must not wipe its kiosk config over a network
+  // blip — it should just wait for the next successful refetch.
+  it("keeps the stored kiosk location instead of clearing it when the locations query errors", async () => {
+    mockUseAuth.mockReturnValue({ user: { id: "u1" }, teamMember: { organization_id: "org-1" }, session: null, loading: false, signOut: vi.fn() });
+    mockUseLocations.mockReturnValue({ allLocations: [], isFetched: true, isError: true });
+    await renderGridScreen({ user: { id: "u1" }, teamMember: { organization_id: "org-1" }, session: null, loading: false, signOut: vi.fn() });
+
+    expect(screen.getByText(/What's on the agenda/i)).toBeInTheDocument();
+    expect(localStorage.getItem("kiosk_location_id")).toBe("00000000-0000-0000-0000-000000000011");
+  });
+
+  it("keeps the stored kiosk location on an anonymous device when the location re-check query errors", async () => {
+    // The anonymous kiosk path (no live session — the normal state for a
+    // wall-mounted device) re-verifies its location via a raw supabase call,
+    // independent of useLocations. It used to destructure only `data` and
+    // ignore `error`, so a failed request looked identical to "row not
+    // found" and wiped the kiosk's config.
+    const { supabase } = await import("@/lib/supabase");
+    mockUseAuth.mockReturnValue({ user: null, teamMember: null, session: null, loading: false, signOut: vi.fn() });
+    localStorage.setItem("kiosk_location_id", "00000000-0000-0000-0000-000000000011");
+    localStorage.setItem("kiosk_location_name", "Terrace");
+    localStorage.setItem("kiosk_owner_user_id", "u1");
+    localStorage.setItem("kiosk_owner_org_id", "org-1");
+    localStorage.setItem("kiosk_token", "test-kiosk-token-uuid");
+
+    (supabase.from as any).mockImplementationOnce((table: string) => ({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue(
+        table === "locations"
+          ? { data: null, error: { message: "network error" } }
+          : { data: null, error: null },
+      ),
+    }));
+
+    renderWithProviders(<Kiosk />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/What's on the agenda/i)).toBeInTheDocument();
+    });
+    expect(localStorage.getItem("kiosk_location_id")).toBe("00000000-0000-0000-0000-000000000011");
+  });
+
+  it("still clears the kiosk location when the locations query succeeds but genuinely no longer contains it", async () => {
+    mockUseAuth.mockReturnValue({ user: { id: "u1" }, teamMember: { organization_id: "org-1" }, session: null, loading: false, signOut: vi.fn() });
+    mockUseLocations.mockReturnValue({ allLocations: [], isFetched: true, isError: false });
+    localStorage.setItem("kiosk_location_id", "00000000-0000-0000-0000-000000000011");
+    localStorage.setItem("kiosk_location_name", "Terrace");
+    localStorage.setItem("kiosk_owner_user_id", "u1");
+    localStorage.setItem("kiosk_owner_org_id", "org-1");
+    localStorage.setItem("kiosk_token", "test-kiosk-token-uuid");
+    renderWithProviders(<Kiosk />);
+
+    await waitFor(() => {
+      expect(localStorage.getItem("kiosk_location_id")).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Four places in `Kiosk.tsx` (three `useLocations()`-based checks, one raw anonymous-path Supabase query — the path a real, wall-mounted kiosk with no login session actually runs through) treated "this location isn't in the freshly fetched list" as "this location was deleted," wiping `kiosk_location_id`/`kiosk_owner_*`/`kiosk_token` and dropping the device back to the unconfigured/marketing-homepage state.
- None of the four distinguished a genuinely-empty **successful** fetch from a **failed** one: React Query's `isFetched` is `true` after an error too (`allLocations` stays `[]`), and the raw anonymous-path query destructured only `{ data }`, silently discarding `error`.
- Any transient network blip (very plausible on a restaurant's shared WiFi) permanently reset a working kiosk.
- `useLocations()` now also returns `isError`; all four checks in `Kiosk.tsx`, plus the two equivalent checks in `PinEntryModal.tsx`'s admin PIN flow, skip the "not found → clear" branch when the fetch errored, leaving the existing config in place to retry on the next successful fetch.

Fixes #582

## Test plan
- [x] `bun run test src/test/pages/Kiosk.test.tsx` — 65/65 pass, including 3 new regression tests:
  - a stored location survives an errored `useLocations()` fetch
  - an anonymous device (no session) survives an errored raw re-check query
  - a location is still correctly cleared when the fetch succeeds and it's genuinely gone
- [x] `bun run lint` — no new errors
- [x] `bun run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)