### PR TITLE
Remove italic from the kiosk grid location-name headline

### DIFF
--- a/src/pages/Kiosk.tsx
+++ b/src/pages/Kiosk.tsx
@@ -839,7 +839,7 @@ export default function Kiosk() {
 
       {/* Agenda heading */}
       <div className="px-5 pt-6 pb-2">
-        <h1 className="font-display text-3xl italic text-foreground leading-tight text-center">
+        <h1 className="font-display text-3xl text-foreground leading-tight text-center">
           {locationName || t("grid.kioskFallbackName")}
         </h1>
 


### PR DESCRIPTION
## Summary
- Removes `italic` from the kiosk grid's location-name headline (`Kiosk.tsx`)

Closes #612

## Test plan
- [x] `bun run lint` — 0 errors
- [x] `bun run build` — succeeds
- [x] `bun run test` — 1383/1383 pass
- [x] Single className property removed, no test depends on it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
