### PR TITLE
Translate ResponseTypePicker, CustomRecurrencePicker, BuildWithAIModal, ConvertFileModal (Phase 4, part 8 of #594)

### DIFF
--- a/src/locales/en/checklists.json
+++ b/src/locales/en/checklists.json
@@ -165,6 +165,49 @@
     "media": "Photo / Media",
     "instruction": "Instruction"
   },
+  "responsePicker": {
+    "heading": "Type of response",
+    "responsesSection": "Responses",
+    "multipleChoiceSection": "Multiple choice"
+  },
+  "customRecurrence": {
+    "heading": "Custom recurrence",
+    "repeatEvery": "Repeat every",
+    "units": { "day": "day", "week": "week", "month": "month", "year": "year" },
+    "repeatOn": "Repeat on",
+    "dayInitials": { "mon": "M", "tue": "T", "wed": "W", "thu": "T", "fri": "F", "sat": "S", "sun": "S" },
+    "ends": "Ends",
+    "never": "Never",
+    "on": "On",
+    "after": "After",
+    "occurrences": "occurrences",
+    "cancel": "Cancel",
+    "done": "Done"
+  },
+  "buildAI": {
+    "heading": "Build with AI",
+    "description": "Describe the checklist you need and AI will generate it for you.",
+    "promptPlaceholder": "e.g. Create a daily opening checklist for a restaurant kitchen with food safety, cleanliness, and equipment checks…",
+    "generating": "Generating…",
+    "generate": "Generate checklist",
+    "unexpectedResponse": "Unexpected response from AI. Please try again.",
+    "genericError": "Something went wrong. Please try again."
+  },
+  "convertFile": {
+    "heading": "Convert file to checklist",
+    "close": "Close",
+    "description": "Upload an Excel, PDF, or image file and we'll convert it into a checklist.",
+    "tapToSelect": "Tap to select a file",
+    "fileTypesHint": "Excel, PDF, or image · Max 10MB",
+    "converting": "Converting…",
+    "convert": "Convert to checklist",
+    "genericError": "Something went wrong. Please try again.",
+    "quotaError": "AI service quota reached. Please try again later or contact support.",
+    "unavailableError": "The AI service is temporarily unavailable. Please try again in a moment.",
+    "unexpectedResponseError": "The AI returned an unexpected response. Please try again.",
+    "networkError": "Network error. Check your connection and try again.",
+    "unexpectedFromAI": "Unexpected response from AI. Please try again."
+  },
   "preview": {
     "yes": "Yes",
     "no": "No",

--- a/src/locales/es/checklists.json
+++ b/src/locales/es/checklists.json
@@ -165,6 +165,49 @@
     "media": "Foto / Multimedia",
     "instruction": "Instrucción"
   },
+  "responsePicker": {
+    "heading": "Tipo de respuesta",
+    "responsesSection": "Respuestas",
+    "multipleChoiceSection": "Opción múltiple"
+  },
+  "customRecurrence": {
+    "heading": "Repetición personalizada",
+    "repeatEvery": "Repetir cada",
+    "units": { "day": "día", "week": "semana", "month": "mes", "year": "año" },
+    "repeatOn": "Repetir el",
+    "dayInitials": { "mon": "L", "tue": "M", "wed": "X", "thu": "J", "fri": "V", "sat": "S", "sun": "D" },
+    "ends": "Termina",
+    "never": "Nunca",
+    "on": "El día",
+    "after": "Después de",
+    "occurrences": "repeticiones",
+    "cancel": "Cancelar",
+    "done": "Listo"
+  },
+  "buildAI": {
+    "heading": "Crear con IA",
+    "description": "Describe la lista que necesitas y la IA la generará por ti.",
+    "promptPlaceholder": "p. ej. Crea una lista de apertura diaria para una cocina de restaurante con revisiones de seguridad alimentaria, limpieza y equipo…",
+    "generating": "Generando…",
+    "generate": "Generar lista",
+    "unexpectedResponse": "Respuesta inesperada de la IA. Inténtalo de nuevo.",
+    "genericError": "Algo salió mal. Inténtalo de nuevo."
+  },
+  "convertFile": {
+    "heading": "Convertir archivo a lista",
+    "close": "Cerrar",
+    "description": "Sube un archivo Excel, PDF o imagen y lo convertiremos en una lista de verificación.",
+    "tapToSelect": "Toca para seleccionar un archivo",
+    "fileTypesHint": "Excel, PDF o imagen · Máx. 10 MB",
+    "converting": "Convirtiendo…",
+    "convert": "Convertir a lista",
+    "genericError": "Algo salió mal. Inténtalo de nuevo.",
+    "quotaError": "Se alcanzó el límite del servicio de IA. Inténtalo más tarde o contacta a soporte.",
+    "unavailableError": "El servicio de IA no está disponible temporalmente. Inténtalo de nuevo en un momento.",
+    "unexpectedResponseError": "La IA devolvió una respuesta inesperada. Inténtalo de nuevo.",
+    "networkError": "Error de red. Revisa tu conexión e inténtalo de nuevo.",
+    "unexpectedFromAI": "Respuesta inesperada de la IA. Inténtalo de nuevo."
+  },
   "preview": {
     "yes": "Sí",
     "no": "No",

--- a/src/pages/checklists/BuildWithAIModal.tsx
+++ b/src/pages/checklists/BuildWithAIModal.tsx
@@ -1,11 +1,13 @@
 import { useState } from "react";
 import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
 import { X, Sparkles, AlertCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { supabase } from "@/lib/supabase";
 import type { SectionDef } from "./types";
 
 export function BuildWithAIModal({ onClose, onGenerate }: { onClose: () => void; onGenerate: (title: string, sections: SectionDef[]) => void }) {
+  const { t } = useTranslation("checklists");
   const [prompt, setPrompt] = useState("");
   const [generating, setGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -23,11 +25,11 @@ export function BuildWithAIModal({ onClose, onGenerate }: { onClose: () => void;
       if (data?.error) throw new Error(data.error);
 
       const { title, sections } = data as { title: string; sections: SectionDef[] };
-      if (!title || !Array.isArray(sections)) throw new Error("Unexpected response from AI. Please try again.");
+      if (!title || !Array.isArray(sections)) throw new Error(t("buildAI.unexpectedResponse"));
       onGenerate(title, sections);
       onClose();
     } catch (e: any) {
-      setError(e?.message ?? "Something went wrong. Please try again.");
+      setError(e?.message ?? t("buildAI.genericError"));
     } finally {
       setGenerating(false);
     }
@@ -38,17 +40,17 @@ export function BuildWithAIModal({ onClose, onGenerate }: { onClose: () => void;
       <div className="bg-card w-full max-w-lg rounded-t-2xl p-5 pb-20 space-y-5 animate-fade-in sm:max-w-2xl sm:rounded-2xl sm:pb-8">
         <div className="flex items-center justify-between">
           <h2 className="font-display text-lg text-foreground flex items-center gap-2">
-            Build with AI
+            {t("buildAI.heading")}
             <Sparkles size={16} className="text-lavender" />
           </h2>
           <button onClick={onClose} className="btn-icon">
             <X size={18} className="text-muted-foreground" />
           </button>
         </div>
-        <p className="text-sm text-muted-foreground">Describe the checklist you need and AI will generate it for you.</p>
+        <p className="text-sm text-muted-foreground">{t("buildAI.description")}</p>
         <textarea
           autoFocus
-          placeholder="e.g. Create a daily opening checklist for a restaurant kitchen with food safety, cleanliness, and equipment checks…"
+          placeholder={t("buildAI.promptPlaceholder")}
           value={prompt}
           onChange={e => setPrompt(e.target.value)}
           rows={4}
@@ -68,7 +70,7 @@ export function BuildWithAIModal({ onClose, onGenerate }: { onClose: () => void;
           )}
         >
           <Sparkles size={14} />
-          {generating ? "Generating…" : "Generate checklist"}
+          {generating ? t("buildAI.generating") : t("buildAI.generate")}
         </button>
       </div>
     </div>,

--- a/src/pages/checklists/ConvertFileModal.tsx
+++ b/src/pages/checklists/ConvertFileModal.tsx
@@ -1,8 +1,10 @@
 import { useState, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
 import { X, FileUp, AlertCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { supabase } from "@/lib/supabase";
+import i18n from "@/lib/i18n";
 import type { SectionDef } from "./types";
 
 /** Reads a file as a base64-encoded string. */
@@ -70,24 +72,26 @@ async function extractFileContent(file: File): Promise<
 }
 
 function humanizeConvertError(msg: string): string {
-  if (!msg) return "Something went wrong. Please try again.";
+  const t = (key: string) => i18n.t(`convertFile.${key}`, { ns: "checklists" });
+  if (!msg) return t("genericError");
   const l = msg.toLowerCase();
   if (l.includes("quota") || l.includes("billing") || l.includes("credit") || l.includes("rate limit") || l.includes("429")) {
-    return "AI service quota reached. Please try again later or contact support.";
+    return t("quotaError");
   }
   if (l.includes("non-2xx") || l.includes("edge function") || l.includes("502") || l.includes("503")) {
-    return "The AI service is temporarily unavailable. Please try again in a moment.";
+    return t("unavailableError");
   }
   if (l.includes("not an array") || l.includes("unexpected response")) {
-    return "The AI returned an unexpected response. Please try again.";
+    return t("unexpectedResponseError");
   }
   if (l.includes("network") || l.includes("failed to fetch")) {
-    return "Network error. Check your connection and try again.";
+    return t("networkError");
   }
   return msg;
 }
 
 export function ConvertFileModal({ onClose, onConvert }: { onClose: () => void; onConvert: (sections: SectionDef[]) => void }) {
+  const { t } = useTranslation("checklists");
   const [dragOver, setDragOver] = useState(false);
   const [file, setFile] = useState<File | null>(null);
   const [converting, setConverting] = useState(false);
@@ -122,7 +126,7 @@ export function ConvertFileModal({ onClose, onConvert }: { onClose: () => void; 
       if (data?.error) throw new Error(data.error);
 
       const { sections } = data as { sections: SectionDef[] };
-      if (!Array.isArray(sections)) throw new Error("Unexpected response from AI. Please try again.");
+      if (!Array.isArray(sections)) throw new Error(t("convertFile.unexpectedFromAI"));
       onConvert(sections);
       onClose();
     } catch (e: any) {
@@ -142,16 +146,16 @@ export function ConvertFileModal({ onClose, onConvert }: { onClose: () => void; 
         onClick={e => e.stopPropagation()}
       >
         <div className="flex items-center justify-between">
-          <h2 className="font-display text-lg text-foreground">Convert file to checklist</h2>
+          <h2 className="font-display text-lg text-foreground">{t("convertFile.heading")}</h2>
           <button
             onClick={onClose}
             className="flex items-center gap-1 px-3 py-1.5 rounded-full bg-muted hover:bg-muted/80 transition-colors text-xs font-medium text-muted-foreground"
           >
             <X size={14} />
-            Close
+            {t("convertFile.close")}
           </button>
         </div>
-        <p className="text-sm text-muted-foreground">Upload an Excel, PDF, or image file and we'll convert it into a checklist.</p>
+        <p className="text-sm text-muted-foreground">{t("convertFile.description")}</p>
         {/* Hidden input kept in DOM so Safari can always trigger it via .click() */}
         <input
           ref={fileInputRef}
@@ -180,8 +184,8 @@ export function ConvertFileModal({ onClose, onConvert }: { onClose: () => void; 
             <p className="text-sm font-medium text-foreground">{file.name}</p>
           ) : (
             <>
-              <p className="text-sm font-medium text-foreground">Tap to select a file</p>
-              <p className="text-xs text-muted-foreground mt-1">Excel, PDF, or image · Max 10MB</p>
+              <p className="text-sm font-medium text-foreground">{t("convertFile.tapToSelect")}</p>
+              <p className="text-xs text-muted-foreground mt-1">{t("convertFile.fileTypesHint")}</p>
             </>
           )}
         </div>
@@ -198,7 +202,7 @@ export function ConvertFileModal({ onClose, onConvert }: { onClose: () => void; 
             file && !converting ? "bg-sage text-primary-foreground hover:bg-sage-deep" : "bg-muted text-muted-foreground cursor-not-allowed"
           )}
         >
-          {converting ? "Converting…" : "Convert to checklist"}
+          {converting ? t("convertFile.converting") : t("convertFile.convert")}
         </button>
       </div>
     </div>,

--- a/src/pages/checklists/CustomRecurrencePicker.tsx
+++ b/src/pages/checklists/CustomRecurrencePicker.tsx
@@ -1,4 +1,5 @@
 import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
 import { ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { CustomRecurrence } from "./types";
@@ -8,18 +9,19 @@ export function CustomRecurrencePicker({ value, onChange, onClose }: {
   onChange: (v: CustomRecurrence) => void;
   onClose: () => void;
 }) {
-  const DAYS = ["M", "T", "W", "T", "F", "S", "S"];
+  const { t } = useTranslation("checklists");
   const DAY_KEYS = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"];
+  const DAYS = DAY_KEYS.map(k => t(`customRecurrence.dayInitials.${k}`));
   const UNITS: CustomRecurrence["unit"][] = ["day", "week", "month", "year"];
 
   return createPortal(
     <div className="fixed inset-0 z-[70] flex items-end justify-center pb-16 bg-foreground/20 backdrop-blur-sm animate-fade-in sm:items-center sm:pb-0 sm:px-4 sm:py-8">
       <div className="bg-card w-full max-w-lg rounded-t-2xl p-5 pb-20 space-y-5 animate-fade-in max-h-[85vh] overflow-y-auto sm:max-w-2xl sm:rounded-2xl sm:max-h-[90vh]">
-        <h2 className="font-display text-xl text-foreground">Custom recurrence</h2>
+        <h2 className="font-display text-xl text-foreground">{t("customRecurrence.heading")}</h2>
 
         {/* Repeat every */}
         <div className="flex items-center gap-3">
-          <span className="text-sm text-foreground">Repeat every</span>
+          <span className="text-sm text-foreground">{t("customRecurrence.repeatEvery")}</span>
           <input type="number" min={1} value={value.interval}
             onChange={e => onChange({ ...value, interval: Math.max(1, parseInt(e.target.value) || 1) })}
             className="w-16 text-sm border border-border rounded-lg px-3 py-2 bg-muted text-center focus:outline-none focus:ring-1 focus:ring-ring"
@@ -28,7 +30,7 @@ export function CustomRecurrencePicker({ value, onChange, onClose }: {
             <select value={value.unit}
               onChange={e => onChange({ ...value, unit: e.target.value as CustomRecurrence["unit"] })}
               className="text-sm border border-border rounded-lg px-3 py-2 bg-muted pr-8 focus:outline-none focus:ring-1 focus:ring-ring appearance-none">
-              {UNITS.map(u => <option key={u} value={u}>{u}</option>)}
+              {UNITS.map(u => <option key={u} value={u}>{t(`customRecurrence.units.${u}`)}</option>)}
             </select>
             <ChevronDown size={14} className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground pointer-events-none" />
           </div>
@@ -37,7 +39,7 @@ export function CustomRecurrencePicker({ value, onChange, onClose }: {
         {/* Repeat on (only for week) */}
         {value.unit === "week" && (
           <div>
-            <p className="text-sm text-foreground mb-2">Repeat on</p>
+            <p className="text-sm text-foreground mb-2">{t("customRecurrence.repeatOn")}</p>
             <div className="flex gap-2">
               {DAYS.map((d, i) => (
                 <button key={i} onClick={() => {
@@ -59,21 +61,21 @@ export function CustomRecurrencePicker({ value, onChange, onClose }: {
 
         {/* Ends */}
         <div>
-          <p className="text-sm text-foreground mb-3">Ends</p>
+          <p className="text-sm text-foreground mb-3">{t("customRecurrence.ends")}</p>
           <div className="space-y-3">
             <label className="flex items-center gap-3 cursor-pointer">
               <div className={cn("w-5 h-5 rounded-full border-2 flex items-center justify-center",
                 value.ends === "never" ? "border-sage" : "border-border")}>
                 {value.ends === "never" && <div className="w-2.5 h-2.5 rounded-full bg-sage" />}
               </div>
-              <button onClick={() => onChange({ ...value, ends: "never" })} className="text-sm text-foreground">Never</button>
+              <button onClick={() => onChange({ ...value, ends: "never" })} className="text-sm text-foreground">{t("customRecurrence.never")}</button>
             </label>
             <label className="flex items-center gap-3 cursor-pointer">
               <div className={cn("w-5 h-5 rounded-full border-2 flex items-center justify-center",
                 value.ends === "on" ? "border-sage" : "border-border")}>
                 {value.ends === "on" && <div className="w-2.5 h-2.5 rounded-full bg-sage" />}
               </div>
-              <button onClick={() => onChange({ ...value, ends: "on" })} className="text-sm text-foreground">On</button>
+              <button onClick={() => onChange({ ...value, ends: "on" })} className="text-sm text-foreground">{t("customRecurrence.on")}</button>
               <input type="date" value={value.endDate || ""} onChange={e => onChange({ ...value, ends: "on", endDate: e.target.value })}
                 className="text-sm border border-border rounded-lg px-3 py-1.5 bg-muted focus:outline-none focus:ring-1 focus:ring-ring" />
             </label>
@@ -82,21 +84,21 @@ export function CustomRecurrencePicker({ value, onChange, onClose }: {
                 value.ends === "after" ? "border-sage" : "border-border")}>
                 {value.ends === "after" && <div className="w-2.5 h-2.5 rounded-full bg-sage" />}
               </div>
-              <button onClick={() => onChange({ ...value, ends: "after" })} className="text-sm text-foreground">After</button>
+              <button onClick={() => onChange({ ...value, ends: "after" })} className="text-sm text-foreground">{t("customRecurrence.after")}</button>
               <input type="number" min={1} value={value.occurrences || 13}
                 onChange={e => onChange({ ...value, ends: "after", occurrences: parseInt(e.target.value) || 1 })}
                 className="w-16 text-sm border border-border rounded-lg px-3 py-1.5 bg-muted text-center focus:outline-none focus:ring-1 focus:ring-ring" />
-              <span className="text-sm text-muted-foreground">occurrences</span>
+              <span className="text-sm text-muted-foreground">{t("customRecurrence.occurrences")}</span>
             </label>
           </div>
         </div>
 
         <div className="flex gap-3 pt-2">
           <button onClick={onClose} className="flex-1 py-3 rounded-xl text-sm font-medium border border-border text-foreground hover:bg-muted transition-colors">
-            Cancel
+            {t("customRecurrence.cancel")}
           </button>
           <button onClick={onClose} className="flex-1 py-3 rounded-xl text-sm font-medium bg-sage text-primary-foreground hover:bg-sage-deep transition-colors">
-            Done
+            {t("customRecurrence.done")}
           </button>
         </div>
       </div>

--- a/src/pages/checklists/ResponseTypePicker.tsx
+++ b/src/pages/checklists/ResponseTypePicker.tsx
@@ -1,9 +1,10 @@
 import type { CSSProperties } from "react";
 import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
 import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { ResponseType } from "./types";
-import { RESPONSE_TYPES, multipleChoiceSets } from "./data";
+import { RESPONSE_TYPES, multipleChoiceSets, getResponseTypeLabel } from "./data";
 
 export type ResponseTypePickerAnchorRect = Pick<DOMRect, "top" | "right" | "bottom" | "left" | "width" | "height">;
 
@@ -37,6 +38,7 @@ export function ResponseTypePicker({ onSelect, onClose, anchorRect }: {
   onClose: () => void;
   anchorRect?: ResponseTypePickerAnchorRect | null;
 }) {
+  const { t } = useTranslation("checklists");
   // Always render into document.body via a portal so CSS transforms or
   // backdrop-filter on any ancestor (e.g. animate-fade-in uses translateY,
   // which creates a new containing block for position:fixed children) cannot
@@ -57,21 +59,21 @@ export function ResponseTypePicker({ onSelect, onClose, anchorRect }: {
         aria-modal="true"
       >
         <div className="flex items-center justify-between px-5 pt-5 pb-3 border-b border-border shrink-0">
-          <h2 className="font-display text-lg text-foreground">Type of response</h2>
+          <h2 className="font-display text-lg text-foreground">{t("responsePicker.heading")}</h2>
           <button onClick={onClose} className="btn-icon">
             <X size={18} className="text-muted-foreground" />
           </button>
         </div>
         <div className="overflow-y-auto flex-1 pb-6">
-          <p className="px-5 pt-4 pb-2 text-xs font-semibold text-muted-foreground uppercase tracking-wide">Responses</p>
+          <p className="px-5 pt-4 pb-2 text-xs font-semibold text-muted-foreground uppercase tracking-wide">{t("responsePicker.responsesSection")}</p>
           {RESPONSE_TYPES.map(rt => (
             <button key={rt.key} onClick={() => { onSelect(rt.key); onClose(); }}
               className="w-full flex items-center gap-3 px-5 py-3 hover:bg-muted/50 transition-colors text-left">
               <rt.icon size={18} className="text-sage shrink-0" />
-              <span className="text-sm text-foreground">{rt.label}</span>
+              <span className="text-sm text-foreground">{getResponseTypeLabel(rt.key)}</span>
             </button>
           ))}
-          <p className="px-5 pt-4 pb-2 text-xs font-semibold text-muted-foreground uppercase tracking-wide">Multiple choice</p>
+          <p className="px-5 pt-4 pb-2 text-xs font-semibold text-muted-foreground uppercase tracking-wide">{t("responsePicker.multipleChoiceSection")}</p>
           {multipleChoiceSets.map(mc => (
             <button key={mc.id} onClick={() => { onSelect("multiple_choice", mc.id); onClose(); }}
               className="w-full flex items-center gap-3 px-5 py-3 hover:bg-muted/50 transition-colors text-left">


### PR DESCRIPTION
Four smaller builder-adjacent modals in one slice:
- **ResponseTypePicker**: heading + section labels, response type labels via the new `getResponseTypeLabel()` getter (`data.ts`, #618).
- **CustomRecurrencePicker**: heading, interval unit dropdown, day-of-week initials (translated per-language: M/T/W/T/F/S/S → L/M/X/J/V/S/D in Spanish), Ends/Never/On/After controls.
- **BuildWithAIModal + ConvertFileModal**: headings, descriptions, placeholders, generate/convert buttons, and all humanized error message variants (quota/unavailable/network/unexpected-response). `humanizeConvertError()` is a plain function called outside render, so it uses the i18n singleton like `alert-copy.ts` / `getScheduleLabel()`.

**Deliberately left untouched:** `multipleChoiceSets` in `data.ts` (the preset choice values like "Good"/"Fair"/"Poor" become persisted checklist content when picked, not UI chrome — same staff-entered-content-stays-as-written scope boundary as Infohub docs and checklist item text, established in #594's original scope decision).

Real Spanish translations throughout.

## Test plan
- [x] `bun run lint` — 0 errors
- [x] `bun run test:ci` — 90/90 files, 1383/1383 tests passing
- [x] `bun run build` — succeeds
- [x] Targeted runs for all four components (58/58) before the full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
