### PR TITLE
Translate Dashboard + operational alert copy (Phase 4, part 3 of #594)

### DIFF
--- a/src/lib/alert-copy.ts
+++ b/src/lib/alert-copy.ts
@@ -1,3 +1,5 @@
+import i18n from "@/lib/i18n";
+
 export interface AlertCopy {
   title: string;
   body: string;
@@ -32,43 +34,45 @@ function extractQuotedSubject(message: string): string | null {
 function formatContext(alert: AlertLike): string {
   const bits = [alert.area?.trim()].filter(Boolean) as string[];
   if (alert.time?.trim()) bits.push(alert.time.trim());
-  return bits.length > 0 ? bits.join(" · ") : "Open the checklist for more detail.";
+  return bits.length > 0 ? bits.join(" · ") : i18n.t("alerts.copy.contextFallback", { ns: "dashboard" });
 }
 
 export function formatOperationalAlertCopy(alert: AlertLike): AlertCopy {
   const message = alert.message.trim();
   const lower = message.toLowerCase();
   const subject = extractQuotedSubject(message);
+  const t = (key: string, options?: Record<string, unknown>) =>
+    i18n.t(`alerts.copy.${key}`, { ns: "dashboard", ...options });
 
   if (lower.includes("outside the allowed range")) {
     const range = message.match(/\(([^)]+)\)\s*$/)?.[1]?.trim();
     const value = message.match(/recorded\s+(.+?)\s+—/i)?.[1]?.trim();
     return {
-      title: "Response needs a review",
-      body: value ? `Recorded value: ${value}.` : "A recorded value is outside the expected range.",
-      helper: range ? `Allowed range: ${range}.` : formatContext(alert),
+      title: t("reviewNeeded.title"),
+      body: value ? t("reviewNeeded.bodyWithValue", { value }) : t("reviewNeeded.bodyGeneric"),
+      helper: range ? t("reviewNeeded.helperRange", { range }) : formatContext(alert),
     };
   }
 
   if (/(answered\s+is\s+n\/a|no response|not provided|left blank)/i.test(message)) {
     return {
-      title: "Follow-up needed",
-      body: subject ? `${subject} was left unanswered.` : "A checklist step was left unanswered.",
-      helper: "A response was not provided, so this item needs attention.",
+      title: t("followUp.title"),
+      body: subject ? t("followUp.bodyWithSubject", { subject }) : t("followUp.bodyGeneric"),
+      helper: t("followUp.helper"),
     };
   }
 
   if (lower.startsWith("action required") || lower.startsWith("action needed")) {
     return {
-      title: "Action needed",
-      body: subject ?? "A checklist step needs attention.",
-      helper: "Open the checklist to review the detail.",
+      title: t("actionNeeded.title"),
+      body: subject ?? t("actionNeeded.bodyGeneric"),
+      helper: t("actionNeeded.helper"),
     };
   }
 
   return {
-    title: alert.type === "error" ? "Needs attention" : "Check this item",
-    body: subject ?? "A checklist step needs attention.",
+    title: alert.type === "error" ? t("fallback.titleError") : t("fallback.titleWarn"),
+    body: subject ?? t("fallback.bodyGeneric"),
     helper: formatContext(alert),
   };
 }

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -4,19 +4,21 @@ import enCommon from "@/locales/en/common.json";
 import esCommon from "@/locales/es/common.json";
 import enKiosk from "@/locales/en/kiosk.json";
 import esKiosk from "@/locales/es/kiosk.json";
+import enDashboard from "@/locales/en/dashboard.json";
+import esDashboard from "@/locales/es/dashboard.json";
 
 export const SUPPORTED_LANGUAGES = ["en", "es"] as const;
 export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
 export const DEFAULT_LANGUAGE: SupportedLanguage = "en";
 
 const resources = {
-  en: { common: enCommon, kiosk: enKiosk },
-  es: { common: esCommon, kiosk: esKiosk },
+  en: { common: enCommon, kiosk: enKiosk, dashboard: enDashboard },
+  es: { common: esCommon, kiosk: esKiosk, dashboard: esDashboard },
 };
 
-// Namespaces are added here as each app area is translated (dashboard,
-// checklists, settings, admin, billing, ...) — see issue #594.
-const NAMESPACES = ["common", "kiosk"];
+// Namespaces are added here as each app area is translated (checklists,
+// settings, admin, billing, ...) — see issue #594.
+const NAMESPACES = ["common", "kiosk", "dashboard"];
 
 // Picks a supported language from a raw BCP-47 tag (e.g. "es-MX" -> "es"),
 // falling back to DEFAULT_LANGUAGE for anything unsupported/unset. Kept as a

--- a/src/locales/en/dashboard.json
+++ b/src/locales/en/dashboard.json
@@ -1,0 +1,56 @@
+{
+  "greeting": "Here's what's happening today",
+  "notificationsAriaLabel": "Notifications",
+  "stats": {
+    "checklists": "Checklists",
+    "alerts": "Alerts",
+    "overdue": "Overdue"
+  },
+  "alerts": {
+    "sectionLabel": "Operational alerts",
+    "allClearTitle": "All clear",
+    "allClearBody": "It looks like everything is calm now.",
+    "seeAll": "See all {{count}} alerts",
+    "openAriaLabel": "Open alerts and review {{title}}",
+    "copy": {
+      "reviewNeeded": {
+        "title": "Response needs a review",
+        "bodyWithValue": "Recorded value: {{value}}.",
+        "bodyGeneric": "A recorded value is outside the expected range.",
+        "helperRange": "Allowed range: {{range}}."
+      },
+      "followUp": {
+        "title": "Follow-up needed",
+        "bodyWithSubject": "{{subject}} was left unanswered.",
+        "bodyGeneric": "A checklist step was left unanswered.",
+        "helper": "A response was not provided, so this item needs attention."
+      },
+      "actionNeeded": {
+        "title": "Action needed",
+        "bodyGeneric": "A checklist step needs attention.",
+        "helper": "Open the checklist to review the detail."
+      },
+      "fallback": {
+        "titleError": "Needs attention",
+        "titleWarn": "Check this item",
+        "bodyGeneric": "A checklist step needs attention."
+      },
+      "contextFallback": "Open the checklist for more detail."
+    }
+  },
+  "compliance": {
+    "sectionLabel": "Daily compliance",
+    "tabs": {
+      "today": "today",
+      "week": "week",
+      "month": "month"
+    },
+    "noLocations": {
+      "title": "No locations yet",
+      "body": "Add a location to see health scores here."
+    },
+    "checklistsCompleted": "{{completed}}/{{count}} checklists completed",
+    "noChecklistsAssigned": "No checklists assigned",
+    "tapToReview": "Tap to review reporting →"
+  }
+}

--- a/src/locales/es/dashboard.json
+++ b/src/locales/es/dashboard.json
@@ -1,0 +1,56 @@
+{
+  "greeting": "Esto es lo que ocurre hoy",
+  "notificationsAriaLabel": "Notificaciones",
+  "stats": {
+    "checklists": "Listas",
+    "alerts": "Alertas",
+    "overdue": "Atrasado"
+  },
+  "alerts": {
+    "sectionLabel": "Alertas operativas",
+    "allClearTitle": "Todo en orden",
+    "allClearBody": "Por ahora todo parece estar tranquilo.",
+    "seeAll": "Ver las {{count}} alertas",
+    "openAriaLabel": "Abrir alertas y revisar {{title}}",
+    "copy": {
+      "reviewNeeded": {
+        "title": "La respuesta necesita revisión",
+        "bodyWithValue": "Valor registrado: {{value}}.",
+        "bodyGeneric": "Un valor registrado está fuera del rango esperado.",
+        "helperRange": "Rango permitido: {{range}}."
+      },
+      "followUp": {
+        "title": "Requiere seguimiento",
+        "bodyWithSubject": "{{subject}} quedó sin responder.",
+        "bodyGeneric": "Un paso de la lista quedó sin responder.",
+        "helper": "No se proporcionó una respuesta, así que este ítem necesita atención."
+      },
+      "actionNeeded": {
+        "title": "Requiere acción",
+        "bodyGeneric": "Un paso de la lista necesita atención.",
+        "helper": "Abre la lista de verificación para revisar el detalle."
+      },
+      "fallback": {
+        "titleError": "Necesita atención",
+        "titleWarn": "Revisa este ítem",
+        "bodyGeneric": "Un paso de la lista necesita atención."
+      },
+      "contextFallback": "Abre la lista de verificación para más detalle."
+    }
+  },
+  "compliance": {
+    "sectionLabel": "Cumplimiento diario",
+    "tabs": {
+      "today": "hoy",
+      "week": "semana",
+      "month": "mes"
+    },
+    "noLocations": {
+      "title": "Aún no hay ubicaciones",
+      "body": "Agrega una ubicación para ver los puntajes aquí."
+    },
+    "checklistsCompleted": "{{completed}}/{{count}} listas completadas",
+    "noChecklistsAssigned": "Sin listas asignadas",
+    "tapToReview": "Toca para revisar los informes →"
+  }
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import { endOfMonth, endOfWeek, endOfDay, isWithinInterval, startOfDay, startOfMonth, startOfWeek } from "date-fns";
 import { Layout } from "@/components/Layout";
 import { AlertCircle, TrendingUp, ChevronRight, ChevronLeft, Bell } from "lucide-react";
@@ -87,12 +88,13 @@ function PaginationDots({ page, totalPages, setPage }: { page: number; totalPage
 
 export default function Dashboard() {
   const navigate = useNavigate();
+  const { t, i18n } = useTranslation("dashboard");
   const [complianceTab, setComplianceTab]          = useState<ComplianceTab>("today");
   const [page, setPage]                            = useState(0);
 
   const today    = new Date();
-  const dateLabel = today.toLocaleDateString("en-GB", { weekday: "long", day: "numeric", month: "long" });
-  const greeting  = "Here's what's happening today";
+  const dateLabel = today.toLocaleDateString(i18n.language === "es" ? "es-ES" : "en-GB", { weekday: "long", day: "numeric", month: "long" });
+  const greeting  = t("greeting");
 
   // ── Auth ──
   const { teamMember } = useAuth();
@@ -196,7 +198,7 @@ export default function Dashboard() {
             id="notifications-btn"
             onClick={() => navigate("/notifications")}
             className="relative p-2 rounded-full hover:bg-muted transition-colors"
-            aria-label="Notifications"
+            aria-label={t("notificationsAriaLabel")}
           >
             <Bell size={20} className="text-muted-foreground" />
             {allAlerts.length > 0 && (
@@ -218,7 +220,7 @@ export default function Dashboard() {
               <p className="text-xl font-semibold text-[hsl(var(--powder-blue-deep))]">
                 {logs.filter(l => l.created_at.slice(0, 10) === todayStr).length}
               </p>
-              <p className="text-xs text-muted-foreground mt-0.5 uppercase tracking-wide">Checklists</p>
+              <p className="text-xs text-muted-foreground mt-0.5 uppercase tracking-wide">{t("stats.checklists")}</p>
             </div>
             <div className="bg-card border border-border rounded-2xl p-3 text-center shadow-card">
               <p className={cn("text-xl font-semibold",
@@ -226,25 +228,25 @@ export default function Dashboard() {
               )}>
                 {allAlerts.length}
               </p>
-              <p className="text-xs text-muted-foreground mt-0.5 uppercase tracking-wide">Alerts</p>
+              <p className="text-xs text-muted-foreground mt-0.5 uppercase tracking-wide">{t("stats.alerts")}</p>
             </div>
             <div className="bg-card border border-border rounded-2xl p-3 text-center shadow-card">
               <p className={cn("text-xl font-semibold", overdueCount > 0 ? "text-status-warn" : "text-foreground")}>
                 {overdueCount}
               </p>
-              <p className="text-xs text-muted-foreground mt-0.5 uppercase tracking-wide">Overdue</p>
+              <p className="text-xs text-muted-foreground mt-0.5 uppercase tracking-wide">{t("stats.overdue")}</p>
             </div>
           </div>
         </section>
 
         {/* ── A. Operational Alerts ── */}
         <section>
-          <p className="section-label mb-3">Operational alerts</p>
+          <p className="section-label mb-3">{t("alerts.sectionLabel")}</p>
           {allAlerts.length === 0 ? (
             <div className="bg-card border border-border rounded-2xl p-6 text-center">
               <Bell size={20} className="mx-auto text-sage" aria-hidden="true" />
-              <p className="text-sm font-medium text-foreground">All clear</p>
-              <p className="text-xs text-muted-foreground mt-1">It looks like everything is calm now.</p>
+              <p className="text-sm font-medium text-foreground">{t("alerts.allClearTitle")}</p>
+              <p className="text-xs text-muted-foreground mt-1">{t("alerts.allClearBody")}</p>
             </div>
           ) : (
             <div className="space-y-2">
@@ -259,7 +261,7 @@ export default function Dashboard() {
                       "w-full bg-card border border-border rounded-2xl px-4 py-3 flex items-start gap-3 border-l-4 text-left transition-colors hover:bg-muted/40 focus:outline-none focus:ring-1 focus:ring-ring",
                       alert.type === "error" ? "border-l-status-error" : "border-l-status-warn",
                     )}
-                    aria-label={`Open alerts and review ${copy.title}`}
+                    aria-label={t("alerts.openAriaLabel", { title: copy.title })}
                   >
                     <AlertCircle size={15}
                       className={cn("mt-0.5 shrink-0", alert.type === "error" ? "text-status-error" : "text-status-warn")}
@@ -278,7 +280,7 @@ export default function Dashboard() {
                   onClick={() => navigate("/notifications")}
                   className="w-full flex items-center justify-center gap-1.5 py-2.5 text-xs text-sage font-semibold rounded-2xl border border-border bg-card hover:bg-muted transition-colors"
                 >
-                  See all {allAlerts.length} alerts
+                  {t("alerts.seeAll", { count: allAlerts.length })}
                   <ChevronRight size={12} />
                 </button>
               )}
@@ -289,7 +291,7 @@ export default function Dashboard() {
         {/* ── B. Daily Compliance ── */}
         <section>
           <div className="flex items-center justify-between mb-3 gap-2">
-            <p className="section-label">Daily compliance</p>
+            <p className="section-label">{t("compliance.sectionLabel")}</p>
             <div className="flex items-center bg-muted rounded-full p-0.5 text-xs shrink-0">
               {(["today", "week", "month"] as ComplianceTab[]).map(tab => (
                 <button key={tab}
@@ -300,7 +302,7 @@ export default function Dashboard() {
                     complianceTab === tab ? "bg-card text-foreground shadow-sm font-medium" : "text-muted-foreground"
                   )}
                 >
-                  {tab}
+                  {t(`compliance.tabs.${tab}`)}
                 </button>
               ))}
             </div>
@@ -312,8 +314,8 @@ export default function Dashboard() {
                 <TrendingUp size={20} className="text-sage" />
               </div>
               <div>
-                <p className="text-sm font-semibold text-foreground">No locations yet</p>
-                <p className="text-xs text-muted-foreground mt-1">Add a location to see health scores here.</p>
+                <p className="text-sm font-semibold text-foreground">{t("compliance.noLocations.title")}</p>
+                <p className="text-xs text-muted-foreground mt-1">{t("compliance.noLocations.body")}</p>
               </div>
             </div>
           ) : (
@@ -342,10 +344,10 @@ export default function Dashboard() {
                         <p className="text-xs font-semibold text-foreground leading-tight line-clamp-2">{loc.name}</p>
                         <p className="text-xs text-muted-foreground mt-1">
                           {loc.count > 0
-                            ? `${loc.completedCount}/${loc.count} checklists completed`
-                            : "No checklists assigned"}
+                            ? t("compliance.checklistsCompleted", { completed: loc.completedCount, count: loc.count })
+                            : t("compliance.noChecklistsAssigned")}
                         </p>
-                        <p className="text-xs text-sage mt-0.5 font-medium">Tap to review reporting →</p>
+                        <p className="text-xs text-sage mt-0.5 font-medium">{t("compliance.tapToReview")}</p>
                       </div>
                     </button>
                   );


### PR DESCRIPTION
Third slice of the string-extraction sweep tracked in #594: the Dashboard page (greeting, stat strip, operational alerts section, daily compliance section) plus the shared `formatOperationalAlertCopy()` templates in `alert-copy.ts`.

- New `dashboard` i18n namespace (`src/locales/{en,es}/dashboard.json`), registered in `src/lib/i18n.ts`.
- `alert-copy.ts` now pulls its static title/body/helper templates from the `dashboard` namespace via the i18n singleton (it's a plain function, not a component, called from both Dashboard and Notifications) — the raw `alert.message`/`area`/`time` values from checklist logs are left untranslated, consistent with the static-UI-only scope in #594.
- Real Spanish translations throughout, not placeholders.
- Date label (`toLocaleDateString`) now formats with `es-ES` when the active language is Spanish.

**Verified against a local Supabase instance:** signed up via the real OTP flow (Mailpit), confirmed the Dashboard renders correctly in English, switched to Español in Account settings, confirmed a full re-render — greeting, stat labels, "All clear" empty state, "No locations yet" empty state, compliance tabs, and the date heading all translated with no layout breakage.

**Known gap, left for a future slice:** `Notifications.tsx` also calls `formatOperationalAlertCopy()` but doesn't yet wrap its own page chrome in `useTranslation()`, so it won't re-render on a language change while mounted (same untranslated-page state as before this PR, just noting it since this PR touches its shared dependency).

## Test plan
- [x] `bun run lint` — 0 errors (pre-existing warnings only)
- [x] `bun run test:ci` — 90/90 files, 1383/1383 tests passing
- [x] `bun run build` — succeeds
- [x] Manual QA in English and Spanish against local Supabase (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
