### PR TITLE
Translate Notifications page chrome (Phase 4, part 4 of #594)

### DIFF
--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -6,19 +6,21 @@ import enKiosk from "@/locales/en/kiosk.json";
 import esKiosk from "@/locales/es/kiosk.json";
 import enDashboard from "@/locales/en/dashboard.json";
 import esDashboard from "@/locales/es/dashboard.json";
+import enNotifications from "@/locales/en/notifications.json";
+import esNotifications from "@/locales/es/notifications.json";
 
 export const SUPPORTED_LANGUAGES = ["en", "es"] as const;
 export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
 export const DEFAULT_LANGUAGE: SupportedLanguage = "en";
 
 const resources = {
-  en: { common: enCommon, kiosk: enKiosk, dashboard: enDashboard },
-  es: { common: esCommon, kiosk: esKiosk, dashboard: esDashboard },
+  en: { common: enCommon, kiosk: enKiosk, dashboard: enDashboard, notifications: enNotifications },
+  es: { common: esCommon, kiosk: esKiosk, dashboard: esDashboard, notifications: esNotifications },
 };
 
 // Namespaces are added here as each app area is translated (checklists,
 // settings, admin, billing, ...) — see issue #594.
-const NAMESPACES = ["common", "kiosk", "dashboard"];
+const NAMESPACES = ["common", "kiosk", "dashboard", "notifications"];
 
 // Picks a supported language from a raw BCP-47 tag (e.g. "es-MX" -> "es"),
 // falling back to DEFAULT_LANGUAGE for anything unsupported/unset. Kept as a

--- a/src/locales/en/notifications.json
+++ b/src/locales/en/notifications.json
@@ -1,0 +1,8 @@
+{
+  "subtitle": "Active operational alerts",
+  "backAriaLabel": "Back",
+  "dismissAriaLabel": "Dismiss alert",
+  "clearAll": "Clear all",
+  "count_one": "{{count}} alert",
+  "count_other": "{{count}} alerts"
+}

--- a/src/locales/es/notifications.json
+++ b/src/locales/es/notifications.json
@@ -1,0 +1,8 @@
+{
+  "subtitle": "Alertas operativas activas",
+  "backAriaLabel": "Atrás",
+  "dismissAriaLabel": "Descartar alerta",
+  "clearAll": "Borrar todo",
+  "count_one": "{{count}} alerta",
+  "count_other": "{{count}} alertas"
+}

--- a/src/pages/Notifications.tsx
+++ b/src/pages/Notifications.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import { Layout } from "@/components/Layout";
 import { AlertCircle, ArrowLeft, Trash2, X } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -7,6 +8,7 @@ import { formatOperationalAlertCopy } from "@/lib/alert-copy";
 
 export default function Notifications() {
   const navigate = useNavigate();
+  const { t } = useTranslation("notifications");
   const { data: alerts = [] } = useAlerts();
   const dismissMut = useDismissAlert();
   const clearMut = useClearAlerts();
@@ -17,12 +19,12 @@ export default function Notifications() {
   return (
     <Layout
       title="Olia"
-      subtitle="Active operational alerts"
+      subtitle={t("subtitle")}
       headerLeft={
         <button
           onClick={() => navigate("/dashboard")}
           className="p-2 rounded-full hover:bg-muted transition-colors"
-          aria-label="Back"
+          aria-label={t("backAriaLabel")}
         >
           <ArrowLeft size={18} className="text-muted-foreground" />
         </button>
@@ -30,14 +32,14 @@ export default function Notifications() {
     >
       <section>
         <div className="flex items-center justify-between mb-3">
-          <p className="section-label">{alerts.length} alert{alerts.length !== 1 ? "s" : ""}</p>
+          <p className="section-label">{t("count", { count: alerts.length })}</p>
           {alerts.length > 0 && (
             <button
               onClick={clearAll}
               className="flex items-center gap-1.5 text-xs text-status-error font-medium hover:opacity-80 transition-opacity"
             >
               <Trash2 size={12} />
-              Clear all
+              {t("clearAll")}
             </button>
           )}
         </div>
@@ -49,8 +51,8 @@ export default function Notifications() {
               <path d="M26 40l10 10 18-20" stroke="hsl(var(--sage))" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
             </svg>
             <div>
-              <p className="text-sm font-medium text-foreground">All clear</p>
-              <p className="text-xs text-muted-foreground mt-1">It looks like everything is calm now.</p>
+              <p className="text-sm font-medium text-foreground">{t("dashboard:alerts.allClearTitle")}</p>
+              <p className="text-xs text-muted-foreground mt-1">{t("dashboard:alerts.allClearBody")}</p>
             </div>
           </div>
         ) : (
@@ -77,7 +79,7 @@ export default function Notifications() {
                   <button
                     onClick={() => clearOne(alert.id)}
                     className="btn-icon shrink-0"
-                    aria-label="Dismiss alert"
+                    aria-label={t("dismissAriaLabel")}
                   >
                     <X size={14} className="text-muted-foreground" />
                   </button>


### PR DESCRIPTION
Small slice: page title/subtitle, alert count label (i18next `_one`/`_other` pluralization), Clear all / Dismiss / Back controls.

Reuses the "All clear" empty state from the `dashboard` namespace via cross-namespace lookup (`t("dashboard:alerts.allClearTitle")`) rather than duplicating the string — it's the same copy already translated in #614.

Closes the gap flagged in #614: Notifications now has its own `useTranslation()` call, so it re-renders on language change while mounted.

## Test plan
- [x] `bun run lint` — 0 errors
- [x] Targeted vitest run (`Notifications.test.tsx`, `alert-copy.test.ts`) — 11/11 passing
- [x] `bun run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
