### PR TITLE
Add staff language preference + switcher in Settings

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useEffect, useState } from "react";
 import type { Session, User } from "@supabase/supabase-js";
 import { supabase } from "@/lib/supabase";
 import { queryClient } from "@/lib/query-client";
+import i18n, { type SupportedLanguage } from "@/lib/i18n";
 
 interface TeamMemberProfile {
   id: string;
@@ -12,6 +13,7 @@ interface TeamMemberProfile {
   location_ids: string[];
   permissions: Record<string, boolean>;
   pin_reset_required?: boolean;
+  language: SupportedLanguage;
 }
 
 interface AuthContextValue {
@@ -22,6 +24,7 @@ interface AuthContextValue {
   setupError: string | null;   // set when setup_new_organization fails
   retrySetup: () => void;      // lets the UI offer a "Try again" button
   signOut: () => Promise<void>;
+  updateLanguage: (language: SupportedLanguage) => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextValue>({
@@ -32,6 +35,7 @@ const AuthContext = createContext<AuthContextValue>({
   setupError: null,
   retrySetup: () => {},
   signOut: async () => {},
+  updateLanguage: async () => {},
 });
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
@@ -259,6 +263,29 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   // fetchTeamMember uses only supabase (module-level) and stable state setters.
   }, []);
 
+  // Keeps the app's active i18n language in sync with the signed-in user's
+  // saved preference — covers both the initial load and updateLanguage()
+  // below (which writes teamMember.language optimistically, then this
+  // effect picks up the change rather than calling i18n directly, so
+  // rollback-on-failure only needs to touch teamMember state).
+  useEffect(() => {
+    if (teamMember?.language) {
+      i18n.changeLanguage(teamMember.language);
+    }
+  }, [teamMember?.language]);
+
+  const updateLanguage = async (language: SupportedLanguage) => {
+    if (!teamMember) throw new Error("Not signed in");
+    const previous = teamMember.language;
+    setTeamMember((current) => (current ? { ...current, language } : current));
+
+    const { error } = await supabase.from("team_members").update({ language }).eq("id", teamMember.id);
+    if (error) {
+      setTeamMember((current) => (current ? { ...current, language: previous } : current));
+      throw error;
+    }
+  };
+
   const retrySetup = () => {
     if (!user) return;
     setLoading(true);
@@ -273,7 +300,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   };
 
   return (
-    <AuthContext.Provider value={{ user, session, teamMember, loading, setupError, retrySetup, signOut }}>
+    <AuthContext.Provider value={{ user, session, teamMember, loading, setupError, retrySetup, signOut, updateLanguage }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/pages/admin/AccountTab.tsx
+++ b/src/pages/admin/AccountTab.tsx
@@ -9,6 +9,9 @@ import { cn } from "@/lib/utils";
 import { supabase } from "@/lib/supabase";
 import { Switch } from "@/components/ui/switch";
 import { toast } from "@/components/ui/sonner";
+import { useAuth } from "@/contexts/AuthContext";
+import { LanguageSwitcher } from "@/components/LanguageSwitcher";
+import type { SupportedLanguage } from "@/lib/i18n";
 import {
   type Location, type StaffProfile, type TeamMember, type ManagerPermissions,
   type StaffDepartment,
@@ -88,6 +91,7 @@ export function AccountTab({
   pendingInviteStatus, onInviteMember, onEditMember, onDeleteMember, section,
 }: AccountTabProps) {
   const navigate = useNavigate();
+  const { teamMember: authTeamMember, updateLanguage } = useAuth();
   const { plan, planStatus, isActive } = usePlan();
   const isNative = useIsNativeApp();
   const saveAdminPin = useSaveAdminPin();
@@ -182,6 +186,15 @@ export function AccountTab({
       toast.error(err instanceof Error ? err.message : "Could not save account profile");
     } finally {
       setProfileSaving(false);
+    }
+  };
+
+  const handleLanguageChange = async (language: SupportedLanguage) => {
+    try {
+      await updateLanguage(language);
+      toast.success("Language updated");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Could not update language");
     }
   };
 
@@ -341,6 +354,13 @@ export function AccountTab({
                 value={profileEmail}
                 onChange={e => setProfileEmail(e.target.value)}
                 className="w-full border border-border rounded-xl px-3 py-2.5 text-sm bg-muted focus:outline-none focus:ring-1 focus:ring-ring"
+              />
+            </label>
+            <label className="space-y-1 block">
+              <span className="text-xs text-muted-foreground font-medium">Language</span>
+              <LanguageSwitcher
+                value={authTeamMember?.language ?? "en"}
+                onChange={handleLanguageChange}
               />
             </label>
             <button

--- a/src/test/contexts/AuthContext.test.tsx
+++ b/src/test/contexts/AuthContext.test.tsx
@@ -2,6 +2,8 @@ import { renderHook, act, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactNode } from "react";
 import { AuthProvider, useAuth } from "@/contexts/AuthContext";
+import { supabase } from "@/lib/supabase";
+import i18n from "@/lib/i18n";
 
 const { mockSignOut, mockOnAuthStateChange, mockRpc, mockQueryClientClear, mockTeamMemberSingle } = vi.hoisted(() => ({
   mockSignOut: vi.fn().mockResolvedValue({}),
@@ -290,5 +292,77 @@ describe("AuthContext", () => {
 
     expect(mockRpc).not.toHaveBeenCalled();
     expect(mockQueryClientClear).toHaveBeenCalledTimes(1);
+  });
+
+  describe("language preference (#594)", () => {
+    beforeEach(() => {
+      teamMemberRow = {
+        id: "user-1",
+        organization_id: "org-1",
+        name: "Sarah Johnson",
+        email: "sarah@acme.com",
+        role: "Owner",
+        location_ids: [],
+        permissions: {},
+        language: "en",
+      };
+    });
+
+    async function signInUser1(result: { current: ReturnType<typeof useAuth> }) {
+      await act(async () => {
+        authStateCallback?.("SIGNED_IN", { user: { id: "user-1", user_metadata: {} } });
+      });
+      await waitFor(() => expect(result.current.teamMember?.id).toBe("user-1"));
+    }
+
+    it("syncs i18n to the signed-in team member's saved language", async () => {
+      teamMemberRow!.language = "es";
+      const changeLanguageSpy = vi.spyOn(i18n, "changeLanguage");
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      await signInUser1(result);
+
+      expect(result.current.teamMember?.language).toBe("es");
+      expect(changeLanguageSpy).toHaveBeenCalledWith("es");
+    });
+
+    it("updateLanguage persists the new language and updates local state", async () => {
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      await signInUser1(result);
+
+      await act(async () => {
+        await result.current.updateLanguage("es");
+      });
+
+      expect(result.current.teamMember?.language).toBe("es");
+      expect(vi.mocked(supabase.from)).toHaveBeenCalledWith("team_members");
+    });
+
+    it("rolls back local state and rethrows when the persist fails", async () => {
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      await signInUser1(result);
+
+      vi.mocked(supabase.from).mockReturnValueOnce({
+        update: () => ({ eq: () => Promise.resolve({ error: new Error("network down") }) }),
+      } as any);
+
+      await expect(
+        act(async () => {
+          await result.current.updateLanguage("es");
+        }),
+      ).rejects.toThrow("network down");
+
+      expect(result.current.teamMember?.language).toBe("en");
+    });
+
+    it("updateLanguage throws when there is no signed-in team member", async () => {
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await expect(result.current.updateLanguage("es")).rejects.toThrow("Not signed in");
+    });
   });
 });

--- a/supabase/migrations/20260807000001_team_member_language.sql
+++ b/supabase/migrations/20260807000001_team_member_language.sql
@@ -1,0 +1,10 @@
+-- ================================================================
+-- Per-user staff-app language preference (#594).
+--
+-- No CHECK constraint on the value: the app validates against its own
+-- supported-language list (src/lib/i18n.ts) and adding a new language
+-- later should not require a migration.
+-- ================================================================
+
+ALTER TABLE team_members
+  ADD COLUMN IF NOT EXISTS language text NOT NULL DEFAULT 'en';


### PR DESCRIPTION
Phase 2 of #594 — makes the language switcher from #595 actually functional for the staff-facing app.

## What's in this PR
- **Migration:** `team_members.language` (`text not null default 'en'`, no `CHECK` constraint — adding language #3 later is just a locale file, not a migration). Update policy already allows a user to update their own row (`id = auth.uid()`), so no new RPC needed.
- **`AuthContext`:** `TeamMemberProfile.language` field; a `useEffect` that keeps the active i18n language synced to the signed-in user's saved preference; `updateLanguage()` — optimistic update, persists via a direct `team_members` update, rolls back local state and rethrows on failure.
- **Settings > Account:** `LanguageSwitcher` wired in right below Email, with a toast on save success/failure.

## Not in this PR (later phases)
- No Kiosk language picker yet (guest-facing, separate device-scoped concern — Phase 3).
- No string extraction from existing pages yet — switching languages today only proves the plumbing works, since there's nothing translated to see. String extraction is Phase 4.

## Verification
- `bun run milestone` (lint + test:ci + build) — all green
- New tests: `AuthContext`'s `updateLanguage` (persist, rollback-on-error, i18n sync, "not signed in" guard)
- **Manually verified against a local Supabase instance** (`supabase start` + `bun run dev`): signed up a fresh account via the real signup + OTP flow, opened Settings > Account, switched Language to Español, saw the "Language updated" toast, reloaded the page, and confirmed "Español" was still selected — proving the round-trip through the DB actually works, not just local React state.
