### PR TITLE
Translate LogDetailModal + ChecklistPreviewModal (Phase 4, part 7 of #594)

### DIFF
--- a/src/locales/en/checklists.json
+++ b/src/locales/en/checklists.json
@@ -143,5 +143,57 @@
       "badgeActionRequired": "ACTION REQ.",
       "badgeUnstarted": "UNSTARTED"
     }
+  },
+  "logDetail": {
+    "exportPdf": "Export PDF",
+    "required": "Required",
+    "instruction": "Instruction",
+    "completed": "Completed",
+    "notCompleted": "Not completed",
+    "noValueEntered": "No value entered",
+    "photo": "Photo",
+    "noPhotoAttached": "No photo attached",
+    "noAnswerEntered": "No answer entered",
+    "noAnswerDetail": "No answer detail recorded for this submission.",
+    "readOnlyNotice": "This is a read-only report. Submitted responses cannot be edited."
+  },
+  "responseTypes": {
+    "checkbox": "Checkbox",
+    "text": "Text answer",
+    "number": "Number",
+    "datetime": "Date & Time",
+    "media": "Photo / Media",
+    "instruction": "Instruction"
+  },
+  "preview": {
+    "yes": "Yes",
+    "no": "No",
+    "notApplicable": "N/A",
+    "optionA": "Option A",
+    "optionB": "Option B",
+    "optionC": "Option C",
+    "fahrenheit": "Fahrenheit",
+    "celsius": "Celsius",
+    "acceptableRange": "Acceptable range: {{min}} to {{max}} {{unit}}",
+    "typeYourAnswer": "Type your answer…",
+    "takePhoto": "Take photo",
+    "instructionPlaceholder": "Instruction content will appear here",
+    "openLinkedTraining": "Open linked training: {{title}}",
+    "openLinkedDocument": "Open linked document: {{title}}",
+    "questionCount_one": "{{count}} question",
+    "questionCount_other": "{{count}} questions",
+    "questionFallback": "Question {{n}}",
+    "edit": "Edit",
+    "close": "Close",
+    "visibleFromTo": "Visible {{from}} - {{to}}",
+    "due": "Due {{time}}",
+    "visibleAllDay": "Visible all day",
+    "required": "Required",
+    "multipleChoiceFallback": "Multiple choice",
+    "followUpQuestion": "Follow-up question",
+    "untitledFollowUp": "Untitled follow-up question",
+    "responseTypeFallback": "Response type",
+    "nestedTriggersEnabled": "{{responseType}} and nested triggers enabled",
+    "structuralPreviewNotice": "This is a structural preview. Staff will see and interact with this checklist from the Kiosk."
   }
 }

--- a/src/locales/es/checklists.json
+++ b/src/locales/es/checklists.json
@@ -143,5 +143,57 @@
       "badgeActionRequired": "REQUIERE ACCIÓN",
       "badgeUnstarted": "SIN EMPEZAR"
     }
+  },
+  "logDetail": {
+    "exportPdf": "Exportar PDF",
+    "required": "Obligatorio",
+    "instruction": "Instrucción",
+    "completed": "Completado",
+    "notCompleted": "No completado",
+    "noValueEntered": "No se ingresó ningún valor",
+    "photo": "Foto",
+    "noPhotoAttached": "Sin foto adjunta",
+    "noAnswerEntered": "No se ingresó respuesta",
+    "noAnswerDetail": "No hay detalle de respuestas registrado para este envío.",
+    "readOnlyNotice": "Este es un informe de solo lectura. Las respuestas enviadas no se pueden editar."
+  },
+  "responseTypes": {
+    "checkbox": "Casilla",
+    "text": "Respuesta de texto",
+    "number": "Número",
+    "datetime": "Fecha y hora",
+    "media": "Foto / Multimedia",
+    "instruction": "Instrucción"
+  },
+  "preview": {
+    "yes": "Sí",
+    "no": "No",
+    "notApplicable": "N/D",
+    "optionA": "Opción A",
+    "optionB": "Opción B",
+    "optionC": "Opción C",
+    "fahrenheit": "Fahrenheit",
+    "celsius": "Celsius",
+    "acceptableRange": "Rango aceptable: {{min}} a {{max}} {{unit}}",
+    "typeYourAnswer": "Escribe tu respuesta…",
+    "takePhoto": "Tomar foto",
+    "instructionPlaceholder": "El contenido de la instrucción aparecerá aquí",
+    "openLinkedTraining": "Abrir capacitación vinculada: {{title}}",
+    "openLinkedDocument": "Abrir documento vinculado: {{title}}",
+    "questionCount_one": "{{count}} pregunta",
+    "questionCount_other": "{{count}} preguntas",
+    "questionFallback": "Pregunta {{n}}",
+    "edit": "Editar",
+    "close": "Cerrar",
+    "visibleFromTo": "Visible {{from}} - {{to}}",
+    "due": "Vence {{time}}",
+    "visibleAllDay": "Visible todo el día",
+    "required": "Obligatorio",
+    "multipleChoiceFallback": "Opción múltiple",
+    "followUpQuestion": "Pregunta de seguimiento",
+    "untitledFollowUp": "Pregunta de seguimiento sin título",
+    "responseTypeFallback": "Tipo de respuesta",
+    "nestedTriggersEnabled": "{{responseType}} y disparadores anidados habilitados",
+    "structuralPreviewNotice": "Esta es una vista previa estructural. El personal verá e interactuará con esta lista desde el Kiosco."
   }
 }

--- a/src/pages/checklists/ChecklistPreviewModal.tsx
+++ b/src/pages/checklists/ChecklistPreviewModal.tsx
@@ -1,10 +1,11 @@
 import { useEffect } from "react";
 import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
 import { X, Pencil, CheckSquare, Square, Hash, Type, Calendar, Camera, PenLine, User, Info, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { ChecklistItem, ResponseType } from "./types";
 import { getScheduleLabel } from "./types";
-import { RESPONSE_TYPES } from "./data";
+import { RESPONSE_TYPES, getResponseTypeLabel } from "./data";
 
 function formatTime12h(time24: string) {
   const [h, m] = time24.split(":").map(Number);
@@ -31,10 +32,11 @@ function MockResponse({
     instructionLinkSection?: "library" | "training";
   };
 }) {
+  const { t } = useTranslation("checklists");
   if (responseType === "checkbox") {
     return (
       <div className="flex gap-2 mt-2">
-        {["Yes", "No", "N/A"].map(opt => (
+        {[t("preview.yes"), t("preview.no"), t("preview.notApplicable")].map(opt => (
           <div key={opt} className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-border bg-muted/50 text-xs text-muted-foreground">
             <Square size={11} /> {opt}
           </div>
@@ -43,7 +45,7 @@ function MockResponse({
     );
   }
   if (responseType === "multiple_choice") {
-    const previewChoices = choices?.length ? choices : ["Option A", "Option B", "Option C"];
+    const previewChoices = choices?.length ? choices : [t("preview.optionA"), t("preview.optionB"), t("preview.optionC")];
     return (
         <div className="flex gap-2 mt-2 flex-wrap">
         {previewChoices.map((opt, idx) => (
@@ -69,13 +71,17 @@ function MockResponse({
           <span className="text-xs text-muted-foreground">0.00</span>
           {isTemperature && (
             <span className="ml-auto text-xs px-2 py-0.5 rounded-full bg-sage-light text-sage-deep">
-              {questionConfig?.temperatureUnit === "F" ? "Fahrenheit" : "Celsius"}
+              {questionConfig?.temperatureUnit === "F" ? t("preview.fahrenheit") : t("preview.celsius")}
             </span>
           )}
         </div>
         {isTemperature && (
           <p className="text-xs text-muted-foreground">
-            Acceptable range: {questionConfig?.numberMin ?? "—"} to {questionConfig?.numberMax ?? "—"} {questionConfig?.temperatureUnit === "F" ? "F" : "C"}
+            {t("preview.acceptableRange", {
+              min: questionConfig?.numberMin ?? "—",
+              max: questionConfig?.numberMax ?? "—",
+              unit: questionConfig?.temperatureUnit === "F" ? "F" : "C",
+            })}
           </p>
         )}
       </div>
@@ -85,7 +91,7 @@ function MockResponse({
     return (
       <div className="mt-2 flex items-center gap-2 px-3 py-2 rounded-lg border border-border bg-muted/50">
         <Type size={11} className="text-muted-foreground shrink-0" />
-        <span className="text-xs text-muted-foreground">Type your answer…</span>
+        <span className="text-xs text-muted-foreground">{t("preview.typeYourAnswer")}</span>
       </div>
     );
   }
@@ -107,7 +113,7 @@ function MockResponse({
     return (
       <div className="mt-2 flex items-center gap-2 px-3 py-2 rounded-lg border border-dashed border-border bg-muted/30 w-32">
         <Camera size={11} className="text-muted-foreground shrink-0" />
-        <span className="text-xs text-muted-foreground">Take photo</span>
+        <span className="text-xs text-muted-foreground">{t("preview.takePhoto")}</span>
       </div>
     );
   }
@@ -118,12 +124,14 @@ function MockResponse({
       <div className="mt-2 px-3 py-2 rounded-lg bg-muted/40 border-l-2 border-l-sage/40 space-y-2">
         <div className="flex items-center gap-1.5">
           <Info size={11} className="text-sage shrink-0" />
-          <span className="text-xs text-muted-foreground italic">Instruction content will appear here</span>
+          <span className="text-xs text-muted-foreground italic">{t("preview.instructionPlaceholder")}</span>
         </div>
         {questionConfig?.instructionLinkTitle && (
           <div className="inline-flex items-center gap-1.5 rounded-full border border-sage/20 bg-background/70 px-3 py-1 text-xs text-sage-deep">
             <ChevronRight size={10} />
-            Open linked {questionConfig.instructionLinkSection === "training" ? "training" : "document"}: {questionConfig.instructionLinkTitle}
+            {questionConfig.instructionLinkSection === "training"
+              ? t("preview.openLinkedTraining", { title: questionConfig.instructionLinkTitle })
+              : t("preview.openLinkedDocument", { title: questionConfig.instructionLinkTitle })}
           </div>
         )}
       </div>
@@ -137,12 +145,13 @@ export function ChecklistPreviewModal({ checklist, onClose, onEdit }: {
   onClose: () => void;
   onEdit: () => void;
 }) {
+  const { t } = useTranslation("checklists");
   const sections = checklist.sections?.length ? checklist.sections : [{
     id: "preview-sec",
     name: "",
     questions: Array.from({ length: checklist.questionsCount || 1 }, (_, i) => ({
       id: `pq-${i}`,
-      text: `Question ${i + 1}`,
+      text: t("preview.questionFallback", { n: i + 1 }),
       responseType: "checkbox" as ResponseType,
       required: i < 2,
     })),
@@ -170,7 +179,7 @@ export function ChecklistPreviewModal({ checklist, onClose, onEdit }: {
           <div className="flex-1 min-w-0 pr-3">
             <h2 className="font-display text-lg text-foreground leading-snug">{checklist.title}</h2>
             <div className="flex items-center gap-2 mt-1 flex-wrap">
-              <span className="text-xs text-muted-foreground">{totalQ} question{totalQ !== 1 ? "s" : ""}</span>
+              <span className="text-xs text-muted-foreground">{t("preview.questionCount", { count: totalQ })}</span>
               {checklist.schedule && (
                 <>
                   <span className="text-muted-foreground/40 text-xs">·</span>
@@ -187,20 +196,20 @@ export function ChecklistPreviewModal({ checklist, onClose, onEdit }: {
                 <>
                   <span className="text-muted-foreground/40 text-xs">·</span>
                   <span className="text-xs text-muted-foreground">
-                    Visible {formatTime12h(checklist.visibility_from!)} - {formatTime12h(checklist.visibility_until!)}
+                    {t("preview.visibleFromTo", { from: formatTime12h(checklist.visibility_from!), to: formatTime12h(checklist.visibility_until!) })}
                   </span>
                 </>
               )}
               {!hasVisibilityWindow && checklist.due_time && (
                 <>
                   <span className="text-muted-foreground/40 text-xs">·</span>
-                  <span className="text-xs text-muted-foreground">Due {formatTime12h(checklist.due_time)}</span>
+                  <span className="text-xs text-muted-foreground">{t("preview.due", { time: formatTime12h(checklist.due_time) })}</span>
                 </>
               )}
               {!hasVisibilityWindow && !checklist.due_time && (
                 <>
                   <span className="text-muted-foreground/40 text-xs">·</span>
-                  <span className="text-xs text-muted-foreground">Visible all day</span>
+                  <span className="text-xs text-muted-foreground">{t("preview.visibleAllDay")}</span>
                 </>
               )}
             </div>
@@ -208,14 +217,14 @@ export function ChecklistPreviewModal({ checklist, onClose, onEdit }: {
           <div className="flex flex-wrap items-center gap-2 shrink-0 sm:justify-end">
             <button onClick={onEdit}
               className="flex items-center gap-1.5 text-xs font-medium text-sage px-3 py-1.5 rounded-full border border-sage/40 hover:bg-sage-light transition-colors">
-              <Pencil size={12} /> Edit
+              <Pencil size={12} /> {t("preview.edit")}
             </button>
             <button
               onClick={onClose}
               className="flex items-center gap-1 px-3 py-1.5 rounded-full bg-muted hover:bg-muted/80 transition-colors text-xs font-medium text-muted-foreground"
             >
               <X size={14} />
-              Close
+              {t("preview.close")}
             </button>
           </div>
         </div>
@@ -243,14 +252,14 @@ export function ChecklistPreviewModal({ checklist, onClose, onEdit }: {
                       </div>
                       <div className="flex-1 min-w-0">
                         <div className="flex items-start gap-2">
-                          <p className="text-sm text-foreground flex-1">{q.text || `Question ${globalIdx + 1}`}</p>
+                          <p className="text-sm text-foreground flex-1">{q.text || t("preview.questionFallback", { n: globalIdx + 1 })}</p>
                           {q.required && (
-                            <span className="text-xs text-status-error font-medium shrink-0 mt-0.5">Required</span>
+                            <span className="text-xs text-status-error font-medium shrink-0 mt-0.5">{t("preview.required")}</span>
                           )}
                         </div>
                         <div className="flex items-center gap-1 mt-1">
                           <RtIcon size={10} className="text-muted-foreground" />
-                          <span className="text-xs text-muted-foreground">{rtDef?.label || "Multiple choice"}</span>
+                          <span className="text-xs text-muted-foreground">{rtDef ? getResponseTypeLabel(rtDef.key) : t("preview.multipleChoiceFallback")}</span>
                         </div>
                         <MockResponse
                           responseType={q.responseType}
@@ -268,10 +277,14 @@ export function ChecklistPreviewModal({ checklist, onClose, onEdit }: {
                                 if (!followUp) return null;
                                 return (
                                   <div key={`${q.id}-${ri}-${ti}`} className="rounded-lg border border-sage/20 bg-sage/5 px-3 py-2">
-                                    <p className="text-xs uppercase tracking-wide text-sage-deep/70">Follow-up question</p>
-                                    <p className="text-sm font-medium text-foreground mt-1">{followUp.text || "Untitled follow-up question"}</p>
+                                    <p className="text-xs uppercase tracking-wide text-sage-deep/70">{t("preview.followUpQuestion")}</p>
+                                    <p className="text-sm font-medium text-foreground mt-1">{followUp.text || t("preview.untitledFollowUp")}</p>
                                     <p className="text-xs text-muted-foreground mt-0.5">
-                                      {RESPONSE_TYPES.find(r => r.key === followUp.responseType)?.label || "Response type"} and nested triggers enabled
+                                      {t("preview.nestedTriggersEnabled", {
+                                        responseType: RESPONSE_TYPES.find(r => r.key === followUp.responseType)
+                                          ? getResponseTypeLabel(followUp.responseType)
+                                          : t("preview.responseTypeFallback"),
+                                      })}
                                     </p>
                                   </div>
                                 );
@@ -290,7 +303,7 @@ export function ChecklistPreviewModal({ checklist, onClose, onEdit }: {
           {/* Footer note */}
           <div className="px-5 py-4 border-t border-border mt-2">
             <p className="text-xs text-muted-foreground text-center">
-              This is a structural preview. Staff will see and interact with this checklist from the Kiosk.
+              {t("preview.structuralPreviewNotice")}
             </p>
           </div>
         </div>

--- a/src/pages/checklists/LogDetailModal.tsx
+++ b/src/pages/checklists/LogDetailModal.tsx
@@ -1,4 +1,5 @@
 import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
 import { X, Camera, Check, MessageSquare, FileText, Hash, Type, Calendar, GitBranch, Info } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { exportLogDetailPdf } from "@/lib/export-utils";
@@ -27,6 +28,7 @@ function isAnswered(type: string, ans: any): boolean {
 }
 
 export function LogDetailModal({ log, onClose }: { log: LogEntry; onClose: () => void }) {
+  const { t } = useTranslation("checklists");
   const scoreColor =
     log.score == null ? "text-muted-foreground" :
     log.score >= 85 ? "text-status-ok" :
@@ -61,7 +63,7 @@ export function LogDetailModal({ log, onClose }: { log: LogEntry; onClose: () =>
             <span className={cn("text-lg font-semibold", scoreColor)}>{log.score == null ? "—" : `${log.score}%`}</span>
             <button onClick={handleExportPdf}
               className="flex items-center gap-1.5 text-xs font-medium text-sage px-3 py-1.5 rounded-full border border-sage/40 hover:bg-sage-light transition-colors">
-              <FileText size={12} /> Export PDF
+              <FileText size={12} /> {t("logDetail.exportPdf")}
             </button>
             <button onClick={onClose} className="btn-icon">
               <X size={18} className="text-muted-foreground" />
@@ -127,34 +129,34 @@ export function LogDetailModal({ log, onClose }: { log: LogEntry; onClose: () =>
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2 flex-wrap">
                       <p className="text-sm text-foreground leading-snug">{ans.label}</p>
-                      {ans.required && <span className="text-xs text-muted-foreground/60">Required</span>}
+                      {ans.required && <span className="text-xs text-muted-foreground/60">{t("logDetail.required")}</span>}
                       {type === "instruction" && (
-                        <span className="text-xs text-sage/70 font-medium uppercase tracking-wide">Instruction</span>
+                        <span className="text-xs text-sage/70 font-medium uppercase tracking-wide">{t("logDetail.instruction")}</span>
                       )}
                     </div>
 
                     {/* Answer value */}
                     {type === "checkbox" && (
                       <p className={cn("mt-1 text-xs font-medium", answered ? "text-status-ok" : "text-status-error")}>
-                        {answered ? "Completed" : "Not completed"}
+                        {answered ? t("logDetail.completed") : t("logDetail.notCompleted")}
                       </p>
                     )}
                     {type === "number" && ans.answer && (
                       <p className="mt-1 text-sm font-medium text-foreground">{ans.answer}</p>
                     )}
                     {type === "number" && !ans.answer && (
-                      <p className="mt-1 text-xs text-status-error font-medium">No value entered</p>
+                      <p className="mt-1 text-xs text-status-error font-medium">{t("logDetail.noValueEntered")}</p>
                     )}
                     {type === "photo" && (answered ? (
                       <div className="mt-2 w-24 h-16 rounded-lg bg-muted flex items-center justify-center border border-border">
                         <Camera size={18} className="text-muted-foreground" />
-                        <span className="text-xs text-muted-foreground ml-1">Photo</span>
+                        <span className="text-xs text-muted-foreground ml-1">{t("logDetail.photo")}</span>
                       </div>
-                    ) : <p className="mt-1 text-xs text-status-error font-medium">No photo attached</p>)}
+                    ) : <p className="mt-1 text-xs text-status-error font-medium">{t("logDetail.noPhotoAttached")}</p>)}
                     {(type === "text" || type === "multiple_choice" || type === "datetime") && (
                       ans.answer
                         ? <p className="mt-1 text-sm text-foreground">{ans.answer}</p>
-                        : <p className="mt-1 text-xs text-status-error font-medium">No answer entered</p>
+                        : <p className="mt-1 text-xs text-status-error font-medium">{t("logDetail.noAnswerEntered")}</p>
                     )}
                     {type === "instruction" && ans.answer && ans.answer !== "" && ans.answer !== "undefined" && (
                       <p className="mt-1 text-xs text-muted-foreground">{ans.answer}</p>
@@ -174,14 +176,14 @@ export function LogDetailModal({ log, onClose }: { log: LogEntry; onClose: () =>
 
           {!(log.answers ?? []).length && (
             <div className="px-5 py-8 text-center">
-              <p className="text-sm text-muted-foreground">No answer detail recorded for this submission.</p>
+              <p className="text-sm text-muted-foreground">{t("logDetail.noAnswerDetail")}</p>
             </div>
           )}
         </div>
 
         <div className="px-5 py-4 border-t border-border shrink-0">
           <p className="text-xs text-muted-foreground text-center">
-            This is a read-only report. Submitted responses cannot be edited.
+            {t("logDetail.readOnlyNotice")}
           </p>
         </div>
       </div>

--- a/src/pages/checklists/data.ts
+++ b/src/pages/checklists/data.ts
@@ -1,5 +1,6 @@
 import type { ElementType } from "react";
 import { CalendarIcon, Type, Hash, CheckSquare, Image, Pencil, User, Info } from "lucide-react";
+import i18n from "@/lib/i18n";
 import type { FolderItem, ChecklistItem, Action, LogEntry, ResponseType } from "./types";
 
 // ─── Mock Data ────────────────────────────────────────────────────────────────
@@ -107,6 +108,14 @@ export const RESPONSE_TYPES: { key: ResponseType; label: string; icon: ElementTy
   // Existing saved checklists that contain these types still run — the kiosk
   // runner falls back to a plain text input for any unrecognised/removed type.
 ];
+
+// Translated label lookup for RESPONSE_TYPES — used by callers that have been
+// extracted to i18n. The RESPONSE_TYPES.label field above stays English-only
+// until ResponseTypePicker/ChecklistBuilderModal/FollowUpQuestionEditor get
+// their own translation passes (see #594).
+export function getResponseTypeLabel(key: ResponseType): string {
+  return i18n.t(`responseTypes.${key}`, { ns: "checklists" });
+}
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
**LogDetailModal**: Export PDF button, question-type badges (Required, Instruction), answer-state copy (Completed/Not completed, No value entered, No photo attached, No answer entered), empty state, and the read-only footer notice.

**ChecklistPreviewModal**: mock response previews for every response type (checkbox Yes/No/N/A, multiple-choice option placeholders, number/temperature range copy, text/datetime/photo/instruction placeholders), header metadata (question count with i18next pluralization, schedule, visibility window text), Edit/Close buttons, and the follow-up-question callout.

Adds `getResponseTypeLabel()` to `data.ts` as a translated companion to the existing `RESPONSE_TYPES` constant — same pattern as `getScheduleLabel()` in `types.ts` (#616): the constant's `.label` field stays English-only for the not-yet-translated callers (`ResponseTypePicker`, `ChecklistBuilderModal`, `FollowUpQuestionEditor`), while newly-extracted callers use the translated getter.

Real Spanish translations throughout.

## Test plan
- [x] `bun run lint` — 0 errors
- [x] `bun run test:ci` — 90/90 files, 1383/1383 tests passing
- [x] `bun run build` — succeeds
- [x] Targeted runs: `LogDetailModal.test.tsx` (16/16), `ChecklistPreviewModal.test.tsx` (15/15), full `checklists/` directory (14 files, 292 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
