### PR TITLE
Pin Supabase CLI to 2.111.0 in CI to avoid v2.112.0 link regression

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -43,7 +43,11 @@ jobs:
 
       - name: Setup Supabase CLI
         if: steps.check.outputs.changed == 'true'
-        run: npm install -g supabase
+        # Pinned to 2.111.0: v2.112.0 regressed `link` with a schema-validation
+        # error on the api-keys `inserted_at` timestamp, breaking every CI
+        # pipeline that runs `link` + `db push` (supabase/cli#6115). Bump this
+        # once that's fixed upstream.
+        run: npm install -g supabase@2.111.0
 
       - name: Link Supabase project
         if: steps.check.outputs.changed == 'true'


### PR DESCRIPTION
Fixes #597.

`supabase link` (used by the `migrate` job before `db push`) breaks on Supabase CLI v2.112.0, released today — a schema-validation error on the `inserted_at` field of the api-keys response (upstream: [supabase/cli#6115](https://github.com/supabase/cli/issues/6115), also filed today, confirms v2.111.0 is the last known-good version).

This currently blocks the whole `GitHub Pages Deploy` pipeline (not just migrations — `build`/`deploy` both `needs: migrate`) for any push that includes a migration file, which is why PR #596 hasn't deployed yet.

## Fix
Pin `npm install -g supabase@2.111.0` instead of always installing latest.

## Verification
This is a one-line CI config change with no app code touched, so `bun run milestone` doesn't exercise it. Verifying by merging and watching the next `GitHub Pages Deploy` run actually get past the `migrate` job.