### PR TITLE
Apply new white/black/teal brand palette to the app shell

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -8,12 +8,12 @@ const config: CapacitorConfig = {
   // iOS-specific
   ios: {
     contentInset: "automatic",   // respects safe areas automatically
-    backgroundColor: "#FDFAF7",  // alabaster white — matches --background
+    backgroundColor: "#FFFFFF",  // white — matches --background
   },
 
   // Android-specific
   android: {
-    backgroundColor: "#FDFAF7",
+    backgroundColor: "#FFFFFF",
     allowMixedContent: false,
   },
 
@@ -21,7 +21,7 @@ const config: CapacitorConfig = {
     SplashScreen: {
       launchShowDuration: 1200,
       launchAutoHide: true,
-      backgroundColor: "#1A2A47",      // midnight blue
+      backgroundColor: "#0B0F0C",      // near-black — matches --sage
       androidSplashResourceName: "splash",
       androidScaleType: "CENTER_CROP",
       showSpinner: false,
@@ -29,8 +29,8 @@ const config: CapacitorConfig = {
       splashImmersive: true,
     },
     StatusBar: {
-      style: "DARK",              // dark icons on light (alabaster) background
-      backgroundColor: "#FDFAF7",
+      style: "DARK",              // dark icons on light (white) background
+      backgroundColor: "#FFFFFF",
       overlaysWebView: false,
     },
     Keyboard: {

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -20,7 +20,7 @@ export function BottomNav() {
               <span
                 className={cn(
                   "flex items-center justify-center w-10 h-6 rounded-full transition-colors",
-                  active ? "bg-sage" : ""
+                  active ? "bg-[hsl(var(--nav-active-bg))] shadow-nav-active" : ""
                 )}
               >
                 <Icon
@@ -28,14 +28,14 @@ export function BottomNav() {
                   strokeWidth={active ? 2 : 1.5}
                   className={cn(
                     "transition-colors",
-                    active ? "text-white" : "text-muted-foreground"
+                    active ? "text-[hsl(var(--nav-active-icon))]" : "text-muted-foreground"
                   )}
                 />
               </span>
               <span
                 className={cn(
                   "transition-colors tracking-wide",
-                  active ? "text-sage font-semibold" : "text-muted-foreground"
+                  active ? "text-[hsl(var(--nav-active-label))] font-semibold" : "text-muted-foreground"
                 )}
               >
                 {label}

--- a/src/components/SidebarNav.tsx
+++ b/src/components/SidebarNav.tsx
@@ -10,9 +10,9 @@ export function SidebarNav() {
 
   return (
     <aside className="hidden md:flex md:w-[224px] md:shrink-0 pt-5 pb-8">
-      <div className="w-full h-fit rounded-[28px] border border-border bg-card/92 p-3 shadow-[0_18px_50px_rgba(15,23,42,0.06)] backdrop-blur-sm">
+      <div className="w-full h-fit rounded-[28px] border border-border bg-card/92 p-3 shadow-panel backdrop-blur-sm">
         <div className="flex items-center gap-2.5 px-3 pt-1 pb-3 mb-1 border-b border-border/60">
-          <img src="/brand/logo/olia-mark-navy.svg" alt="" className="w-7 h-7 shrink-0" />
+          <img src="/brand/logo/olia-mark-dark.svg" alt="" className="w-7 h-7 shrink-0" />
           <span className="font-display italic text-[17px] font-semibold text-foreground tracking-tight leading-none">Olia</span>
         </div>
         <p className="px-3 pt-2 pb-2 text-[11px] font-semibold uppercase tracking-[0.24em] text-muted-foreground">
@@ -33,13 +33,13 @@ export function SidebarNav() {
                   className={cn(
                     "group flex items-center gap-3 rounded-2xl px-3 py-3 text-sm font-medium transition-all",
                     active
-                      ? "bg-sage text-white shadow-sm"
-                      : "text-muted-foreground hover:bg-muted hover:text-foreground",
+                      ? "bg-[hsl(var(--nav-active-bg))] text-[hsl(var(--nav-active-icon))] shadow-nav-active"
+                      : "text-muted-foreground hover:bg-muted hover:text-foreground hover:shadow-sm",
                   )}
                 >
                   <span
                     className={cn(
-                      "flex h-10 w-10 items-center justify-center rounded-2xl transition-colors",
+                      "flex h-10 w-10 items-center justify-center rounded-2xl transition-colors shadow-inset",
                       active ? "bg-white/16" : "bg-muted text-muted-foreground group-hover:bg-card",
                     )}
                   >

--- a/src/index.css
+++ b/src/index.css
@@ -49,17 +49,19 @@ html { font-size: 16px; }                        /* mobile / default        */
     --space-section-gap: var(--space-6);   /* vertical between sections */
     --space-page-inset:  var(--space-4);   /* page horizontal padding   */
 
-    /* ── Elevation — four levels using espresso base hsl(17 30% 9%)
+    /* ── Elevation — four levels, layered ambient + contact shadow on a
+       near-black base for a lifted, 3D card feel.
        Level 0: flat (no shadow)  →  Level 3: modal / bottom sheet
        ──────────────────────────────────────────────────────────────────── */
-    --shadow-sm:    0 1px 3px 0 hsl(17 30% 9% / 0.06),
-                    0 1px 2px -1px hsl(17 30% 9% / 0.04);   /* level 1 — subtle lift    */
-    --shadow-card:  0 2px 8px 0 hsl(17 30% 9% / 0.06);     /* level 2 — cards          */
-    --shadow-md:    0 4px 12px 0 hsl(17 30% 9% / 0.07),
-                    0 2px 6px -2px hsl(17 30% 9% / 0.05);   /* level 3 — popovers       */
-    --shadow-lg:    0 8px 24px 0 hsl(17 30% 9% / 0.10),
-                    0 4px 12px -2px hsl(17 30% 9% / 0.08);  /* level 4 — modals, sheets */
-    --shadow-inset: inset 0 1px 3px 0 hsl(17 30% 9% / 0.08); /* inputs, pressed states */
+    --shadow-sm:    0 1px 2px hsl(135 15% 5% / 0.08),
+                    0 1px 1px hsl(135 15% 5% / 0.06);        /* level 1 — subtle lift    */
+    --shadow-card:  0 1px 3px hsl(135 15% 5% / 0.08),
+                    0 10px 24px -8px hsl(135 15% 5% / 0.18); /* level 2 — cards          */
+    --shadow-md:    0 2px 6px hsl(135 15% 5% / 0.10),
+                    0 16px 32px -8px hsl(135 15% 5% / 0.20); /* level 3 — popovers       */
+    --shadow-lg:    0 4px 10px hsl(135 15% 5% / 0.12),
+                    0 28px 56px -16px hsl(135 15% 5% / 0.28); /* level 4 — modals, sheets */
+    --shadow-inset: inset 0 1px 3px hsl(135 15% 5% / 0.10);  /* inputs, pressed states */
 
     /* ── Motion — duration + easing tokens
        Use var(--duration-*) + var(--ease-*) in transition/animation declarations.
@@ -75,43 +77,44 @@ html { font-size: 16px; }                        /* mobile / default        */
     --ease-inout:  cubic-bezier(0.4, 0.0, 0.2, 1.0);  /* symmetric — repositioning   */
     --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1); /* slight bounce — playful UX  */
 
-    /* Olia Brand Colors — all HSL */
-    --sage:            222 49% 16%;   /* ink #15213E */
-    --sage-deep:       222 55% 11%;   /* ink deep #0E1830 */
-    --sage-light:      222 40% 93%;   /* light ink tint for badges */
+    /* Olia Brand Colors — all HSL. White / near-black / bright teal,
+       matching the landing page's Sunday-inspired rebrand (see legal-theme.ts). */
+    --sage:            135 15% 5%;    /* near-black ink */
+    --sage-deep:       135 15% 2%;    /* ink deep */
+    --sage-light:      173 55% 93%;   /* light teal tint for badges */
 
-    --lavender:        273 24% 72%;   /* dusty lavender #B8A5C8 */
-    --lavender-deep:   273 32% 50%;   /* WCAG AA on lavender-light */
-    --lavender-light:  273 20% 93%;   /* light lavender tint */
+    --lavender:        0 0% 60%;      /* neutral gray secondary accent */
+    --lavender-deep:   0 0% 25%;      /* WCAG AA on lavender-light */
+    --lavender-light:  0 0% 95%;      /* light neutral tint */
 
-    --powder-blue:       210 44% 78%;   /* structural #B0C8E0 */
-    --powder-blue-deep:  210 52% 42%;
-    --powder-blue-light: 210 35% 93%;
+    --powder-blue:       173 100% 45%;  /* bright teal #00E5CC accent */
+    --powder-blue-deep:  173 100% 25%;  /* darker teal #007E70-ish for text/links */
+    --powder-blue-light: 173 55% 93%;
 
-    --background:      39 43% 93%;   /* ivory #F4EFE5 */
-    --foreground:      17 30% 9%;    /* espresso #1E1410 */
+    --background:      0 0% 100%;    /* white */
+    --foreground:      135 15% 5%;   /* near-black */
 
     --card:            0 0% 100%;    /* pure white #FFFFFF */
-    --card-foreground: 17 30% 9%;
+    --card-foreground: 135 15% 5%;
 
     --popover:         0 0% 100%;
-    --popover-foreground: 17 30% 9%;
+    --popover-foreground: 135 15% 5%;
 
-    --primary:         219 46% 19%;  /* midnight blue */
+    --primary:         135 15% 5%;   /* near-black */
     --primary-foreground: 0 0% 100%;
 
-    --secondary:       273 24% 72%;
-    --secondary-foreground: 17 30% 9%;
+    --secondary:       173 100% 45%; /* bright teal */
+    --secondary-foreground: 135 15% 5%;
 
-    --muted:           37 20% 95%;
-    --muted-foreground: 0 0% 50%;    /* warm gray #857B72 approx */
+    --muted:           0 0% 95%;
+    --muted-foreground: 142 7% 32%;
 
-    --accent:          219 40% 93%;  /* light midnight tint */
-    --accent-foreground: 219 46% 19%;
+    --accent:          173 60% 93%;  /* light teal tint */
+    --accent-foreground: 173 100% 20%;
 
-    --border:          37 13% 83%;   /* warm stone #DDD5C8 */
-    --input:           37 13% 83%;
-    --ring:            219 46% 19%;
+    --border:          0 0% 88%;
+    --input:           0 0% 88%;
+    --ring:            173 100% 45%;
 
     /* Status — semantically distinct from brand primary */
     --status-ok:       147 56% 42%;  /* service green #2FA86A */
@@ -123,19 +126,31 @@ html { font-size: 16px; }                        /* mobile / default        */
 
     --radius: 0.875rem;
 
-    --sidebar-background:          30 30% 97%;   /* near-alabaster sidebar */
-    --sidebar-foreground:          17 30% 9%;
-    --sidebar-primary:             219 46% 19%;  /* midnight blue */
+    --sidebar-background:          0 0% 100%;    /* white sidebar */
+    --sidebar-foreground:          135 15% 5%;
+    --sidebar-primary:             135 15% 5%;   /* near-black */
     --sidebar-primary-foreground:  0 0% 100%;
-    --sidebar-accent:              219 40% 93%;
-    --sidebar-accent-foreground:   219 46% 19%;
-    --sidebar-border:              37 13% 83%;
-    --sidebar-ring:                219 46% 19%;
+    --sidebar-accent:              173 60% 93%;  /* light teal tint */
+    --sidebar-accent-foreground:   173 100% 20%;
+    --sidebar-border:              0 0% 88%;
+    --sidebar-ring:                173 100% 45%;
 
     /* Typography */
     --font-display: 'Cormorant Garamond', Georgia, serif;
     --font-body: 'Hanken Grotesk', system-ui, sans-serif;
     --font-mono: 'IBM Plex Mono', 'Courier New', monospace;
+
+    /* Bottom nav / sidebar "active" indicator — bright teal fill, deep
+       readable teal label, mirroring how the landing page uses the accent
+       as a pop of color on an otherwise black/white UI. */
+    --nav-active-bg:    var(--powder-blue);
+    --nav-active-icon:  var(--foreground);
+    --nav-active-label: var(--powder-blue-deep);
+    --nav-active-shadow: 0 6px 16px hsl(var(--powder-blue) / 0.35);
+
+    /* Sidebar panel — deeper, layered elevation for a lifted, 3D feel */
+    --shadow-panel: 0 2px 6px hsl(135 15% 5% / 0.08),
+                    0 24px 60px -12px hsl(135 15% 5% / 0.22);
   }
 }
 

--- a/src/lib/export-utils.ts
+++ b/src/lib/export-utils.ts
@@ -7,13 +7,13 @@
  */
 
 // ─── Brand colours (RGB) ─────────────────────────────────────────────────────
-// Primary: Midnight Blue #1A2A47  · Background: Alabaster White #FDFAF7
-const SAGE: [number, number, number] = [26, 42, 71];     // midnight blue #1A2A47
+// Primary: near-black #0B0F0C  · Background: white #FFFFFF
+const SAGE: [number, number, number] = [11, 15, 12];     // near-black #0B0F0C
 const OK: [number, number, number] = [58, 107, 79];      // forest green
 const WARN: [number, number, number] = [196, 133, 74];   // warm amber
 const ERR: [number, number, number] = [142, 47, 62];     // deep rose
-const GRAY: [number, number, number] = [133, 123, 114];  // warm gray (muted-foreground)
-const LIGHT_BG: [number, number, number] = [253, 250, 247]; // warm white (card surface)
+const GRAY: [number, number, number] = [76, 87, 80];     // muted-foreground
+const LIGHT_BG: [number, number, number] = [255, 255, 255]; // white (card surface)
 
 function scoreRgb(score: number): [number, number, number] {
   return score >= 85 ? OK : score >= 65 ? WARN : ERR;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -19,9 +19,9 @@ initSentryIfConsented();
 // router is created (see comment there) — importing App below already runs it.
 
 if (Capacitor.isNativePlatform()) {
-  // Status bar: light background (alabaster) with dark icons
+  // Status bar: white background with dark icons
   StatusBar.setStyle({ style: Style.Light });
-  StatusBar.setBackgroundColor({ color: "#FDFAF7" });
+  StatusBar.setBackgroundColor({ color: "#FFFFFF" });
 
   // Hide splash screen after app is ready
   SplashScreen.hide({ fadeOutDuration: 300 });

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -214,13 +214,13 @@ export default function Dashboard() {
 
           {/* Quick stats strip */}
           <div className="grid grid-cols-3 gap-2 mt-4">
-            <div className="bg-card border border-border rounded-2xl p-3 text-center">
-              <p className="text-xl font-bold text-foreground">
+            <div className="bg-card border border-border rounded-2xl p-3 text-center shadow-card">
+              <p className="text-xl font-bold text-[hsl(var(--powder-blue-deep))]">
                 {logs.filter(l => l.created_at.slice(0, 10) === todayStr).length}
               </p>
               <p className="text-xs text-muted-foreground mt-0.5 uppercase tracking-wide">Checklists</p>
             </div>
-            <div className="bg-card border border-border rounded-2xl p-3 text-center">
+            <div className="bg-card border border-border rounded-2xl p-3 text-center shadow-card">
               <p className={cn("text-xl font-bold",
                 allAlerts.length === 0 ? "text-status-ok" : "text-status-error"
               )}>
@@ -228,7 +228,7 @@ export default function Dashboard() {
               </p>
               <p className="text-xs text-muted-foreground mt-0.5 uppercase tracking-wide">Alerts</p>
             </div>
-            <div className="bg-card border border-border rounded-2xl p-3 text-center">
+            <div className="bg-card border border-border rounded-2xl p-3 text-center shadow-card">
               <p className={cn("text-xl font-bold", overdueCount > 0 ? "text-status-warn" : "text-foreground")}>
                 {overdueCount}
               </p>

--- a/src/pages/Kiosk.tsx
+++ b/src/pages/Kiosk.tsx
@@ -792,7 +792,7 @@ export default function Kiosk() {
 
         {/* Center: brand mark + name */}
         <div className="flex items-center justify-center gap-2.5">
-          <img src="/brand/logo/olia-mark-navy.svg" alt="Olia" className="w-10 h-10 shrink-0" />
+          <img src="/brand/logo/olia-mark-dark.svg" alt="Olia" className="w-10 h-10 shrink-0" />
           <div>
             <p className="text-xs font-bold text-foreground uppercase tracking-widest leading-none">Olia</p>
             <p className="text-xs text-sage uppercase tracking-wide leading-none mt-0.5 font-semibold">

--- a/src/pages/kiosk/PinEntryModal.tsx
+++ b/src/pages/kiosk/PinEntryModal.tsx
@@ -111,7 +111,7 @@ export function KioskPinShell({
       className="fixed inset-0 z-[60] flex items-center justify-center bg-foreground/20 backdrop-blur-sm"
       onClick={e => { if (e.target === e.currentTarget) onClose(); }}
     >
-      <div className="bg-card w-full max-w-sm mx-4 rounded-2xl p-6 space-y-5 animate-fade-in">
+      <div className="bg-card w-full max-w-sm mx-4 rounded-2xl p-6 space-y-5 animate-fade-in shadow-lg">
         <div className="flex items-center justify-between">
           <h2 className="font-display text-lg text-foreground">{title}</h2>
           <button onClick={onClose} className="btn-icon" aria-label="Close">
@@ -145,9 +145,9 @@ export function KioskPinShell({
             onClick={onCta}
             disabled={ctaDisabled}
             className={cn(
-              "w-full py-3.5 rounded-2xl font-bold tracking-widest text-sm transition-colors active:scale-[0.98]",
+              "w-full py-3.5 rounded-2xl font-bold tracking-widest text-sm transition-all active:scale-[0.98]",
               !ctaDisabled
-                ? "bg-sage text-white hover:bg-sage-deep"
+                ? "bg-sage text-white hover:bg-sage-deep shadow-card active:shadow-inset"
                 : "bg-muted text-muted-foreground cursor-not-allowed",
             )}
           >
@@ -342,7 +342,7 @@ export function NumberPad({
         if (key === "⌫") return (
           <button
             key={i} type="button" onClick={onBackspace}
-            className="h-16 w-16 mx-auto rounded-full bg-muted text-muted-foreground text-base flex items-center justify-center transition-all active:scale-95 active:bg-muted/60"
+            className="h-16 w-16 mx-auto rounded-full bg-muted text-muted-foreground text-base flex items-center justify-center transition-all shadow-card active:scale-95 active:shadow-inset active:bg-muted/60"
           >
             ⌫
           </button>
@@ -350,7 +350,7 @@ export function NumberPad({
         return (
           <button
             key={i} type="button" onClick={() => onDigit(key)}
-            className="h-16 w-16 mx-auto rounded-full bg-white border border-border text-2xl font-light text-foreground transition-all active:scale-95 active:bg-muted shadow-sm"
+            className="h-16 w-16 mx-auto rounded-full bg-white border border-border text-2xl font-light text-foreground transition-all shadow-card active:scale-95 active:shadow-inset active:bg-muted"
           >
             {key}
           </button>

--- a/src/test/components/BottomNav.test.tsx
+++ b/src/test/components/BottomNav.test.tsx
@@ -36,21 +36,21 @@ describe("BottomNav", () => {
     expect(links).toHaveLength(5);
   });
 
-  it("active nav item (Dashboard) icon span has bg-sage class", () => {
+  it("active nav item (Dashboard) icon span has the nav-active-bg token class", () => {
     renderBottomNav();
     const dashLink = document.getElementById("nav-dashboard");
     expect(dashLink).not.toBeNull();
-    // The icon wrapper span should have bg-sage class when active
+    // The icon wrapper span should carry the nav-active-bg token when active
     const iconSpan = dashLink?.querySelector("span");
-    expect(iconSpan?.className).toContain("bg-sage");
+    expect(iconSpan?.className).toContain("bg-[hsl(var(--nav-active-bg))]");
   });
 
-  it("inactive nav items do not have bg-sage on icon span", () => {
+  it("inactive nav items do not have the nav-active-bg token on icon span", () => {
     renderBottomNav();
     const checklistsLink = document.getElementById("nav-checklists");
     const iconSpan = checklistsLink?.querySelector("span");
-    // Should not contain bg-sage since it's not active
-    expect(iconSpan?.className).not.toContain("bg-sage");
+    // Should not carry the active token since it's not active
+    expect(iconSpan?.className).not.toContain("bg-[hsl(var(--nav-active-bg))]");
   });
 
   it("links point to correct hrefs", () => {

--- a/src/test/components/SidebarNav.test.tsx
+++ b/src/test/components/SidebarNav.test.tsx
@@ -59,12 +59,12 @@ describe("SidebarNav", () => {
   it("marks Dashboard as active when on /dashboard", () => {
     renderWithProviders(<SidebarNav />, { initialEntries: ["/dashboard"] });
     const dashLink = screen.getByRole("link", { name: "Dashboard" });
-    expect(dashLink.className).toContain("bg-sage");
+    expect(dashLink.className).toContain("bg-[hsl(var(--nav-active-bg))]");
   });
 
   it("marks Admin as active when on an /admin/* route", () => {
     renderWithProviders(<SidebarNav />, { initialEntries: ["/admin/location"] });
     const adminLink = screen.getByRole("link", { name: "Admin" });
-    expect(adminLink.className).toContain("bg-sage");
+    expect(adminLink.className).toContain("bg-[hsl(var(--nav-active-bg))]");
   });
 });

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -103,6 +103,8 @@ export default {
         md:    "var(--shadow-md)",
         lg:    "var(--shadow-lg)",       // modals, bottom sheets
         inset: "var(--shadow-inset)",    // inputs, pressed states
+        panel: "var(--shadow-panel)",       // sidebar nav panel
+        "nav-active": "var(--nav-active-shadow)", // active bottom-nav / sidebar pill
       },
       transitionDuration: {
         instant: "var(--duration-instant)",  // 50ms


### PR DESCRIPTION
## Summary
- Promotes the white / near-black / bright-teal (`#00E5CC`) palette already live on the landing page into the shared `--sage`/`--lavender`/`--powder-blue` tokens in `src/index.css`, so the authenticated app (Dashboard, bottom nav, sidebar, kiosk) matches
- Adds dedicated `--nav-active-*` tokens so the active bottom-nav/sidebar item gets a bright teal treatment, and a layered "lifted" shadow system (`--shadow-panel`, new `shadow-card`/`shadow-lg` usage on Dashboard stat tiles, PIN pad, sidebar panel)
- Swaps the app-shell/kiosk logo mark from `olia-mark-navy.svg` to `olia-mark-dark.svg` (already used by the landing page and Signup)
- Updates PDF/CSV export colors (`export-utils.ts`) and native shell colors (`capacitor.config.ts`, status bar background) to match

Closes #588

## Test plan
- [x] `bun run lint` — 0 errors (pre-existing warnings only)
- [x] `bun run build` — succeeds
- [x] `bun run test` — 1360/1360 tests pass (updated 3 assertions in `BottomNav.test.tsx`/`SidebarNav.test.tsx` that checked for the literal `bg-sage` class, now `bg-[hsl(var(--nav-active-bg))]`)
- [x] Verified white background / near-black text / teal accents render correctly on Sign-in and Kiosk setup screens via Playwright screenshot
- [ ] Dora to spot-check the authenticated Dashboard/nav visually once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
