### PR TITLE
Skip Supabase migrate steps in CI when no migration changed

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -25,11 +25,28 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+          fetch-depth: 2
+
+      - name: Check for migration changes
+        id: check
+        run: |
+          # Defaults to "changed" (run migrations) unless we can positively
+          # confirm this push touched no migration files -- a false positive
+          # here just costs a few redundant seconds (supabase db push is a
+          # no-op when nothing's new); a false negative would silently skip a
+          # real schema change, which is far worse.
+          if git rev-parse HEAD^ >/dev/null 2>&1 && git diff --quiet HEAD^ HEAD -- supabase/migrations/; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Setup Supabase CLI
+        if: steps.check.outputs.changed == 'true'
         run: npm install -g supabase
 
       - name: Link Supabase project
+        if: steps.check.outputs.changed == 'true'
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
         run: |
@@ -38,6 +55,7 @@ jobs:
             --password ${{ secrets.SUPABASE_DB_PASSWORD }}
 
       - name: Apply new migrations
+        if: steps.check.outputs.changed == 'true'
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
         run: supabase db push


### PR DESCRIPTION
## Summary
- The `migrate` job ran the Supabase CLI install + link + `db push` on every push to `main`, even when the push contained no migration changes (most pushes — UI/content fixes like today's legal-page and kiosk work).
- Added a `git diff` check against the parent commit, scoped to `supabase/migrations/`; the three expensive steps now skip via `if:` when nothing changed there.
- Fails safe: any uncertainty (e.g. no parent commit) defaults to running migrations. A false positive just costs a few redundant seconds (`db push` is a no-op with nothing new); a false negative would silently skip a real schema change.

Fixes #586

## Test plan
- [x] Verified the shell logic in a scratch git repo against three cases: no migration change (skips), a migration file added (runs), and no parent commit at all (fails safe → runs)
- [x] YAML syntax validated
- Can't fully dry-run the GitHub Actions job locally, but the logic is a plain `if:` gate on existing, unmodified steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)