### PR TITLE
Translate Kiosk setup + completion screens

### DIFF
--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -2,19 +2,21 @@ import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
 import enCommon from "@/locales/en/common.json";
 import esCommon from "@/locales/es/common.json";
+import enKiosk from "@/locales/en/kiosk.json";
+import esKiosk from "@/locales/es/kiosk.json";
 
 export const SUPPORTED_LANGUAGES = ["en", "es"] as const;
 export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
 export const DEFAULT_LANGUAGE: SupportedLanguage = "en";
 
 const resources = {
-  en: { common: enCommon },
-  es: { common: esCommon },
+  en: { common: enCommon, kiosk: enKiosk },
+  es: { common: esCommon, kiosk: esKiosk },
 };
 
 // Namespaces are added here as each app area is translated (dashboard,
-// checklists, settings, kiosk, admin, billing, ...) — see issue #594.
-const NAMESPACES = ["common"];
+// checklists, settings, admin, billing, ...) — see issue #594.
+const NAMESPACES = ["common", "kiosk"];
 
 // Picks a supported language from a raw BCP-47 tag (e.g. "es-MX" -> "es"),
 // falling back to DEFAULT_LANGUAGE for anything unsupported/unset. Kept as a

--- a/src/locales/en/kiosk.json
+++ b/src/locales/en/kiosk.json
@@ -1,0 +1,16 @@
+{
+  "systemOnline": "System Online",
+  "setup": {
+    "title": "Olia Kiosk",
+    "subtitle": "Select a location to launch",
+    "loadingLocations": "Loading locations…",
+    "noLocations": "No locations available. Please ask an admin to add one before launching the kiosk.",
+    "launchButton": "Launch Kiosk"
+  },
+  "completion": {
+    "title": "Well done!",
+    "subtitle": "Every completed checklist keeps the team running smoothly.",
+    "doneButton": "Done",
+    "returningIn": "Returning to home in {{count}}s"
+  }
+}

--- a/src/locales/es/kiosk.json
+++ b/src/locales/es/kiosk.json
@@ -1,0 +1,16 @@
+{
+  "systemOnline": "Sistema en línea",
+  "setup": {
+    "title": "Olia Kiosk",
+    "subtitle": "Selecciona una ubicación para iniciar",
+    "loadingLocations": "Cargando ubicaciones…",
+    "noLocations": "No hay ubicaciones disponibles. Pide a un administrador que añada una antes de iniciar el kiosco.",
+    "launchButton": "Iniciar kiosco"
+  },
+  "completion": {
+    "title": "¡Muy bien!",
+    "subtitle": "Cada lista de verificación completada mantiene al equipo funcionando sin problemas.",
+    "doneButton": "Listo",
+    "returningIn": "Volviendo al inicio en {{count}}s"
+  }
+}

--- a/src/pages/kiosk/CompletionScreen.tsx
+++ b/src/pages/kiosk/CompletionScreen.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
 import { Check } from "lucide-react";
 import type { KioskChecklist } from "./types";
 
@@ -11,6 +12,7 @@ export function CompletionScreen({
   completedAt: Date;
   onDone: () => void;
 }) {
+  const { t } = useTranslation("kiosk");
   const [countdown, setCountdown] = useState(10);
   const onDoneRef = useRef(onDone);
   onDoneRef.current = onDone;
@@ -34,8 +36,8 @@ export function CompletionScreen({
       <div className="w-20 h-20 rounded-full bg-sage-light flex items-center justify-center mb-6">
         <Check size={36} className="text-sage" />
       </div>
-      <h2 className="font-display text-4xl italic text-foreground mb-1">Well done!</h2>
-      <p className="text-sm italic text-muted-foreground mb-5">Every completed checklist keeps the team running smoothly.</p>
+      <h2 className="font-display text-4xl italic text-foreground mb-1">{t("completion.title")}</h2>
+      <p className="text-sm italic text-muted-foreground mb-5">{t("completion.subtitle")}</p>
       <p className="text-base font-medium text-foreground mb-1">{checklist.title}</p>
       <p className="text-sm text-muted-foreground mb-1">{staffName}</p>
       <p className="text-xs text-muted-foreground/70 mb-8">{dateStr} · {timeStr}</p>
@@ -43,9 +45,9 @@ export function CompletionScreen({
         onClick={onDone}
         className="w-full max-w-xs py-3 rounded-xl text-sm font-semibold bg-sage text-primary-foreground hover:bg-sage-deep transition-colors"
       >
-        Done
+        {t("completion.doneButton")}
       </button>
-      <p className="text-xs text-muted-foreground/60 mt-4">Returning to home in {countdown}s</p>
+      <p className="text-xs text-muted-foreground/60 mt-4">{t("completion.returningIn", { count: countdown })}</p>
     </div>
   );
 }

--- a/src/pages/kiosk/KioskSetupScreen.tsx
+++ b/src/pages/kiosk/KioskSetupScreen.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { supabase } from "@/lib/supabase";
 
@@ -9,6 +10,7 @@ export function KioskSetupScreen({
   onSetup: (locationId: string, locationName: string) => void;
   presetLocations?: { id: string; name: string }[];
 }) {
+  const { t } = useTranslation("kiosk");
   const [locations, setLocations] = useState<{ id: string; name: string }[]>(presetLocations ?? []);
   const [selectedId, setSelectedId] = useState("");
   const [loading, setLoading] = useState(!presetLocations);
@@ -43,16 +45,16 @@ export function KioskSetupScreen({
       <div className="w-full max-w-sm">
         <div className="text-center mb-10">
           <img src="/brand/logo/olia-app-icon.svg" alt="Olia" className="w-16 h-16 mx-auto mb-5" />
-          <h1 className="font-display text-3xl italic text-foreground tracking-tight">Olia Kiosk</h1>
-          <p className="section-label mt-2 tracking-widest">Select a location to launch</p>
+          <h1 className="font-display text-3xl italic text-foreground tracking-tight">{t("setup.title")}</h1>
+          <p className="section-label mt-2 tracking-widest">{t("setup.subtitle")}</p>
         </div>
         <div className="bg-card border border-border rounded-2xl p-6 space-y-5">
           <div>
             {loading ? (
-              <p className="text-sm text-muted-foreground py-3 text-center">Loading locations…</p>
+              <p className="text-sm text-muted-foreground py-3 text-center">{t("setup.loadingLocations")}</p>
             ) : locations.length === 0 ? (
               <p className="text-sm text-muted-foreground py-3 text-center">
-                No locations available. Please ask an admin to add one before launching the kiosk.
+                {t("setup.noLocations")}
               </p>
             ) : (
               <select
@@ -78,13 +80,13 @@ export function KioskSetupScreen({
                 : "bg-muted text-muted-foreground cursor-not-allowed",
             )}
           >
-            Launch Kiosk
+            {t("setup.launchButton")}
           </button>
         </div>
         <p className="text-center text-xs text-muted-foreground mt-6">
           <span className="inline-flex items-center gap-1.5">
             <span className="w-1.5 h-1.5 rounded-full bg-status-ok inline-block" />
-            System Online
+            {t("systemOnline")}
           </span>
         </p>
       </div>

--- a/src/test/pages/Kiosk.test.tsx
+++ b/src/test/pages/Kiosk.test.tsx
@@ -1,5 +1,7 @@
 import { screen, fireEvent, waitFor, act, cleanup } from "@testing-library/react";
 import Kiosk, { ChecklistRunner } from "@/pages/Kiosk";
+import { CompletionScreen } from "@/pages/kiosk/CompletionScreen";
+import i18n from "@/lib/i18n";
 import { renderWithProviders } from "../test-utils";
 
 const mockNavigate = vi.fn();
@@ -305,6 +307,16 @@ describe("Kiosk — Setup Screen", () => {
     await waitFor(() => {
       expect(screen.getByText(/System Online/i)).toBeInTheDocument();
     });
+  });
+
+  it("renders in Spanish when the device's stored kiosk_language is es", async () => {
+    localStorage.clear();
+    localStorage.setItem("kiosk_language", "es");
+    renderWithProviders(<Kiosk />);
+    await waitFor(() => {
+      expect(screen.getByText("Selecciona una ubicación para iniciar")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Sistema en línea")).toBeInTheDocument();
   });
 
   it("'Launch Kiosk' button appears", async () => {
@@ -1057,6 +1069,27 @@ describe("Kiosk — Completion Screen", () => {
     });
     // Back on grid screen
     expect(screen.getByText(/What's on the agenda/i)).toBeInTheDocument();
+  });
+
+  it("renders in Spanish when the active language is es", async () => {
+    await i18n.changeLanguage("es");
+    try {
+      await act(async () => {
+        renderWithProviders(
+          <CompletionScreen
+            checklist={{ id: "c1", title: "Opening Checklist" } as any}
+            staffName="Sarah"
+            completedAt={new Date("2026-08-07T10:00:00Z")}
+            onDone={vi.fn()}
+          />,
+        );
+      });
+      expect(screen.getByText("¡Muy bien!")).toBeInTheDocument();
+      expect(screen.getByText("Listo")).toBeInTheDocument();
+      expect(screen.getByText(/Volviendo al inicio en \d+s/)).toBeInTheDocument();
+    } finally {
+      await i18n.changeLanguage("en");
+    }
   });
 });
 


### PR DESCRIPTION
Second slice of Phase 4 (#594). Covers the guest's first screen (`KioskSetupScreen`: "Select a location to launch") and last screen (`CompletionScreen`: "Well done!" + countdown) — both translated into real Spanish, not placeholders.

Also introduces the `kiosk` locale namespace (first new one since Phase 1's scaffold), registered in `src/lib/i18n.ts`.

## Not in this PR
The main grid screen (`Kiosk.tsx`: "What's on the agenda", stat strip, empty states) — deliberately left for the next slice so this stays a reviewable size.

## Verification
- `bun run milestone` — clean
- Full `Kiosk.test.tsx` suite passes (70 tests), including 2 new tests that actually assert the Spanish strings render (not just that keys exist) — one driving it the realistic way (setting `kiosk_language` in `localStorage` before mounting `<Kiosk/>`, since Kiosk.tsx owns and resets that language state itself on mount), one testing `CompletionScreen` directly via `i18n.changeLanguage`.