### PR TITLE
Retrigger CI migration push for team_members.language

### DIFF
--- a/supabase/migrations/20260807000001_team_member_language.sql
+++ b/supabase/migrations/20260807000001_team_member_language.sql
@@ -8,3 +8,10 @@
 
 ALTER TABLE team_members
   ADD COLUMN IF NOT EXISTS language text NOT NULL DEFAULT 'en';
+
+-- Note: this file's original merge (#596) landed the same day as a Supabase
+-- CLI v2.112.0 regression that broke `supabase link` in CI (supabase/cli#6115,
+-- fixed here via #598), so the migration never actually reached prod on that
+-- push. This comment-only touch re-opens the "did migrations change" CI gate
+-- so the next deploy retries `db push` — ADD COLUMN IF NOT EXISTS makes that
+-- safe to run again.


### PR DESCRIPTION
Follow-up to #596/#598. The `team_members.language` migration never actually reached prod: it merged the same day as the Supabase CLI v2.112.0 `link` regression (#597/#598), so the `migrate` job failed before `db push` ran.

This CI's "did migrations change" gate (`.github/workflows/github-pages.yml`) only diffs the latest commit against its parent, so simply merging #598 (the CLI pin, which doesn't touch `supabase/migrations/`) won't retry the push — this comment-only touch to the pending migration file re-opens that gate. `ADD COLUMN IF NOT EXISTS` makes re-running `db push` safe.

Will watch the resulting deploy run to confirm the `migrate` job actually succeeds and the column lands on prod.