### PR TITLE
Translate Checklists list view + shared schedule labels (Phase 4, part 5 of #594)

### DIFF
--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -8,19 +8,21 @@ import enDashboard from "@/locales/en/dashboard.json";
 import esDashboard from "@/locales/es/dashboard.json";
 import enNotifications from "@/locales/en/notifications.json";
 import esNotifications from "@/locales/es/notifications.json";
+import enChecklists from "@/locales/en/checklists.json";
+import esChecklists from "@/locales/es/checklists.json";
 
 export const SUPPORTED_LANGUAGES = ["en", "es"] as const;
 export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
 export const DEFAULT_LANGUAGE: SupportedLanguage = "en";
 
 const resources = {
-  en: { common: enCommon, kiosk: enKiosk, dashboard: enDashboard, notifications: enNotifications },
-  es: { common: esCommon, kiosk: esKiosk, dashboard: esDashboard, notifications: esNotifications },
+  en: { common: enCommon, kiosk: enKiosk, dashboard: enDashboard, notifications: enNotifications, checklists: enChecklists },
+  es: { common: esCommon, kiosk: esKiosk, dashboard: esDashboard, notifications: esNotifications, checklists: esChecklists },
 };
 
-// Namespaces are added here as each app area is translated (checklists,
-// settings, admin, billing, ...) — see issue #594.
-const NAMESPACES = ["common", "kiosk", "dashboard", "notifications"];
+// Namespaces are added here as each app area is translated (settings,
+// admin, billing, ...) — see issue #594.
+const NAMESPACES = ["common", "kiosk", "dashboard", "notifications", "checklists"];
 
 // Picks a supported language from a raw BCP-47 tag (e.g. "es-MX" -> "es"),
 // falling back to DEFAULT_LANGUAGE for anything unsupported/unset. Kept as a

--- a/src/locales/en/checklists.json
+++ b/src/locales/en/checklists.json
@@ -1,0 +1,89 @@
+{
+  "schedule": {
+    "none": "Once",
+    "daily": "Every day",
+    "weekday": "Every weekday",
+    "weekly": "Every week",
+    "monthly": "Every month",
+    "yearly": "Every year"
+  },
+  "shell": {
+    "editing": "Editing: {{title}}",
+    "newChecklist": "New checklist",
+    "subtitle": "Manage your checklists & inspections"
+  },
+  "reportingShell": {
+    "subtitle": "Logs & compliance overview"
+  },
+  "locations": {
+    "all": "All locations"
+  },
+  "search": {
+    "placeholder": "Search checklists…"
+  },
+  "empty": {
+    "folderEmpty": "This folder is empty",
+    "noChecklists": "No checklists yet",
+    "tapToCreate": "Tap to create a checklist or folder"
+  },
+  "folder": {
+    "itemCount_one": "{{count}} item",
+    "itemCount_other": "{{count}} items"
+  },
+  "checklist": {
+    "questionsCount_one": "{{count}} question",
+    "questionsCount_other": "{{count}} questions",
+    "previewTooltip": "Preview checklist"
+  },
+  "newFolder": {
+    "heading": "New folder",
+    "namePlaceholder": "Folder name",
+    "create": "Create folder"
+  },
+  "deleteConfirm": {
+    "headingFolder": "Delete folder?",
+    "headingChecklist": "Delete checklist?",
+    "body": "\"{{name}}\" will be permanently removed.",
+    "cancel": "Cancel",
+    "confirm": "Delete permanently",
+    "fallbackFolder": "this folder",
+    "fallbackChecklist": "this checklist"
+  },
+  "renameFolder": {
+    "heading": "Rename folder",
+    "save": "Rename"
+  },
+  "unsavedExit": {
+    "heading": "Leave without saving?",
+    "body": "Your unsaved changes will be lost if you exit.",
+    "keepEditing": "Keep editing",
+    "discard": "Discard changes"
+  },
+  "breadcrumb": {
+    "all": "All"
+  },
+  "createMenu": {
+    "heading": "Create new",
+    "buildOwn": "Build your own checklist",
+    "convertFile": "Convert file",
+    "convertFileSub": "Excel, image or PDF",
+    "buildAI": "Build with AI",
+    "createFolder": "Create a folder"
+  },
+  "contextMenu": {
+    "moveToFolder": "Move to folder",
+    "rename": "Rename",
+    "delete": "Delete",
+    "edit": "Edit",
+    "duplicate": "Duplicate",
+    "downloadPdf": "Download as PDF"
+  },
+  "moveToFolder": {
+    "heading": "Move to folder",
+    "searchPlaceholder": "Search folders",
+    "noMatch": "No folders match your search.",
+    "noFolder": "No folder",
+    "noFolderUnfiled": "No folder (unfiled)",
+    "noFoldersYet": "No folders yet — create one from the Checklists main view."
+  }
+}

--- a/src/locales/es/checklists.json
+++ b/src/locales/es/checklists.json
@@ -1,0 +1,89 @@
+{
+  "schedule": {
+    "none": "Una vez",
+    "daily": "Todos los días",
+    "weekday": "Cada día laborable",
+    "weekly": "Cada semana",
+    "monthly": "Cada mes",
+    "yearly": "Cada año"
+  },
+  "shell": {
+    "editing": "Editando: {{title}}",
+    "newChecklist": "Nueva lista",
+    "subtitle": "Gestiona tus listas de verificación e inspecciones"
+  },
+  "reportingShell": {
+    "subtitle": "Registros y resumen de cumplimiento"
+  },
+  "locations": {
+    "all": "Todas las ubicaciones"
+  },
+  "search": {
+    "placeholder": "Buscar listas…"
+  },
+  "empty": {
+    "folderEmpty": "Esta carpeta está vacía",
+    "noChecklists": "Aún no hay listas",
+    "tapToCreate": "Toca para crear una lista o carpeta"
+  },
+  "folder": {
+    "itemCount_one": "{{count}} elemento",
+    "itemCount_other": "{{count}} elementos"
+  },
+  "checklist": {
+    "questionsCount_one": "{{count}} pregunta",
+    "questionsCount_other": "{{count}} preguntas",
+    "previewTooltip": "Vista previa de la lista"
+  },
+  "newFolder": {
+    "heading": "Nueva carpeta",
+    "namePlaceholder": "Nombre de la carpeta",
+    "create": "Crear carpeta"
+  },
+  "deleteConfirm": {
+    "headingFolder": "¿Eliminar carpeta?",
+    "headingChecklist": "¿Eliminar lista?",
+    "body": "\"{{name}}\" se eliminará de forma permanente.",
+    "cancel": "Cancelar",
+    "confirm": "Eliminar permanentemente",
+    "fallbackFolder": "esta carpeta",
+    "fallbackChecklist": "esta lista"
+  },
+  "renameFolder": {
+    "heading": "Renombrar carpeta",
+    "save": "Renombrar"
+  },
+  "unsavedExit": {
+    "heading": "¿Salir sin guardar?",
+    "body": "Los cambios sin guardar se perderán si sales.",
+    "keepEditing": "Seguir editando",
+    "discard": "Descartar cambios"
+  },
+  "breadcrumb": {
+    "all": "Todo"
+  },
+  "createMenu": {
+    "heading": "Crear nuevo",
+    "buildOwn": "Crear tu propia lista",
+    "convertFile": "Convertir archivo",
+    "convertFileSub": "Excel, imagen o PDF",
+    "buildAI": "Crear con IA",
+    "createFolder": "Crear una carpeta"
+  },
+  "contextMenu": {
+    "moveToFolder": "Mover a carpeta",
+    "rename": "Renombrar",
+    "delete": "Eliminar",
+    "edit": "Editar",
+    "duplicate": "Duplicar",
+    "downloadPdf": "Descargar como PDF"
+  },
+  "moveToFolder": {
+    "heading": "Mover a carpeta",
+    "searchPlaceholder": "Buscar carpetas",
+    "noMatch": "Ninguna carpeta coincide con tu búsqueda.",
+    "noFolder": "Sin carpeta",
+    "noFolderUnfiled": "Sin carpeta (sin clasificar)",
+    "noFoldersYet": "Aún no hay carpetas — crea una desde la vista principal de Listas."
+  }
+}

--- a/src/pages/Checklists.tsx
+++ b/src/pages/Checklists.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import { Layout } from "@/components/Layout";
 import { ChecklistsTab } from "./checklists/ChecklistsTab";
 
 export default function Checklists() {
   const navigate = useNavigate();
+  const { t } = useTranslation("checklists");
   const [searchParams] = useSearchParams();
   const [builderTitle, setBuilderTitle] = useState<string | null>(null);
 
@@ -26,9 +28,9 @@ export default function Checklists() {
 
   const subtitle = builderTitle !== null
     ? builderTitle
-      ? `Editing: ${builderTitle}`
-      : "New checklist"
-    : "Manage your checklists & inspections";
+      ? t("shell.editing", { title: builderTitle })
+      : t("shell.newChecklist")
+    : t("shell.subtitle");
 
   return (
     <Layout title="Olia" subtitle={subtitle}>

--- a/src/pages/Reporting.tsx
+++ b/src/pages/Reporting.tsx
@@ -1,13 +1,15 @@
 import { useSearchParams } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import { Layout } from "@/components/Layout";
 import { ReportingTab } from "./checklists/ReportingTab";
 
 export default function Reporting() {
+  const { t } = useTranslation("checklists");
   const [searchParams] = useSearchParams();
   const initialLocationId = searchParams.get("location") || undefined;
 
   return (
-    <Layout title="Olia" subtitle="Logs & compliance overview">
+    <Layout title="Olia" subtitle={t("reportingShell.subtitle")}>
       <ReportingTab initialLocationId={initialLocationId} />
     </Layout>
   );

--- a/src/pages/checklists/ChecklistsTab.tsx
+++ b/src/pages/checklists/ChecklistsTab.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback, lazy, Suspense } from "react";
 import { createPortal } from "react-dom";
 import { useSearchParams, useBlocker, useLocation } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import { Plus, Search, ChevronDown, X, GripVertical, MoreVertical, FolderPlus, ClipboardList, Eye, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { FolderItem, ChecklistItem, SectionDef } from "./types";
@@ -33,10 +34,12 @@ function checklistAppliesToLocation(
 }
 
 export function ChecklistsTab({ onBuilderTitleChange }: { onBuilderTitleChange?: (title: string | null) => void }) {
+  const { t } = useTranslation("checklists");
   const [searchParams] = useSearchParams();
   const { can } = usePlan();
   const { data: dbLocations = [] } = useLocations();
-  const locationOptions = ["All locations", ...dbLocations.map(l => l.name)];
+  const allLocationsLabel = t("locations.all");
+  const locationOptions = [allLocationsLabel, ...dbLocations.map(l => l.name)];
 
   // DB data
   const { data: dbFolders = [] } = useFolders();
@@ -95,7 +98,7 @@ export function ChecklistsTab({ onBuilderTitleChange }: { onBuilderTitleChange?:
 
   const [currentFolder, setCurrentFolder] = useState<string | null>(null);
   const [search, setSearch] = useState("");
-  const [selectedLocation, setSelectedLocation] = useState("All locations");
+  const [selectedLocation, setSelectedLocation] = useState(allLocationsLabel);
   const [showLocationDrop, setShowLocationDrop] = useState(false);
   const [showCreateMenu, setShowCreateMenu] = useState(false);
   const [showBuilder, setShowBuilder] = useState(() => {
@@ -134,7 +137,7 @@ export function ChecklistsTab({ onBuilderTitleChange }: { onBuilderTitleChange?:
   const visibleChecklists = checklists
     .filter(c => normalizedSearch ? c.title.toLowerCase().includes(normalizedSearch) : c.folderId === currentFolder)
     .filter(c => {
-      if (selectedLocation === "All locations") return true;
+      if (selectedLocation === allLocationsLabel) return true;
       if (!selectedLocationObj) return true;
       return checklistAppliesToLocation(
         { location_id: c.location_id, location_ids: c.location_ids },
@@ -242,8 +245,8 @@ export function ChecklistsTab({ onBuilderTitleChange }: { onBuilderTitleChange?:
       if (folder) setRenameTarget({ id: folder.id, name: folder.name });
     } else if (action === "delete") {
       const name = contextMenu.type === "folder"
-        ? folders.find(f => f.id === contextMenu.id)?.name ?? "this folder"
-        : checklists.find(c => c.id === contextMenu.id)?.title ?? "this checklist";
+        ? folders.find(f => f.id === contextMenu.id)?.name ?? t("deleteConfirm.fallbackFolder")
+        : checklists.find(c => c.id === contextMenu.id)?.title ?? t("deleteConfirm.fallbackChecklist");
       setDeleteConfirm({ id: contextMenu.id, type: contextMenu.type, name });
     } else if (action === "duplicate" && contextMenu.type === "checklist") {
       const orig = dbChecklists.find(c => c.id === contextMenu.id);
@@ -312,20 +315,20 @@ export function ChecklistsTab({ onBuilderTitleChange }: { onBuilderTitleChange?:
       {(blocker.state === "blocked" || showNavExitConfirm) && createPortal(
         <div className="fixed inset-0 z-[80] flex items-center justify-center bg-foreground/30 backdrop-blur-sm">
           <div className="bg-card rounded-2xl p-6 mx-4 max-w-sm w-full shadow-xl space-y-4">
-            <h3 className="font-display text-lg text-foreground">Leave without saving?</h3>
-            <p className="text-sm text-muted-foreground">Your unsaved changes will be lost if you exit.</p>
+            <h3 className="font-display text-lg text-foreground">{t("unsavedExit.heading")}</h3>
+            <p className="text-sm text-muted-foreground">{t("unsavedExit.body")}</p>
             <div className="flex gap-3">
               <button
                 onClick={() => { setShowNavExitConfirm(false); if (blocker.state === "blocked") blocker.reset(); }}
                 className="flex-1 py-2.5 rounded-xl border border-border text-sm font-medium text-foreground hover:bg-muted transition-colors"
               >
-                Keep editing
+                {t("unsavedExit.keepEditing")}
               </button>
               <button
                 onClick={() => { discardAndClose(); setShowNavExitConfirm(false); if (blocker.state === "blocked") blocker.proceed(); }}
                 className="flex-1 py-2.5 rounded-xl bg-status-error text-white text-sm font-medium hover:opacity-90 transition-opacity"
               >
-                Discard changes
+                {t("unsavedExit.discard")}
               </button>
             </div>
           </div>
@@ -363,7 +366,7 @@ export function ChecklistsTab({ onBuilderTitleChange }: { onBuilderTitleChange?:
       <div className="flex items-center gap-2">
         <div className="relative flex-1">
           <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
-          <input type="text" placeholder="Search checklists…" value={search} onChange={e => setSearch(e.target.value)}
+          <input type="text" placeholder={t("search.placeholder")} value={search} onChange={e => setSearch(e.target.value)}
             className="w-full pl-9 pr-4 py-2.5 border border-border rounded-xl text-sm bg-card focus:outline-none focus:ring-1 focus:ring-ring" />
         </div>
         <button
@@ -386,9 +389,9 @@ export function ChecklistsTab({ onBuilderTitleChange }: { onBuilderTitleChange?:
           </div>
           <div>
             <p className="text-sm font-medium text-foreground">
-              {currentFolder ? "This folder is empty" : "No checklists yet"}
+              {currentFolder ? t("empty.folderEmpty") : t("empty.noChecklists")}
             </p>
-            <p className="text-xs text-muted-foreground mt-1">Tap to create a checklist or folder</p>
+            <p className="text-xs text-muted-foreground mt-1">{t("empty.tapToCreate")}</p>
           </div>
         </button>
       ) : (
@@ -417,7 +420,7 @@ export function ChecklistsTab({ onBuilderTitleChange }: { onBuilderTitleChange?:
                 </div>
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-medium text-foreground truncate">{folder.name}</p>
-                  <p className="text-xs text-muted-foreground">{folder.itemCount} items</p>
+                  <p className="text-xs text-muted-foreground">{t("folder.itemCount", { count: folder.itemCount })}</p>
                 </div>
               </button>
               <button onClick={e => { e.stopPropagation(); setContextMenu({ id: folder.id, type: "folder" }); }}
@@ -445,13 +448,13 @@ export function ChecklistsTab({ onBuilderTitleChange }: { onBuilderTitleChange?:
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-medium text-foreground truncate">{cl.title}</p>
                   <p className="text-xs text-muted-foreground">
-                    {cl.questionsCount} questions{cl.schedule ? ` · ${getScheduleLabel(cl.schedule)}` : ""}
+                    {t("checklist.questionsCount", { count: cl.questionsCount })}{cl.schedule ? ` · ${getScheduleLabel(cl.schedule)}` : ""}
                   </p>
                 </div>
               </button>
               <button onClick={e => { e.stopPropagation(); setPreviewChecklist(cl); }}
                 className="p-2 text-muted-foreground hover:text-sage transition-colors shrink-0"
-                title="Preview checklist">
+                title={t("checklist.previewTooltip")}>
                 <Eye size={16} />
               </button>
               <button onClick={e => { e.stopPropagation(); setContextMenu({ id: cl.id, type: "checklist" }); }}
@@ -515,18 +518,18 @@ export function ChecklistsTab({ onBuilderTitleChange }: { onBuilderTitleChange?:
         <div className="fixed inset-0 z-[60] flex items-end justify-center pb-16 bg-foreground/20 backdrop-blur-sm animate-fade-in">
           <div className="bg-card w-full max-w-lg rounded-t-2xl p-5 pb-20 space-y-4 animate-fade-in">
             <div className="flex items-center justify-between">
-              <h2 className="font-display text-lg text-foreground">New folder</h2>
+              <h2 className="font-display text-lg text-foreground">{t("newFolder.heading")}</h2>
               <button onClick={() => setShowNewFolder(false)} className="btn-icon">
                 <X size={18} className="text-muted-foreground" />
               </button>
             </div>
-            <input autoFocus type="text" placeholder="Folder name" value={newFolderName} onChange={e => setNewFolderName(e.target.value)}
+            <input autoFocus type="text" placeholder={t("newFolder.namePlaceholder")} value={newFolderName} onChange={e => setNewFolderName(e.target.value)}
               className="w-full border border-border rounded-xl px-4 py-3 text-sm bg-muted focus:outline-none focus:ring-1 focus:ring-ring" />
             <button disabled={!newFolderName.trim()} onClick={handleCreateFolder}
               className={cn("w-full py-3 rounded-xl text-sm font-medium transition-colors",
                 newFolderName.trim() ? "bg-sage text-primary-foreground hover:bg-sage-deep" : "bg-muted text-muted-foreground cursor-not-allowed"
               )}>
-              Create folder
+              {t("newFolder.create")}
             </button>
           </div>
         </div>,
@@ -546,14 +549,16 @@ export function ChecklistsTab({ onBuilderTitleChange }: { onBuilderTitleChange?:
                 <Trash2 size={18} className="text-status-error" />
               </div>
               <div>
-                <h2 className="font-display text-base text-foreground">Delete {deleteConfirm.type}?</h2>
-                <p className="text-xs text-muted-foreground mt-0.5 truncate">"{deleteConfirm.name}" will be permanently removed.</p>
+                <h2 className="font-display text-base text-foreground">
+                  {deleteConfirm.type === "folder" ? t("deleteConfirm.headingFolder") : t("deleteConfirm.headingChecklist")}
+                </h2>
+                <p className="text-xs text-muted-foreground mt-0.5 truncate">{t("deleteConfirm.body", { name: deleteConfirm.name })}</p>
               </div>
             </div>
             <div className="flex gap-3">
               <button onClick={() => setDeleteConfirm(null)}
                 className="flex-1 py-3 rounded-xl border border-border text-sm font-medium text-foreground hover:bg-muted transition-colors">
-                Cancel
+                {t("deleteConfirm.cancel")}
               </button>
               <button onClick={() => {
                 if (deleteConfirm.type === "folder") deleteFolderMut.mutate(deleteConfirm.id);
@@ -561,7 +566,7 @@ export function ChecklistsTab({ onBuilderTitleChange }: { onBuilderTitleChange?:
                 setDeleteConfirm(null);
               }}
                 className="flex-1 py-3 rounded-xl bg-status-error text-white text-sm font-medium hover:opacity-90 transition-opacity">
-                Delete permanently
+                {t("deleteConfirm.confirm")}
               </button>
             </div>
           </div>
@@ -589,7 +594,7 @@ export function ChecklistsTab({ onBuilderTitleChange }: { onBuilderTitleChange?:
         <div className="fixed inset-0 z-[60] flex items-end justify-center pb-16 bg-foreground/20 backdrop-blur-sm animate-fade-in">
           <div className="bg-card w-full max-w-lg rounded-t-2xl p-5 pb-20 space-y-4 animate-fade-in">
             <div className="flex items-center justify-between">
-              <h2 className="font-display text-lg text-foreground">Rename folder</h2>
+              <h2 className="font-display text-lg text-foreground">{t("renameFolder.heading")}</h2>
               <button onClick={() => setRenameTarget(null)} className="btn-icon">
                 <X size={18} className="text-muted-foreground" />
               </button>
@@ -604,7 +609,7 @@ export function ChecklistsTab({ onBuilderTitleChange }: { onBuilderTitleChange?:
               className={cn("w-full py-3 rounded-xl text-sm font-medium transition-colors",
                 renameTarget.name.trim() ? "bg-sage text-primary-foreground hover:bg-sage-deep" : "bg-muted text-muted-foreground cursor-not-allowed"
               )}>
-              Rename
+              {t("renameFolder.save")}
             </button>
           </div>
         </div>,

--- a/src/pages/checklists/CreateMenuSheet.tsx
+++ b/src/pages/checklists/CreateMenuSheet.tsx
@@ -1,4 +1,5 @@
 import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
 import { X, ClipboardList, FileUp, Sparkles, FolderPlus, ChevronRight } from "lucide-react";
 
 export function CreateMenuSheet({ onClose, onBuildOwn, onConvertFile, onBuildAI, onCreateFolder }: {
@@ -8,18 +9,19 @@ export function CreateMenuSheet({ onClose, onBuildOwn, onConvertFile, onBuildAI,
   onBuildAI: () => void;
   onCreateFolder: () => void;
 }) {
+  const { t } = useTranslation("checklists");
   const items = [
-    { label: "Build your own checklist", icon: ClipboardList, action: onBuildOwn },
-    { label: "Convert file", sublabel: "Excel, image or PDF", icon: FileUp, action: onConvertFile },
-    { label: "Build with AI", icon: Sparkles, action: onBuildAI, hasAiIcon: true },
-    { label: "Create a folder", icon: FolderPlus, action: onCreateFolder },
+    { label: t("createMenu.buildOwn"), icon: ClipboardList, action: onBuildOwn },
+    { label: t("createMenu.convertFile"), sublabel: t("createMenu.convertFileSub"), icon: FileUp, action: onConvertFile },
+    { label: t("createMenu.buildAI"), icon: Sparkles, action: onBuildAI, hasAiIcon: true },
+    { label: t("createMenu.createFolder"), icon: FolderPlus, action: onCreateFolder },
   ];
 
   return createPortal(
     <div className="fixed inset-0 z-[60] flex items-end justify-center bg-foreground/20 px-4 pb-8 backdrop-blur-sm animate-fade-in sm:items-center sm:px-6 sm:py-10">
       <div className="bg-card w-full max-w-md rounded-3xl border border-border p-5 pb-6 space-y-1 shadow-2xl animate-fade-in">
         <div className="flex items-center justify-between mb-3">
-          <h2 className="font-display text-lg text-foreground">Create new</h2>
+          <h2 className="font-display text-lg text-foreground">{t("createMenu.heading")}</h2>
           <button onClick={onClose} className="btn-icon">
             <X size={18} className="text-muted-foreground" />
           </button>

--- a/src/pages/checklists/FolderBreadcrumb.tsx
+++ b/src/pages/checklists/FolderBreadcrumb.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { ChevronRight } from "lucide-react";
 import type { FolderItem } from "./types";
 
@@ -6,6 +7,7 @@ export function FolderBreadcrumb({ folders, currentId, onNavigate }: {
   currentId: string | null;
   onNavigate: (id: string | null) => void;
 }) {
+  const { t } = useTranslation("checklists");
   if (!currentId) return null;
   const trail: FolderItem[] = [];
   let cur = currentId;
@@ -17,7 +19,7 @@ export function FolderBreadcrumb({ folders, currentId, onNavigate }: {
   }
   return (
     <div className="flex items-center gap-1 text-xs text-muted-foreground overflow-x-auto pb-1">
-      <button onClick={() => onNavigate(null)} className="shrink-0 hover:text-foreground transition-colors">All</button>
+      <button onClick={() => onNavigate(null)} className="shrink-0 hover:text-foreground transition-colors">{t("breadcrumb.all")}</button>
       {trail.map(f => (
         <span key={f.id} className="flex items-center gap-1 shrink-0">
           <ChevronRight size={10} />

--- a/src/pages/checklists/ItemContextMenu.tsx
+++ b/src/pages/checklists/ItemContextMenu.tsx
@@ -1,4 +1,5 @@
 import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
 import { Move, Pencil, Copy, Download, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -7,17 +8,18 @@ export function ItemContextMenu({ type, onAction, onClose }: {
   onAction: (action: string) => void;
   onClose: () => void;
 }) {
+  const { t } = useTranslation("checklists");
   const folderActions = [
-    { key: "move", label: "Move to folder", icon: Move },
-    { key: "rename", label: "Rename", icon: Pencil },
-    { key: "delete", label: "Delete", icon: Trash2 },
+    { key: "move", label: t("contextMenu.moveToFolder"), icon: Move },
+    { key: "rename", label: t("contextMenu.rename"), icon: Pencil },
+    { key: "delete", label: t("contextMenu.delete"), icon: Trash2 },
   ];
   const checklistActions = [
-    { key: "edit", label: "Edit", icon: Pencil },
-    { key: "duplicate", label: "Duplicate", icon: Copy },
-    { key: "move", label: "Move to folder", icon: Move },
-    { key: "download", label: "Download as PDF", icon: Download },
-    { key: "delete", label: "Delete", icon: Trash2 },
+    { key: "edit", label: t("contextMenu.edit"), icon: Pencil },
+    { key: "duplicate", label: t("contextMenu.duplicate"), icon: Copy },
+    { key: "move", label: t("contextMenu.moveToFolder"), icon: Move },
+    { key: "download", label: t("contextMenu.downloadPdf"), icon: Download },
+    { key: "delete", label: t("contextMenu.delete"), icon: Trash2 },
   ];
   const actions = type === "folder" ? folderActions : checklistActions;
 

--- a/src/pages/checklists/MoveToFolderSheet.tsx
+++ b/src/pages/checklists/MoveToFolderSheet.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
 import { X, Folder, Home, Search } from "lucide-react";
 import type { FolderItem } from "./types";
 
@@ -9,8 +10,9 @@ export function MoveToFolderSheet({ folders, currentFolderId, onMove, onClose }:
   onMove: (folderId: string | null) => void;
   onClose: () => void;
 }) {
+  const { t } = useTranslation("checklists");
   const [search, setSearch] = useState("");
-  const rootOption = { id: null as string | null, name: "No folder" };
+  const rootOption = { id: null as string | null, name: t("moveToFolder.noFolder") };
   const filtered = [rootOption, ...folders.filter(f => f.id !== currentFolderId)]
     .filter(f => f.name.toLowerCase().includes(search.toLowerCase()));
 
@@ -18,18 +20,18 @@ export function MoveToFolderSheet({ folders, currentFolderId, onMove, onClose }:
     <div className="fixed inset-0 z-[60] flex items-end justify-center pb-16 bg-foreground/20 backdrop-blur-sm animate-fade-in sm:items-center sm:pb-0 sm:px-4 sm:py-8">
       <div className="bg-card w-full max-w-lg rounded-t-2xl p-5 pb-20 space-y-4 animate-fade-in max-h-[85vh] overflow-y-auto sm:max-w-2xl sm:rounded-2xl sm:max-h-[90vh]">
         <div className="flex items-center justify-between">
-          <h2 className="font-display text-lg text-foreground">Move to folder</h2>
+          <h2 className="font-display text-lg text-foreground">{t("moveToFolder.heading")}</h2>
           <button onClick={onClose} className="btn-icon">
             <X size={18} className="text-muted-foreground" />
           </button>
         </div>
         <div className="relative">
           <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
-          <input type="text" placeholder="Search folders" value={search} onChange={e => setSearch(e.target.value)}
+          <input type="text" placeholder={t("moveToFolder.searchPlaceholder")} value={search} onChange={e => setSearch(e.target.value)}
             className="w-full pl-9 pr-4 py-2.5 border border-border rounded-xl text-sm bg-muted focus:outline-none focus:ring-1 focus:ring-ring" />
         </div>
         {filtered.length === 0 ? (
-          <p className="text-sm text-muted-foreground text-center py-4">No folders match your search.</p>
+          <p className="text-sm text-muted-foreground text-center py-4">{t("moveToFolder.noMatch")}</p>
         ) : (
           <div className="divide-y divide-border card-surface overflow-hidden">
             {filtered.map(f => {
@@ -40,7 +42,7 @@ export function MoveToFolderSheet({ folders, currentFolderId, onMove, onClose }:
                   {isRoot
                     ? <Home size={16} className="text-muted-foreground shrink-0" />
                     : <Folder size={16} className="text-sage shrink-0" />}
-                  <span className="text-sm text-foreground">{isRoot ? "No folder (unfiled)" : f.name}</span>
+                  <span className="text-sm text-foreground">{isRoot ? t("moveToFolder.noFolderUnfiled") : f.name}</span>
                 </button>
               );
             })}
@@ -48,7 +50,7 @@ export function MoveToFolderSheet({ folders, currentFolderId, onMove, onClose }:
         )}
         {folders.length === 0 && (
           <p className="text-xs text-muted-foreground text-center">
-            No folders yet — create one from the Checklists main view.
+            {t("moveToFolder.noFoldersYet")}
           </p>
         )}
       </div>

--- a/src/pages/checklists/types.ts
+++ b/src/pages/checklists/types.ts
@@ -1,3 +1,5 @@
+import i18n from "@/lib/i18n";
+
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 export type TaskType = "checkbox" | "numeric" | "photo";
@@ -110,6 +112,10 @@ export interface SectionDef {
 
 export type ScheduleType = "daily" | "weekday" | "weekly" | "monthly" | "yearly" | "custom" | "none";
 
+// Kept as English-only literals for ChecklistBuilderModal's schedule picker,
+// which hasn't been extracted to i18n yet (see #594) — getScheduleLabel()
+// below is the translated path used everywhere the *saved* schedule is
+// displayed (checklist list rows, preview modal).
 export const SCHEDULE_LABELS: Record<Exclude<ScheduleType, "custom">, string> = {
   none: "Once",
   daily: "Every day",
@@ -145,7 +151,7 @@ export function getScheduleLabel(schedule?: string | null): string | null {
   if (!schedule) return null;
   const parsed = parseScheduleType(schedule);
   if (parsed === "custom") return schedule;
-  return SCHEDULE_LABELS[parsed];
+  return i18n.t(`schedule.${parsed}`, { ns: "checklists" });
 }
 
 export interface CustomRecurrence {


### PR DESCRIPTION
Covers the main Checklists tab (folder/checklist list, search, location filter, empty states, new-folder/rename/delete/move/create-menu/context-menu sheets, unsaved-changes exit guard) plus the `Checklists.tsx` and `Reporting.tsx` page-shell subtitles. New `checklists` i18n namespace.

`getScheduleLabel()` in `types.ts` (displays a *saved* checklist's schedule in list rows and the preview modal) now routes through i18n. `ChecklistBuilderModal`'s schedule *picker* still uses the old English-only `SCHEDULE_LABELS` constant directly — that file hasn't been extracted yet, so its dropdown stays English until its own PR; left a comment in `types.ts` explaining why both exist so it doesn't read as an oversight.

Real Spanish translations throughout, matching the terminology already used in the nav ("Listas de verificación").

**Deliberately out of scope** (large enough to warrant their own PRs): `ChecklistBuilderModal.tsx`, `FollowUpQuestionEditor.tsx`, `LogicRulesEditor.tsx`, `ConvertFileModal.tsx`, `ChecklistPreviewModal.tsx`, `BuildWithAIModal.tsx`, `ResponseTypePicker.tsx`, `CustomRecurrencePicker.tsx`, `LogDetailModal.tsx`, `ReportingTab.tsx`.

## Test plan
- [x] `bun run lint` — 0 errors
- [x] `bun run test:ci` — 90/90 files, 1383/1383 tests passing
- [x] `bun run build` — succeeds
- [x] Targeted test runs for every touched component confirmed green before the full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
