### PR TITLE
Translate primary nav + Layout chrome

### DIFF
--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,20 +1,23 @@
 import { NavLink, useLocation } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { appNavItems } from "./app-nav";
 
 export function BottomNav() {
   const location = useLocation();
+  const { t } = useTranslation();
 
   return (
     <nav className="fixed bottom-0 left-0 right-0 z-50 border-t border-border bg-card shadow-sm safe-area-pb md:hidden">
       <div className="mx-auto flex items-stretch w-full max-w-[1200px] px-2 sm:px-4">
-        {appNavItems.map(({ to, label, icon: Icon }) => {
+        {appNavItems.map(({ id, to, labelKey, icon: Icon }) => {
           const active = location.pathname.startsWith(to);
+          const label = t(labelKey);
           return (
             <NavLink
               key={to}
               to={to}
-              id={`nav-${label.toLowerCase()}`}
+              id={`nav-${id}`}
               className="relative flex flex-1 flex-col items-center justify-center gap-1 py-2 px-2 text-xs font-medium transition-colors min-h-[58px] select-none"
             >
               <span

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, useEffect, useRef } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import { ArrowLeft, LogOut } from "lucide-react";
 import { BottomNav } from "./BottomNav";
 import { SidebarNav } from "./SidebarNav";
@@ -17,6 +18,7 @@ interface LayoutProps {
 
 export function Layout({ children, title, subtitle, headerRight, headerLeft }: LayoutProps) {
   const { user, signOut } = useAuth();
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
   const mainRef = useRef<HTMLElement | null>(null);
@@ -92,12 +94,12 @@ export function Layout({ children, title, subtitle, headerRight, headerLeft }: L
                   onClick={handleBackToKiosk}
                   className="flex items-center gap-1 text-xs font-semibold text-muted-foreground hover:text-foreground transition-colors px-2 py-1.5"
                 >
-                  <ArrowLeft size={14} /> Kiosk
+                  <ArrowLeft size={14} /> {t("layout.backToKiosk")}
                 </button>
               ) : user ? (
                 <button
                   onClick={handleLogout}
-                  aria-label="Log out"
+                  aria-label={t("layout.logOut")}
                   className="p-2 rounded-full hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
                 >
                   <LogOut size={16} />

--- a/src/components/SidebarNav.tsx
+++ b/src/components/SidebarNav.tsx
@@ -1,10 +1,12 @@
 import { NavLink, useLocation } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import { appNavItems } from "./app-nav";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/contexts/AuthContext";
 
 export function SidebarNav() {
   const location = useLocation();
+  const { t } = useTranslation();
   const { teamMember } = useAuth();
   const isOwner = teamMember?.role === "Owner";
 
@@ -16,11 +18,12 @@ export function SidebarNav() {
           <span className="font-display italic text-[17px] font-semibold text-foreground tracking-tight leading-none">Olia</span>
         </div>
         <p className="px-3 pt-2 pb-2 text-[11px] font-semibold uppercase tracking-[0.24em] text-muted-foreground">
-          Navigate
+          {t("nav.sectionLabel")}
         </p>
         <nav aria-label="Primary" className="space-y-1">
-          {appNavItems.map(({ to, label, icon: Icon, children }) => {
+          {appNavItems.map(({ to, labelKey, icon: Icon, children }) => {
             const active = location.pathname.startsWith(to);
+            const label = t(labelKey);
             const visibleChildren = children?.filter((child) => {
               if (child.ownerOnly && !isOwner) return false;
               return true;
@@ -62,7 +65,7 @@ export function SidebarNav() {
                               : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
                           )}
                         >
-                          {child.label}
+                          {t(child.labelKey)}
                         </NavLink>
                       );
                     })}

--- a/src/components/app-nav.ts
+++ b/src/components/app-nav.ts
@@ -8,20 +8,23 @@ import {
 } from "lucide-react";
 
 export interface AppNavItem {
+  /** Stable, non-translated — used for DOM ids (`nav-${id}`), never rendered. */
+  id: string;
   to: string;
-  label: string;
+  /** i18n key (common namespace) for the displayed label. */
+  labelKey: string;
   icon: LucideIcon;
   children?: Array<{
     to: string;
-    label: string;
+    labelKey: string;
     ownerOnly?: boolean;
   }>;
 }
 
 export const appNavItems: AppNavItem[] = [
-  { to: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
-  { to: "/checklists", label: "Checklists", icon: ClipboardList },
-  { to: "/reporting", label: "Reporting", icon: BarChart3 },
-  { to: "/infohub", label: "Infohub", icon: BookOpen },
-  { to: "/admin", label: "Admin", icon: ShieldCheck },
+  { id: "dashboard", to: "/dashboard", labelKey: "nav.dashboard", icon: LayoutDashboard },
+  { id: "checklists", to: "/checklists", labelKey: "nav.checklists", icon: ClipboardList },
+  { id: "reporting", to: "/reporting", labelKey: "nav.reporting", icon: BarChart3 },
+  { id: "infohub", to: "/infohub", labelKey: "nav.infohub", icon: BookOpen },
+  { id: "admin", to: "/admin", labelKey: "nav.admin", icon: ShieldCheck },
 ];

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1,5 +1,17 @@
 {
   "language": {
     "label": "Language"
+  },
+  "nav": {
+    "sectionLabel": "Navigate",
+    "dashboard": "Dashboard",
+    "checklists": "Checklists",
+    "reporting": "Reporting",
+    "infohub": "Infohub",
+    "admin": "Admin"
+  },
+  "layout": {
+    "backToKiosk": "Kiosk",
+    "logOut": "Log out"
   }
 }

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -1,5 +1,17 @@
 {
   "language": {
     "label": "Idioma"
+  },
+  "nav": {
+    "sectionLabel": "Navegar",
+    "dashboard": "Panel",
+    "checklists": "Listas de verificación",
+    "reporting": "Informes",
+    "infohub": "Infohub",
+    "admin": "Admin"
+  },
+  "layout": {
+    "backToKiosk": "Kiosco",
+    "logOut": "Cerrar sesión"
   }
 }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,6 +1,11 @@
 import "@testing-library/jest-dom";
 import { cleanup } from "@testing-library/react";
 import { afterEach } from "vitest";
+// Initializes the i18next singleton for every test file (react-i18next's
+// useTranslation() renders raw keys instead of translated text without an
+// initialized instance, and each test file gets a fresh module registry —
+// see #594).
+import "@/lib/i18n";
 
 afterEach(() => {
   cleanup();


### PR DESCRIPTION
First slice of Phase 4 (#594) — the full string-extraction sweep. This one covers the shared shell every authenticated page renders through: `SidebarNav`, `BottomNav`, and `Layout`'s header ("Back to Kiosk" / "Log out"). Starting here since it's the single highest-visibility target — present on every screen.

## What's in this PR
- `app-nav.ts`: split the stable DOM-id source (`id`, e.g. `id="nav-dashboard"`) from the display label (`labelKey`) — the id has to stay language-independent since unit tests and Maestro flows key off it directly.
- `common.json` (en/es): added `nav.*` and `layout.*` keys, translated (not placeholders).
- `src/test/setup.ts`: initializes the i18next singleton globally for every test file. Each Vitest file gets a fresh module registry, so without this, any test rendering a translated component needs its own `@/lib/i18n` import or `useTranslation()` silently renders raw keys instead of text — doing it once here avoids that footgun recurring on every subsequent extraction PR in this sweep.

## Verification
- `bun run milestone` — clean
- **Manually verified against a local Supabase instance**: logged in, confirmed the sidebar shows "Navigate / Dashboard / Checklists / Reporting / Infohub / Admin", switched to Español in Settings, confirmed it re-rendered as "Navegar / Panel / Listas de verificación / Informes / Infohub / Admin" — including a legitimate two-line wrap for "Listas de verificación" (longer Spanish string) that lays out cleanly. Worth another look during the Phase 5 layout QA pass, but not broken.

Page *content* (Dashboard, Settings forms, etc.) is still English-only — that's the rest of Phase 4, landing in further PRs.