### PR TITLE
Show location name as the kiosk grid headline instead of generic copy

### DIFF
--- a/src/pages/Kiosk.tsx
+++ b/src/pages/Kiosk.tsx
@@ -818,12 +818,7 @@ export default function Kiosk() {
         {/* Center: brand mark + name */}
         <div className="flex items-center justify-center gap-2.5">
           <img src="/brand/logo/olia-mark-dark.svg" alt="Olia" className="w-10 h-10 shrink-0" />
-          <div>
-            <p className="text-xs font-bold text-foreground uppercase tracking-widest leading-none">Olia</p>
-            <p className="text-xs text-sage uppercase tracking-wide leading-none mt-0.5 font-semibold">
-              {locationName || "Kiosk"}
-            </p>
-          </div>
+          <p className="text-xs font-bold text-foreground uppercase tracking-widest leading-none">Olia</p>
         </div>
 
         {/* Right: language + library + admin */}
@@ -849,7 +844,7 @@ export default function Kiosk() {
       {/* Agenda heading */}
       <div className="px-5 pt-6 pb-2">
         <h1 className="font-display text-3xl italic text-foreground leading-tight text-center">
-          What's on the agenda<br />for today?
+          {locationName || "Kiosk"}
         </h1>
 
         {/* Stat strip — DUE / OVERDUE / UPCOMING / DONE */}

--- a/src/test/pages/Kiosk.test.tsx
+++ b/src/test/pages/Kiosk.test.tsx
@@ -176,7 +176,7 @@ async function renderGridScreen(authOverride?: { user: any; teamMember: any; ses
   localStorage.setItem("kiosk_token", "test-kiosk-token-uuid");
   renderWithProviders(<Kiosk />);
 
-  if (!screen.queryByText(/What's on the agenda/i)) {
+  if (!screen.queryByTestId("kiosk-tab-due")) {
     await waitFor(() => {
       expect(document.getElementById("location-select")).not.toBeNull();
     });
@@ -188,7 +188,7 @@ async function renderGridScreen(authOverride?: { user: any; teamMember: any; ses
     }
   }
 
-  await screen.findByText(/What's on the agenda/i);
+  await screen.findByTestId("kiosk-tab-due");
 }
 
 async function openRunnerWithQuestions(questions: any[]) {
@@ -385,7 +385,7 @@ describe("Kiosk — Setup Screen", () => {
       fireEvent.click(btn);
     });
     await waitFor(() => {
-      expect(screen.queryByText(/What's on the agenda/i)).toBeInTheDocument();
+      expect(screen.queryByTestId("kiosk-tab-due")).toBeInTheDocument();
     });
   });
 });
@@ -393,9 +393,9 @@ describe("Kiosk — Setup Screen", () => {
 // ─── Grid Screen tests ────────────────────────────────────────────────────────
 
 describe("Kiosk — Grid Screen", () => {
-  it("grid screen shows 'What's on the agenda' heading", async () => {
+  it("grid screen heading shows the kiosk's location name", async () => {
     await renderGridScreen();
-    expect(screen.getByText(/What's on the agenda/i)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Terrace" })).toBeInTheDocument();
   });
 
   it("shows a device-scoped language picker defaulting to English", async () => {
@@ -459,13 +459,13 @@ describe("Kiosk — Grid Screen", () => {
     // wipe the kiosk's location binding — only a genuinely different signed-in
     // owner should ever reset it.
     await renderGridScreen();
-    expect(screen.getByText(/What's on the agenda/i)).toBeInTheDocument();
+    expect(screen.getByTestId("kiosk-tab-due")).toBeInTheDocument();
     cleanup(); // simulate a full page reload, not just an in-app re-render
 
     mockUseAuth.mockReturnValue({ user: null, teamMember: null, session: null, loading: false, signOut: vi.fn() });
     renderWithProviders(<Kiosk />);
 
-    await screen.findByText(/What's on the agenda/i);
+    await screen.findByTestId("kiosk-tab-due");
     expect(screen.queryByText(/Select a location to launch/i)).not.toBeInTheDocument();
     expect(localStorage.getItem("kiosk_location_id")).toBe("00000000-0000-0000-0000-000000000011");
     expect(localStorage.getItem("kiosk_owner_user_id")).toBe("u1");
@@ -1001,12 +1001,12 @@ describe("Kiosk — Grid Screen (Grand Ballroom)", () => {
 
   async function renderGrandBallroomGrid() {
     renderWithProviders(<Kiosk />);
-    await screen.findByText(/What's on the agenda/i);
+    await screen.findByTestId("kiosk-tab-due");
   }
 
   it("renders grid screen for Grand Ballroom with heading", async () => {
     await renderGrandBallroomGrid();
-    expect(screen.getByText(/What's on the agenda/i)).toBeInTheDocument();
+    expect(screen.getByTestId("kiosk-tab-due")).toBeInTheDocument();
   });
 
   it("Grand Ballroom has Opening Checklist (morning) or Closing Checklist (evening)", async () => {
@@ -1039,7 +1039,7 @@ describe("Kiosk — Completion Screen", () => {
     // Store a test kiosk_token so verify_kiosk_token RPC check passes (SEQ-009).
     localStorage.setItem("kiosk_token", "test-kiosk-token-uuid");
     renderWithProviders(<Kiosk />);
-    await screen.findByText(/What's on the agenda/i);
+    await screen.findByTestId("kiosk-tab-due");
 
     // Open PIN modal
     const checklistBtn = document.querySelector("[id^='checklist-card-']") as HTMLButtonElement;
@@ -1056,7 +1056,7 @@ describe("Kiosk — Completion Screen", () => {
       expect(screen.queryByText("Insert PIN")).not.toBeInTheDocument();
     });
     // Back on grid screen
-    expect(screen.getByText(/What's on the agenda/i)).toBeInTheDocument();
+    expect(screen.getByTestId("kiosk-tab-due")).toBeInTheDocument();
   });
 });
 
@@ -1719,8 +1719,8 @@ describe("Kiosk — URL param locationId", () => {
     renderWithProviders(<Kiosk />, {
       initialEntries: ["/kiosk?locationId=00000000-0000-0000-0000-000000000011"],
     });
-    await screen.findByText(/What's on the agenda/i);
-    expect(screen.getByText(/What's on the agenda/i)).toBeInTheDocument();
+    await screen.findByTestId("kiosk-tab-due");
+    expect(screen.getByTestId("kiosk-tab-due")).toBeInTheDocument();
   });
 });
 
@@ -1735,7 +1735,7 @@ describe("Kiosk — survives a transient locations-fetch error", () => {
     mockUseLocations.mockReturnValue({ allLocations: [], isFetched: true, isError: true });
     await renderGridScreen({ user: { id: "u1" }, teamMember: { organization_id: "org-1" }, session: null, loading: false, signOut: vi.fn() });
 
-    expect(screen.getByText(/What's on the agenda/i)).toBeInTheDocument();
+    expect(screen.getByTestId("kiosk-tab-due")).toBeInTheDocument();
     expect(localStorage.getItem("kiosk_location_id")).toBe("00000000-0000-0000-0000-000000000011");
   });
 
@@ -1766,7 +1766,7 @@ describe("Kiosk — survives a transient locations-fetch error", () => {
     renderWithProviders(<Kiosk />);
 
     await waitFor(() => {
-      expect(screen.getByText(/What's on the agenda/i)).toBeInTheDocument();
+      expect(screen.getByTestId("kiosk-tab-due")).toBeInTheDocument();
     });
     expect(localStorage.getItem("kiosk_location_id")).toBe("00000000-0000-0000-0000-000000000011");
   });


### PR DESCRIPTION
## Summary
- Removes the location name from under the "Olia" wordmark in the kiosk grid header
- Replaces the "What's on the agenda for today?" headline with the location name (`locationName || "Kiosk"`)
- Updates `Kiosk.test.tsx`: the ~28 tests that used the old headline text as a generic "grid screen has loaded" signal now check `kiosk-tab-due` (a stable testid unrelated to copy) instead; the one test specifically about the headline copy now asserts it renders the location name

Closes #607

## Test plan
- [x] `bun run lint` — 0 errors
- [x] `bun run build` — succeeds
- [x] `bun run test` — 1381/1381 pass (verified twice, one unrelated pre-existing flaky teardown error in `Kiosk.logic.test.tsx` reproduces on unmodified `main` too)
- [ ] Could not get a live screenshot this round — local Supabase is down (unrelated pre-existing issue, containers no longer exist), which also blocks the kiosk from reaching the grid screen locally to visually confirm. Logic is covered by the updated test asserting the heading renders the location name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
