### PR TITLE
Add Kiosk language picker (device-scoped, persists)

### DIFF
--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -7,6 +7,12 @@ interface LanguageSwitcherProps {
   value: SupportedLanguage;
   onChange: (language: SupportedLanguage) => void;
   className?: string;
+  /**
+   * "default" — full-width Select for a settings form (shows the endonym).
+   * "pill" — compact rounded-full trigger matching the Kiosk header's
+   * Library/Admin buttons (shows a short code); for the guest-facing picker.
+   */
+  variant?: "default" | "pill";
 }
 
 // Endonyms — each language's own name for itself, shown as-is regardless of
@@ -17,16 +23,30 @@ const LANGUAGE_ENDONYM: Record<SupportedLanguage, string> = {
   es: "Español",
 };
 
+const LANGUAGE_SHORT_LABEL: Record<SupportedLanguage, string> = {
+  en: "EN",
+  es: "ES",
+};
+
 // Presentational only — callers own where the chosen language is persisted
 // (Supabase profile for the staff app, localStorage for the device-scoped
 // Kiosk picker; see issue #594).
-export function LanguageSwitcher({ value, onChange, className }: LanguageSwitcherProps) {
+export function LanguageSwitcher({ value, onChange, className, variant = "default" }: LanguageSwitcherProps) {
   const { t } = useTranslation();
+  const isPill = variant === "pill";
 
   return (
     <Select value={value} onValueChange={(next) => onChange(next as SupportedLanguage)}>
-      <SelectTrigger className={cn("w-full", className)} aria-label={t("language.label")}>
-        <SelectValue />
+      <SelectTrigger
+        className={cn(
+          isPill
+            ? "w-auto h-auto gap-1.5 rounded-full border-border px-3 py-1.5 text-xs font-semibold text-muted-foreground hover:bg-muted"
+            : "w-full",
+          className,
+        )}
+        aria-label={t("language.label")}
+      >
+        {isPill ? <span>{LANGUAGE_SHORT_LABEL[value]}</span> : <SelectValue />}
       </SelectTrigger>
       <SelectContent>
         {SUPPORTED_LANGUAGES.map((lang) => (

--- a/src/pages/Kiosk.tsx
+++ b/src/pages/Kiosk.tsx
@@ -6,6 +6,8 @@ import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/contexts/AuthContext";
 import { useLocations } from "@/hooks/useLocations";
 import { enqueueLog, drainQueue } from "@/lib/submission-queue";
+import { LanguageSwitcher } from "@/components/LanguageSwitcher";
+import i18n, { resolveSupportedLanguage, type SupportedLanguage } from "@/lib/i18n";
 
 // ─── Sub-modules ──────────────────────────────────────────────────────────────
 import type { KioskChecklist, KioskScreen } from "./kiosk/types";
@@ -158,6 +160,22 @@ export default function Kiosk() {
   const [showLibraryPin, setShowLibraryPin] = useState(false);
   const [libraryMemberId, setLibraryMemberId] = useState<string | null>(null);
   const [libraryMemberName, setLibraryMemberName] = useState("");
+
+  // Device-scoped, not tied to any account: a kiosk isn't logged in, and per
+  // #594 the last language a guest picked on this device should stick for
+  // the next guest rather than resetting on idle/session end.
+  const [kioskLanguage, setKioskLanguage] = useState<SupportedLanguage>(
+    () => resolveSupportedLanguage(localStorage.getItem("kiosk_language")),
+  );
+
+  useEffect(() => {
+    i18n.changeLanguage(kioskLanguage);
+  }, [kioskLanguage]);
+
+  const handleKioskLanguageChange = (language: SupportedLanguage) => {
+    setKioskLanguage(language);
+    localStorage.setItem("kiosk_language", language);
+  };
 
   useEffect(() => {
     if (loading) return;
@@ -808,8 +826,9 @@ export default function Kiosk() {
           </div>
         </div>
 
-        {/* Right: library + admin */}
+        {/* Right: language + library + admin */}
         <div className="flex justify-end items-center gap-2">
+          <LanguageSwitcher variant="pill" value={kioskLanguage} onChange={handleKioskLanguageChange} />
           <button
             id="library-btn"
             onClick={() => setShowLibraryPin(true)}

--- a/src/test/components/LanguageSwitcher.test.tsx
+++ b/src/test/components/LanguageSwitcher.test.tsx
@@ -32,4 +32,20 @@ describe("LanguageSwitcher", () => {
     render(<LanguageSwitcher value="en" onChange={vi.fn()} className="custom-class" />);
     expect(screen.getByRole("combobox")).toHaveClass("custom-class");
   });
+
+  describe("pill variant (Kiosk header)", () => {
+    it("shows a short code instead of the full endonym", () => {
+      render(<LanguageSwitcher value="en" onChange={vi.fn()} variant="pill" />);
+      expect(screen.getByRole("combobox")).toHaveTextContent("EN");
+      expect(screen.queryByText("English")).not.toBeInTheDocument();
+    });
+
+    it("still lists full endonyms in the dropdown and calls onChange on selection", () => {
+      const onChange = vi.fn();
+      render(<LanguageSwitcher value="en" onChange={onChange} variant="pill" />);
+      fireEvent.click(screen.getByRole("combobox"));
+      fireEvent.click(screen.getByText("Español"));
+      expect(onChange).toHaveBeenCalledWith("es");
+    });
+  });
 });

--- a/src/test/pages/Kiosk.test.tsx
+++ b/src/test/pages/Kiosk.test.tsx
@@ -398,6 +398,28 @@ describe("Kiosk — Grid Screen", () => {
     expect(screen.getByText(/What's on the agenda/i)).toBeInTheDocument();
   });
 
+  it("shows a device-scoped language picker defaulting to English", async () => {
+    await renderGridScreen();
+    expect(screen.getByRole("combobox")).toHaveTextContent("EN");
+  });
+
+  it("restores a previously chosen kiosk language from localStorage on load", async () => {
+    localStorage.setItem("kiosk_language", "es");
+    await renderGridScreen();
+    expect(screen.getByRole("combobox")).toHaveTextContent("ES");
+  });
+
+  it("persists the chosen language to localStorage so it sticks for the next guest", async () => {
+    await renderGridScreen();
+    fireEvent.click(screen.getByRole("combobox"));
+    fireEvent.click(screen.getByText("Español"));
+
+    await waitFor(() => {
+      expect(localStorage.getItem("kiosk_language")).toBe("es");
+    });
+    expect(screen.getByRole("combobox")).toHaveTextContent("ES");
+  });
+
   it("clears stale kiosk location state when a signed-in owner has no kiosk owner stored yet", async () => {
     mockUseAuth.mockReturnValue({ user: { id: "u1" }, teamMember: { organization_id: "org-1" }, session: null, loading: false, signOut: vi.fn() });
     localStorage.setItem("kiosk_location_id", "00000000-0000-0000-0000-000000000011");


### PR DESCRIPTION
Phase 3 of #594 — the guest-facing half of the language switcher, following #595/#596.

## What's in this PR
- **`LanguageSwitcher`**: new `variant="pill"` — compact rounded-full trigger matching the Kiosk header's Library/Admin buttons, showing a short code ("EN"/"ES") instead of the full endonym so it fits the tight header row. `variant="default"` (Settings) is unchanged.
- **`Kiosk.tsx`**: wired the pill into the grid screen header, next to Library/Admin. Language is device-scoped via `localStorage` ("kiosk_language") — no login involved, so this is intentionally separate from the staff `AuthContext` mechanism in #596. Per Dora's call: the last guest's choice persists for the next guest (no reset on idle/session end).

## Not in this PR
- No string extraction yet — the picker is fully functional, but there's nothing translated to see switching languages today (that's Phase 4).

## Verification
- `bun run milestone` — clean
- New tests: `LanguageSwitcher` pill variant (short code display, dropdown still shows full endonyms, `onChange` fires), `Kiosk.tsx` (defaults to English, restores a stored language, persists a new choice to `localStorage`)
- **Manually verified against a local Supabase instance**: signed up an owner, added a real location, launched the kiosk, switched to Español via the pill, reloaded the page (simulating the next guest), and confirmed "ES" was still selected — the localStorage round-trip actually works.
