### PR TITLE
Unify display and body font on Switzer; use weight for hierarchy

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -159,7 +159,7 @@ html { font-size: 16px; }                        /* mobile / default        */
     --sidebar-ring:                173 100% 45%;
 
     /* Typography */
-    --font-display: 'Cormorant Garamond', Georgia, serif;
+    --font-display: 'Switzer', system-ui, sans-serif;
     --font-body: 'Switzer', 'Hanken Grotesk', system-ui, sans-serif;
     --font-mono: 'IBM Plex Mono', 'Courier New', monospace;
 
@@ -194,10 +194,18 @@ html { font-size: 16px; }                        /* mobile / default        */
     -webkit-font-smoothing: antialiased;
   }
 
+  /* Display and body now share one typeface (Switzer) — weight is what
+     separates a headline from body text, so headings get a deliberate bump
+     over the 400 body baseline: h1 heaviest (600, page-defining moments),
+     h2-h4 one step down (500, section/modal titles). */
   h1, h2, h3, h4 {
     font-family: var(--font-display);
     line-height: var(--leading-tight);
     letter-spacing: -0.01em;
+    font-weight: 500;
+  }
+  h1 {
+    font-weight: 600;
   }
 }
 

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -21,7 +21,7 @@ function SignupHeader() {
     <Link
       to="/"
       className="fixed top-6 left-6 flex items-center gap-2 text-lg hover:opacity-70 transition-opacity"
-      style={{ fontFamily: "var(--font-display)", fontStyle: "italic", color: "hsl(var(--foreground))" }}
+      style={{ fontFamily: "var(--font-display)", fontStyle: "italic", fontWeight: 600, color: "hsl(var(--foreground))" }}
     >
       <img src="/brand/logo/olia-mark-dark.svg" alt="" className="w-6 h-6" />
       Olia

--- a/src/pages/admin/AccountTab.tsx
+++ b/src/pages/admin/AccountTab.tsx
@@ -944,7 +944,7 @@ export function AccountTab({
           <div className="flex items-start justify-between gap-2 px-4 py-4">
             <div>
               <p className="text-xs text-muted-foreground font-medium mb-0.5">Current plan</p>
-              <p className="font-display text-xl text-foreground leading-tight">Olia {PLAN_LABELS[plan]}</p>
+              <p className="font-display font-semibold text-xl text-foreground leading-tight">Olia {PLAN_LABELS[plan]}</p>
               <p className="text-sm text-muted-foreground mt-1">
                 {PLAN_PRICES[plan].monthly === 0
                   ? "Free · No billing required"

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,9 +11,14 @@ export default {
       screens: { sm: "480px", md: "768px", lg: "1024px" },
     },
     extend: {
+      // display/body reference the CSS custom properties (index.css) rather than
+      // hardcoding a typeface, so changing --font-display/--font-body in one
+      // place actually takes effect everywhere the font-display/font-body
+      // utility classes are used — previously these were hardcoded literals
+      // disconnected from the CSS variables, silently ignoring any change.
       fontFamily: {
-        display: ["Cormorant Garamond", "Georgia", "serif"],
-        body: ["Hanken Grotesk", "system-ui", "sans-serif"],
+        display: ["var(--font-display)"],
+        body: ["var(--font-body)"],
         mono: ["IBM Plex Mono", "Courier New", "monospace"],
       },
       fontSize: {


### PR DESCRIPTION
## Summary
- `--font-display` → Switzer (was Cormorant Garamond serif) — display and body now share one typeface
- `h1` weight 600, `h2`/`h3`/`h4` weight 500, against the 400 body baseline — weight carries the hierarchy the serif/sans contrast used to
- Fixed `tailwind.config.ts`'s `fontFamily.display`/`fontFamily.body`, previously hardcoded literals disconnected from the `--font-display`/`--font-body` CSS variables — editing the variable silently did nothing before this fix
- Explicit weight added to the two non-heading `font-display` usages that lacked it (Signup logo link, AccountTab plan name)

Closes #603

## Test plan
- [x] `bun run lint` — 0 errors
- [x] `bun run build` — succeeds
- [x] `bun run test` — 1376/1376 pass
- [x] Verified with actual computed style (`getComputedStyle`), not just a screenshot: `font-family: Switzer, system-ui, sans-serif`, `font-weight: 600` on the Sign-in `h1`
- [x] Screenshotted Sign-in and Kiosk setup screens to confirm visual result

**Known caveat:** no italic Switzer weight was provided, so `italic` + `font-display` (Kiosk headline, "Olia Kiosk" setup, completion screen) now renders a browser-synthesized oblique rather than a true italic cut. Documented in #603.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
