### PR TITLE
Translate Infohub — Library, Training, and every shared modal (Phase 4, part 12 of #594)

### DIFF
--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -10,19 +10,21 @@ import enNotifications from "@/locales/en/notifications.json";
 import esNotifications from "@/locales/es/notifications.json";
 import enChecklists from "@/locales/en/checklists.json";
 import esChecklists from "@/locales/es/checklists.json";
+import enInfohub from "@/locales/en/infohub.json";
+import esInfohub from "@/locales/es/infohub.json";
 
 export const SUPPORTED_LANGUAGES = ["en", "es"] as const;
 export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
 export const DEFAULT_LANGUAGE: SupportedLanguage = "en";
 
 const resources = {
-  en: { common: enCommon, kiosk: enKiosk, dashboard: enDashboard, notifications: enNotifications, checklists: enChecklists },
-  es: { common: esCommon, kiosk: esKiosk, dashboard: esDashboard, notifications: esNotifications, checklists: esChecklists },
+  en: { common: enCommon, kiosk: enKiosk, dashboard: enDashboard, notifications: enNotifications, checklists: enChecklists, infohub: enInfohub },
+  es: { common: esCommon, kiosk: esKiosk, dashboard: esDashboard, notifications: esNotifications, checklists: esChecklists, infohub: esInfohub },
 };
 
 // Namespaces are added here as each app area is translated (settings,
 // admin, billing, ...) — see issue #594.
-const NAMESPACES = ["common", "kiosk", "dashboard", "notifications", "checklists"];
+const NAMESPACES = ["common", "kiosk", "dashboard", "notifications", "checklists", "infohub"];
 
 // Picks a supported language from a raw BCP-47 tag (e.g. "es-MX" -> "es"),
 // falling back to DEFAULT_LANGUAGE for anything unsupported/unset. Kept as a

--- a/src/locales/en/infohub.json
+++ b/src/locales/en/infohub.json
@@ -1,0 +1,161 @@
+{
+  "subtitleLibrary": "Documents & SOPs",
+  "subtitleTraining": "Staff training modules",
+  "searchLibraryPlaceholder": "Search documents and folders…",
+  "searchTrainingPlaceholder": "Search training and folders…",
+  "addContent": "Add content",
+  "tabs": {
+    "library": "Library",
+    "training": "Training"
+  },
+  "folders": "Folders",
+  "documents": "Documents",
+  "modules": "Modules",
+  "restricted": "Restricted",
+  "docCount_one": "{{count}} document",
+  "docCount_other": "{{count}} documents",
+  "subfolderCount_one": "{{count}} subfolder",
+  "subfolderCount_other": "{{count}} subfolders",
+  "moduleCount": "{{count}} modules",
+  "durationSteps": "{{duration}} · {{count}} steps",
+  "done": "Done",
+  "openAiTools": "Open AI tools for {{title}}",
+  "emptyState": {
+    "noMatchLibrary": "No matching library items.",
+    "noMatchTraining": "No matching training items.",
+    "folderEmpty": "This folder is empty.",
+    "noFolders": "No folders yet.",
+    "tapToCreate": "Tap to create a folder or document."
+  },
+  "archived": "Archived ({{count}})",
+  "restore": "Restore",
+  "actions": {
+    "moveToFolder": "Move to folder",
+    "renameFolder": "Rename folder",
+    "manageAccess": "Manage access",
+    "archiveFolder": "Archive folder",
+    "downloadFile": "Download file",
+    "archiveFile": "Archive file"
+  },
+  "aiSheet": {
+    "libraryDocument": "library document",
+    "trainingModule": "training module",
+    "heading": "AI Tools",
+    "generateFrom": "Generate study materials for \"{{title}}\" from {{source}} content.",
+    "notEnoughContent": "This document does not have enough content for AI generation.",
+    "unexpectedResponse": "Unexpected AI response. Please try again.",
+    "genericError": "Something went wrong. Please try again.",
+    "summary": {
+      "title": "Generate summary",
+      "description": "AI-powered key points from this content",
+      "sectionLabel": "Summary",
+      "takeawayLabel": "Takeaway"
+    },
+    "flashcards": {
+      "title": "Create flashcards",
+      "description": "Turn content into review flashcards",
+      "sectionLabel": "Flashcards",
+      "front": "Front",
+      "back": "Back"
+    },
+    "quiz": {
+      "title": "Generate quiz",
+      "description": "Test understanding with auto-generated questions",
+      "sectionLabel": "Quiz"
+    }
+  },
+  "shared": {
+    "moveToFolder": {
+      "heading": "Move to folder",
+      "searchPlaceholder": "Search folders",
+      "rootOption": "Root (no folder)",
+      "noFoldersFound": "No folders found."
+    },
+    "newFolder": {
+      "heading": "New folder",
+      "nameLabel": "Folder name",
+      "namePlaceholder": "e.g. Health & Safety",
+      "create": "Create folder"
+    },
+    "renameFolder": {
+      "heading": "Rename folder",
+      "nameLabel": "Folder name",
+      "save": "Rename"
+    },
+    "newDocument": {
+      "heading": "New document",
+      "titleLabel": "Title",
+      "titlePlaceholder": "e.g. Fire safety procedure",
+      "folderLabel": "Folder",
+      "tagsLabel": "Tags",
+      "tagsHint": "(comma-separated, optional)",
+      "tagsPlaceholder": "e.g. Safety, Weekly, Kitchen",
+      "create": "Create document"
+    },
+    "filePreview": {
+      "download": "Download",
+      "closePreview": "Close preview",
+      "cannotPreview": "This file type can't be previewed in the browser.",
+      "downloadToOpen": "Download to open"
+    },
+    "upload": {
+      "heading": "Upload file",
+      "fileTooLarge": "File is too large. Maximum size is 20 MB.",
+      "notSignedIn": "Not signed in.",
+      "uploadFailed": "Upload failed. Please try again.",
+      "dragDropPrefix": "Drag & drop or",
+      "browse": "browse",
+      "fileTypesHint": "PDF, DOC, DOCX, images · max 20 MB",
+      "uploading": "Uploading…",
+      "upload": "Upload file"
+    },
+    "plusMenu": {
+      "heading": "Create new",
+      "newDocumentTitle": "New document",
+      "newDocumentDesc": "Create a new document from scratch",
+      "uploadFileTitle": "Upload file",
+      "uploadFileDesc": "Upload a PDF, DOC, or image",
+      "newFolderTitle": "New folder",
+      "newFolderDesc": "Organise documents into a folder"
+    },
+    "manageAccess": {
+      "heading": "Manage access",
+      "orgWideTitle": "Org-wide access",
+      "orgWideDesc": "Everyone in the organization can see this item.",
+      "restrictedTitle": "Restricted access",
+      "restrictedDesc": "Limit visibility by person, role, or location.",
+      "teamMembers": "Team members",
+      "roles": "Roles",
+      "locations": "Locations",
+      "save": "Save access"
+    },
+    "searchOverlay": {
+      "placeholder": "Search all documents...",
+      "startTyping": "Start typing to search across Library and Training.",
+      "noResults": "No results found.",
+      "library": "Library",
+      "training": "Training",
+      "durationSteps": "{{duration}} · {{count}} steps"
+    },
+    "breadcrumbAllFolders": "All folders",
+    "noResponseProvided": "No response provided"
+  },
+  "docViews": {
+    "editingDocument": "Editing document",
+    "updatedOn": "Updated {{date}}",
+    "openAiTools": "Open AI tools",
+    "titleLabel": "Title",
+    "summaryLabel": "Summary",
+    "contentLabel": "Content",
+    "tagsLabel": "Tags (comma-separated)",
+    "tagsPlaceholder": "e.g. Service, Safety, Weekly",
+    "saveChanges": "Save changes",
+    "fileFallback": "File",
+    "tapToAddContent": "Tap to add content",
+    "durationStepsProgress": "{{duration}} · {{completed}}/{{total}} steps",
+    "step": "Step {{n}}",
+    "moduleComplete": "Module complete.",
+    "moduleCompleteNotice": "Well done. This module has been marked as completed.",
+    "markIncomplete": "Mark as incomplete"
+  }
+}

--- a/src/locales/es/infohub.json
+++ b/src/locales/es/infohub.json
@@ -1,0 +1,161 @@
+{
+  "subtitleLibrary": "Documentos y procedimientos",
+  "subtitleTraining": "Módulos de capacitación del personal",
+  "searchLibraryPlaceholder": "Buscar documentos y carpetas…",
+  "searchTrainingPlaceholder": "Buscar capacitación y carpetas…",
+  "addContent": "Agregar contenido",
+  "tabs": {
+    "library": "Biblioteca",
+    "training": "Capacitación"
+  },
+  "folders": "Carpetas",
+  "documents": "Documentos",
+  "modules": "Módulos",
+  "restricted": "Restringido",
+  "docCount_one": "{{count}} documento",
+  "docCount_other": "{{count}} documentos",
+  "subfolderCount_one": "{{count}} subcarpeta",
+  "subfolderCount_other": "{{count}} subcarpetas",
+  "moduleCount": "{{count}} módulos",
+  "durationSteps": "{{duration}} · {{count}} pasos",
+  "done": "Hecho",
+  "openAiTools": "Abrir herramientas de IA para {{title}}",
+  "emptyState": {
+    "noMatchLibrary": "No hay elementos de biblioteca que coincidan.",
+    "noMatchTraining": "No hay elementos de capacitación que coincidan.",
+    "folderEmpty": "Esta carpeta está vacía.",
+    "noFolders": "Aún no hay carpetas.",
+    "tapToCreate": "Toca para crear una carpeta o documento."
+  },
+  "archived": "Archivados ({{count}})",
+  "restore": "Restaurar",
+  "actions": {
+    "moveToFolder": "Mover a carpeta",
+    "renameFolder": "Renombrar carpeta",
+    "manageAccess": "Gestionar acceso",
+    "archiveFolder": "Archivar carpeta",
+    "downloadFile": "Descargar archivo",
+    "archiveFile": "Archivar archivo"
+  },
+  "aiSheet": {
+    "libraryDocument": "documento de biblioteca",
+    "trainingModule": "módulo de capacitación",
+    "heading": "Herramientas de IA",
+    "generateFrom": "Genera material de estudio para \"{{title}}\" a partir del contenido de {{source}}.",
+    "notEnoughContent": "Este documento no tiene suficiente contenido para la generación con IA.",
+    "unexpectedResponse": "Respuesta inesperada de la IA. Inténtalo de nuevo.",
+    "genericError": "Algo salió mal. Inténtalo de nuevo.",
+    "summary": {
+      "title": "Generar resumen",
+      "description": "Puntos clave generados por IA a partir de este contenido",
+      "sectionLabel": "Resumen",
+      "takeawayLabel": "Conclusión"
+    },
+    "flashcards": {
+      "title": "Crear tarjetas de estudio",
+      "description": "Convierte el contenido en tarjetas de repaso",
+      "sectionLabel": "Tarjetas de estudio",
+      "front": "Frente",
+      "back": "Reverso"
+    },
+    "quiz": {
+      "title": "Generar cuestionario",
+      "description": "Evalúa la comprensión con preguntas generadas automáticamente",
+      "sectionLabel": "Cuestionario"
+    }
+  },
+  "shared": {
+    "moveToFolder": {
+      "heading": "Mover a carpeta",
+      "searchPlaceholder": "Buscar carpetas",
+      "rootOption": "Raíz (sin carpeta)",
+      "noFoldersFound": "No se encontraron carpetas."
+    },
+    "newFolder": {
+      "heading": "Nueva carpeta",
+      "nameLabel": "Nombre de la carpeta",
+      "namePlaceholder": "p. ej. Salud y Seguridad",
+      "create": "Crear carpeta"
+    },
+    "renameFolder": {
+      "heading": "Renombrar carpeta",
+      "nameLabel": "Nombre de la carpeta",
+      "save": "Renombrar"
+    },
+    "newDocument": {
+      "heading": "Nuevo documento",
+      "titleLabel": "Título",
+      "titlePlaceholder": "p. ej. Procedimiento de seguridad contra incendios",
+      "folderLabel": "Carpeta",
+      "tagsLabel": "Etiquetas",
+      "tagsHint": "(separadas por comas, opcional)",
+      "tagsPlaceholder": "p. ej. Seguridad, Semanal, Cocina",
+      "create": "Crear documento"
+    },
+    "filePreview": {
+      "download": "Descargar",
+      "closePreview": "Cerrar vista previa",
+      "cannotPreview": "Este tipo de archivo no se puede previsualizar en el navegador.",
+      "downloadToOpen": "Descargar para abrir"
+    },
+    "upload": {
+      "heading": "Subir archivo",
+      "fileTooLarge": "El archivo es demasiado grande. El tamaño máximo es 20 MB.",
+      "notSignedIn": "No has iniciado sesión.",
+      "uploadFailed": "Error al subir el archivo. Inténtalo de nuevo.",
+      "dragDropPrefix": "Arrastra y suelta o",
+      "browse": "explora",
+      "fileTypesHint": "PDF, DOC, DOCX, imágenes · máx. 20 MB",
+      "uploading": "Subiendo…",
+      "upload": "Subir archivo"
+    },
+    "plusMenu": {
+      "heading": "Crear nuevo",
+      "newDocumentTitle": "Nuevo documento",
+      "newDocumentDesc": "Crea un nuevo documento desde cero",
+      "uploadFileTitle": "Subir archivo",
+      "uploadFileDesc": "Sube un PDF, DOC o imagen",
+      "newFolderTitle": "Nueva carpeta",
+      "newFolderDesc": "Organiza documentos en una carpeta"
+    },
+    "manageAccess": {
+      "heading": "Gestionar acceso",
+      "orgWideTitle": "Acceso para toda la organización",
+      "orgWideDesc": "Todos en la organización pueden ver este elemento.",
+      "restrictedTitle": "Acceso restringido",
+      "restrictedDesc": "Limita la visibilidad por persona, rol o ubicación.",
+      "teamMembers": "Miembros del equipo",
+      "roles": "Roles",
+      "locations": "Ubicaciones",
+      "save": "Guardar acceso"
+    },
+    "searchOverlay": {
+      "placeholder": "Buscar en todos los documentos...",
+      "startTyping": "Empieza a escribir para buscar en Biblioteca y Capacitación.",
+      "noResults": "No se encontraron resultados.",
+      "library": "Biblioteca",
+      "training": "Capacitación",
+      "durationSteps": "{{duration}} · {{count}} pasos"
+    },
+    "breadcrumbAllFolders": "Todas las carpetas",
+    "noResponseProvided": "No se proporcionó respuesta"
+  },
+  "docViews": {
+    "editingDocument": "Editando documento",
+    "updatedOn": "Actualizado el {{date}}",
+    "openAiTools": "Abrir herramientas de IA",
+    "titleLabel": "Título",
+    "summaryLabel": "Resumen",
+    "contentLabel": "Contenido",
+    "tagsLabel": "Etiquetas (separadas por comas)",
+    "tagsPlaceholder": "p. ej. Servicio, Seguridad, Semanal",
+    "saveChanges": "Guardar cambios",
+    "fileFallback": "Archivo",
+    "tapToAddContent": "Toca para agregar contenido",
+    "durationStepsProgress": "{{duration}} · {{completed}}/{{total}} pasos",
+    "step": "Paso {{n}}",
+    "moduleComplete": "Módulo completado.",
+    "moduleCompleteNotice": "Bien hecho. Este módulo se ha marcado como completado.",
+    "markIncomplete": "Marcar como incompleto"
+  }
+}

--- a/src/pages/Infohub.tsx
+++ b/src/pages/Infohub.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo, useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import { Layout } from "@/components/Layout";
 import { useAuth } from "@/contexts/AuthContext";
 import { useInfohubContent } from "@/hooks/useInfohubContent";
@@ -38,6 +39,7 @@ import { LibraryDocDetail, TrainingDocDetail } from "./infohub/InfohubDocumentVi
 // ─── Infohub Page ─────────────────────────────────────────────────────────────
 
 export default function Infohub() {
+  const { t } = useTranslation("infohub");
   const location = useLocation();
   const navigate = useNavigate();
   const { teamMember } = useAuth();
@@ -271,30 +273,30 @@ export default function Infohub() {
     />
   );
 
-  const subtitle = subTab === "library" ? "Documents & SOPs" : "Staff training modules";
+  const subtitle = subTab === "library" ? t("subtitleLibrary") : t("subtitleTraining");
 
   // Folder menu actions
   const folderActions = (folder: { id: string; name: string; access: InfohubAccessControl }, section: "library" | "training") => {
     const actions = [
-      { label: "Move to folder", icon: <FolderInput size={16} className="text-muted-foreground" />, onClick: () => setMoveTarget({ type: "folder", id: folder.id, section }) },
-      { label: "Rename folder", icon: <Pencil size={16} className="text-muted-foreground" />, onClick: () => setRenameTarget({ id: folder.id, name: folder.name, section }) },
+      { label: t("actions.moveToFolder"), icon: <FolderInput size={16} className="text-muted-foreground" />, onClick: () => setMoveTarget({ type: "folder", id: folder.id, section }) },
+      { label: t("actions.renameFolder"), icon: <Pencil size={16} className="text-muted-foreground" />, onClick: () => setRenameTarget({ id: folder.id, name: folder.name, section }) },
     ];
     if (canManageAccess) {
       actions.push({
-        label: "Manage access",
+        label: t("actions.manageAccess"),
         icon: <Shield size={16} className="text-muted-foreground" />,
         onClick: () => setAccessTarget({ id: folder.id, type: "folder", section, name: folder.name, access: folder.access }),
       });
     }
-    actions.push({ label: "Archive folder", icon: <Archive size={16} className="text-muted-foreground" />, onClick: () => handleArchiveFolder(folder.id, section) });
+    actions.push({ label: t("actions.archiveFolder"), icon: <Archive size={16} className="text-muted-foreground" />, onClick: () => handleArchiveFolder(folder.id, section) });
     return actions;
   };
 
   const docActions = (doc: DocItem | TrainingDoc, section: "library" | "training") => {
     const actions = [
-      { label: "Move to folder", icon: <FolderInput size={16} className="text-muted-foreground" />, onClick: () => setMoveTarget({ type: "doc", id: doc.id, section }) },
+      { label: t("actions.moveToFolder"), icon: <FolderInput size={16} className="text-muted-foreground" />, onClick: () => setMoveTarget({ type: "doc", id: doc.id, section }) },
       {
-        label: "Download file",
+        label: t("actions.downloadFile"),
         icon: <Download size={16} className="text-muted-foreground" />,
         onClick: async () => {
           const libraryDoc = section === "library" ? (doc as DocItem) : null;
@@ -328,12 +330,12 @@ export default function Infohub() {
     ];
     if (canManageAccess) {
       actions.push({
-        label: "Manage access",
+        label: t("actions.manageAccess"),
         icon: <Shield size={16} className="text-muted-foreground" />,
         onClick: () => setAccessTarget({ id: doc.id, type: "doc", section, name: doc.title, access: doc.access }),
       });
     }
-    actions.push({ label: "Archive file", icon: <Archive size={16} className="text-muted-foreground" />, onClick: () => handleArchiveDoc(doc.id, section) });
+    actions.push({ label: t("actions.archiveFile"), icon: <Archive size={16} className="text-muted-foreground" />, onClick: () => handleArchiveDoc(doc.id, section) });
     return actions;
   };
 
@@ -354,7 +356,7 @@ export default function Infohub() {
           <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
           <input
             type="text"
-            placeholder={subTab === "library" ? "Search documents and folders…" : "Search training and folders…"}
+            placeholder={subTab === "library" ? t("searchLibraryPlaceholder") : t("searchTrainingPlaceholder")}
             value={searchQuery}
             onChange={e => setSearchQuery(e.target.value)}
             className="w-full rounded-xl border border-border bg-card py-2.5 pl-9 pr-4 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
@@ -362,7 +364,7 @@ export default function Infohub() {
         </div>
         <button
           onClick={() => setShowPlusMenu(true)}
-          aria-label="Add content"
+          aria-label={t("addContent")}
           className="flex h-10 w-10 items-center justify-center rounded-xl bg-sage text-primary-foreground transition-colors hover:bg-sage-deep shrink-0"
         >
           <Plus size={18} />
@@ -372,8 +374,8 @@ export default function Infohub() {
       {/* Sub-tab toggle */}
       <div className="flex gap-1 bg-muted rounded-xl p-1">
         {([
-          { key: "library" as const, label: "Library", icon: BookOpen },
-          { key: "training" as const, label: "Training", icon: GraduationCap },
+          { key: "library" as const, label: t("tabs.library"), icon: BookOpen },
+          { key: "training" as const, label: t("tabs.training"), icon: GraduationCap },
         ]).map(({ key, label, icon: Icon }) => (
           <button key={key}
             onClick={() => {
@@ -399,7 +401,7 @@ export default function Infohub() {
 
           {accessibleLibFolders.length > 0 && (
             <>
-              <p className="section-label">Folders</p>
+              <p className="section-label">{t("folders")}</p>
               <div className="card-surface divide-y divide-border">
                 {accessibleLibFolders.map((folder, idx) => (
                   <div key={folder.id} className="relative"
@@ -425,14 +427,14 @@ export default function Infohub() {
                           {folder.access.accessScope === "restricted" && (
                             <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
                               <Lock size={10} />
-                              Restricted
+                              {t("restricted")}
                             </span>
                           )}
                         </div>
                         <p className="text-xs text-muted-foreground mt-0.5">
-                          {countDocsInFolder(folder.id, libFolders, libDocs)} {countDocsInFolder(folder.id, libFolders, libDocs) === 1 ? "document" : "documents"}
+                          {t("docCount", { count: countDocsInFolder(folder.id, libFolders, libDocs) })}
                           {libFolders.filter(f => f.parentId === folder.id).length > 0 &&
-                            ` · ${libFolders.filter(f => f.parentId === folder.id).length} subfolder${libFolders.filter(f => f.parentId === folder.id).length > 1 ? 's' : ''}`
+                            ` · ${t("subfolderCount", { count: libFolders.filter(f => f.parentId === folder.id).length })}`
                           }
                         </p>
                       </div>
@@ -457,7 +459,7 @@ export default function Infohub() {
           {/* Documents in current folder */}
           {(currentLibFolder || normalizedSearch) && accessibleDocsInCurrentFolder.length > 0 && (
             <>
-              <p className="section-label">Documents</p>
+              <p className="section-label">{t("documents")}</p>
               <div className="card-surface divide-y divide-border">
                 {accessibleDocsInCurrentFolder.map(doc => (
                   <div key={doc.id} className="relative">
@@ -474,7 +476,7 @@ export default function Infohub() {
                           {doc.access.accessScope === "restricted" && (
                             <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
                               <Lock size={10} />
-                              Restricted
+                              {t("restricted")}
                             </span>
                           )}
                         </div>
@@ -483,7 +485,7 @@ export default function Infohub() {
                       </div>
                       <button
                         onClick={e => { e.stopPropagation(); setAiSheetDocTitle(doc.title); }}
-                        aria-label={`Open AI tools for ${doc.title}`}
+                        aria-label={t("openAiTools", { title: doc.title })}
                         className="p-1.5 rounded-full hover:bg-lavender-light transition-colors shrink-0"
                       >
                         <Sparkles size={14} className="text-lavender-deep" />
@@ -515,10 +517,10 @@ export default function Infohub() {
               </div>
               <p className="text-sm text-muted-foreground">
                 {normalizedSearch
-                  ? "No matching library items."
-                  : currentLibFolder ? "This folder is empty." : "No folders yet."}
+                  ? t("emptyState.noMatchLibrary")
+                  : currentLibFolder ? t("emptyState.folderEmpty") : t("emptyState.noFolders")}
               </p>
-              <p className="text-xs text-muted-foreground mt-1">Tap to create a folder or document.</p>
+              <p className="text-xs text-muted-foreground mt-1">{t("emptyState.tapToCreate")}</p>
             </button>
           )}
           {archivedLibDocs.length > 0 && (
@@ -528,7 +530,7 @@ export default function Infohub() {
                 className="flex items-center gap-1.5 section-label hover:text-foreground transition-colors w-full"
               >
                 <Archive size={12} />
-                Archived ({archivedLibDocs.length})
+                {t("archived", { count: archivedLibDocs.length })}
                 <ChevronRight size={12} className={cn("ml-0.5 transition-transform", showArchived && "rotate-90")} />
               </button>
               {showArchived && (
@@ -543,7 +545,7 @@ export default function Infohub() {
                         onClick={() => handleRestoreDoc(doc.id)}
                         className="text-xs text-sage font-medium px-2.5 py-1 rounded-lg hover:bg-sage-light transition-colors shrink-0"
                       >
-                        Restore
+                        {t("restore")}
                       </button>
                     </div>
                   ))}
@@ -562,7 +564,7 @@ export default function Infohub() {
 
           {accessibleTrainFolders.length > 0 && (
             <>
-              <p className="section-label">Folders</p>
+              <p className="section-label">{t("folders")}</p>
               <div className="card-surface divide-y divide-border">
                 {accessibleTrainFolders.map((folder, idx) => (
                   <div key={folder.id} className="relative"
@@ -588,11 +590,11 @@ export default function Infohub() {
                           {folder.access.accessScope === "restricted" && (
                             <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
                               <Lock size={10} />
-                              Restricted
+                              {t("restricted")}
                             </span>
                           )}
                         </div>
-                        <p className="text-xs text-muted-foreground mt-0.5">{countTrainingDocsInFolder(folder.id, trainFolders, trainDocs)} modules</p>
+                        <p className="text-xs text-muted-foreground mt-0.5">{t("moduleCount", { count: countTrainingDocsInFolder(folder.id, trainFolders, trainDocs) })}</p>
                       </div>
                       <button
                         onClick={e => { e.stopPropagation(); setOpenMenuId(openMenuId === folder.id ? null : folder.id); }}
@@ -614,7 +616,7 @@ export default function Infohub() {
 
           {(currentTrainFolder || normalizedSearch) && accessibleDocsInCurrentTrainFolder.length > 0 && (
             <>
-              <p className="section-label">Modules</p>
+              <p className="section-label">{t("modules")}</p>
               <div className="card-surface divide-y divide-border">
                 {accessibleDocsInCurrentTrainFolder.map(doc => (
                   <div key={doc.id} className="relative">
@@ -632,21 +634,21 @@ export default function Infohub() {
                           {doc.access.accessScope === "restricted" && (
                             <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
                               <Lock size={10} />
-                              Restricted
+                              {t("restricted")}
                             </span>
                           )}
                         </div>
-                        <p className="text-xs text-muted-foreground mt-0.5">{doc.duration} · {doc.steps.length} steps</p>
+                        <p className="text-xs text-muted-foreground mt-0.5">{t("durationSteps", { duration: doc.duration, count: doc.steps.length })}</p>
                       </div>
                       <button
                         onClick={e => { e.stopPropagation(); setAiSheetDocTitle(doc.title); }}
-                        aria-label={`Open AI tools for ${doc.title}`}
+                        aria-label={t("openAiTools", { title: doc.title })}
                         className="p-1.5 rounded-full hover:bg-lavender-light transition-colors shrink-0"
                       >
                         <Sparkles size={14} className="text-lavender-deep" />
                       </button>
                       {doc.completed && (
-                        <span className="text-xs px-2 py-0.5 rounded-full font-medium status-ok shrink-0">Done</span>
+                        <span className="text-xs px-2 py-0.5 rounded-full font-medium status-ok shrink-0">{t("done")}</span>
                       )}
                       <button
                         onClick={e => { e.stopPropagation(); setOpenMenuId(openMenuId === doc.id ? null : doc.id); }}
@@ -673,9 +675,9 @@ export default function Infohub() {
                 <Plus size={18} className="text-lavender-deep" />
               </div>
               <p className="text-sm text-muted-foreground">
-                {normalizedSearch ? "No matching training items." : "This folder is empty."}
+                {normalizedSearch ? t("emptyState.noMatchTraining") : t("emptyState.folderEmpty")}
               </p>
-              <p className="text-xs text-muted-foreground mt-1">Tap to create a folder or document.</p>
+              <p className="text-xs text-muted-foreground mt-1">{t("emptyState.tapToCreate")}</p>
             </button>
           )}
         </>
@@ -753,7 +755,7 @@ export default function Infohub() {
       {aiSheetDocTitle && (
         <AIActionsSheet
           docTitle={aiSheetDocTitle}
-          sourceLabel={subTab === "library" ? "library document" : "training module"}
+          sourceLabel={subTab === "library" ? t("aiSheet.libraryDocument") : t("aiSheet.trainingModule")}
           sourceText={
             subTab === "library"
               ? (libDocs.find(doc => doc.title === aiSheetDocTitle)?.content ?? "")

--- a/src/pages/infohub/InfohubDocumentViews.tsx
+++ b/src/pages/infohub/InfohubDocumentViews.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 
 import { CheckCircle, ChevronLeft, Circle, Download, FileText, Pencil, Sparkles, Tag } from "lucide-react";
 import { supabase } from "@/lib/supabase";
@@ -19,6 +20,7 @@ export function LibraryDocDetail({
   onBack: () => void;
   onSave: (updated: DocItem) => void;
 }) {
+  const { t } = useTranslation("infohub");
   const folder = folders.find((folderItem) => folderItem.id === doc.folderId);
   const [aiSheet, setAiSheet] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
@@ -56,14 +58,14 @@ export function LibraryDocDetail({
           </button>
           <div className="flex-1 min-w-0">
             <h1 className="font-display text-lg text-foreground leading-tight truncate">
-              {isEditing ? "Editing document" : doc.title}
+              {isEditing ? t("docViews.editingDocument") : doc.title}
             </h1>
-            <p className="text-xs text-muted-foreground mt-0.5">{folder?.name} · Updated {doc.lastUpdated}</p>
+            <p className="text-xs text-muted-foreground mt-0.5">{folder?.name} · {t("docViews.updatedOn", { date: doc.lastUpdated })}</p>
           </div>
           {!isEditing && (
             <button
               onClick={() => setAiSheet(true)}
-              aria-label="Open AI tools"
+              aria-label={t("docViews.openAiTools")}
               className="p-2 rounded-full hover:bg-lavender-light transition-colors"
             >
               <Sparkles size={18} className="text-lavender-deep" />
@@ -85,7 +87,7 @@ export function LibraryDocDetail({
         {isEditing ? (
           <>
             <div className="space-y-2">
-              <label className="text-xs font-medium text-muted-foreground">Title</label>
+              <label className="text-xs font-medium text-muted-foreground">{t("docViews.titleLabel")}</label>
               <input
                 autoFocus
                 value={editTitle}
@@ -94,7 +96,7 @@ export function LibraryDocDetail({
               />
             </div>
             <div className="space-y-2">
-              <label className="text-xs font-medium text-muted-foreground">Summary</label>
+              <label className="text-xs font-medium text-muted-foreground">{t("docViews.summaryLabel")}</label>
               <textarea
                 value={editSummary}
                 onChange={(e) => setEditSummary(e.target.value)}
@@ -103,7 +105,7 @@ export function LibraryDocDetail({
               />
             </div>
             <div className="space-y-2">
-              <label className="text-xs font-medium text-muted-foreground">Content</label>
+              <label className="text-xs font-medium text-muted-foreground">{t("docViews.contentLabel")}</label>
               <textarea
                 data-testid="doc-content-editor"
                 value={editContent}
@@ -113,16 +115,16 @@ export function LibraryDocDetail({
               />
             </div>
             <div className="space-y-2">
-              <label className="text-xs font-medium text-muted-foreground">Tags (comma-separated)</label>
+              <label className="text-xs font-medium text-muted-foreground">{t("docViews.tagsLabel")}</label>
               <input
                 value={editTags}
                 onChange={(e) => setEditTags(e.target.value)}
-                placeholder="e.g. Service, Safety, Weekly"
+                placeholder={t("docViews.tagsPlaceholder")}
                 className="w-full border border-border rounded-xl px-4 py-3 text-sm bg-background focus:outline-none focus:ring-2 focus:ring-sage/30"
               />
             </div>
             <button onClick={handleSave} className="w-full py-3 rounded-xl bg-sage text-white text-sm font-medium hover:bg-sage-deep transition-colors">
-              Save changes
+              {t("docViews.saveChanges")}
             </button>
           </>
         ) : (
@@ -142,7 +144,7 @@ export function LibraryDocDetail({
                 </div>
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-medium text-foreground truncate">{doc.title}</p>
-                  <p className="text-xs text-muted-foreground">{doc.fileType ?? "File"}</p>
+                  <p className="text-xs text-muted-foreground">{doc.fileType ?? t("docViews.fileFallback")}</p>
                 </div>
                 {fileSignedUrl ? (
                   <a
@@ -151,7 +153,7 @@ export function LibraryDocDetail({
                     rel="noopener noreferrer"
                     download
                     className="p-2 rounded-full hover:bg-muted transition-colors"
-                    aria-label="Download file"
+                    aria-label={t("actions.downloadFile")}
                   >
                     <Download size={16} className="text-muted-foreground" />
                   </a>
@@ -167,7 +169,7 @@ export function LibraryDocDetail({
                 <p className="text-sm text-foreground leading-relaxed whitespace-pre-line">{doc.content}</p>
               ) : (
                 <button onClick={() => setIsEditing(true)} className="w-full text-sm text-muted-foreground text-center py-4 hover:text-foreground transition-colors">
-                  Tap to add content
+                  {t("docViews.tapToAddContent")}
                 </button>
               )}
             </div>
@@ -177,7 +179,7 @@ export function LibraryDocDetail({
       {aiSheet && (
         <AIActionsSheet
           docTitle={doc.title}
-          sourceLabel="library document"
+          sourceLabel={t("aiSheet.libraryDocument")}
           sourceText={`${doc.title}\n\n${doc.summary}\n\n${doc.content}`}
           onClose={() => setAiSheet(false)}
         />
@@ -195,6 +197,7 @@ export function TrainingDocDetail({
   onBack: () => void;
   onToggleComplete: (completed: boolean) => void;
 }) {
+  const { t } = useTranslation("infohub");
   const onToggleCompleteRef = useRef(onToggleComplete);
   const lastReportedCompletion = useRef<boolean | null>(null);
   const [completedSteps, setCompletedSteps] = useState<Set<number>>(
@@ -235,11 +238,11 @@ export function TrainingDocDetail({
           </button>
           <div className="flex-1 min-w-0">
             <h1 className="font-display text-lg text-foreground leading-tight truncate">{doc.title}</h1>
-            <p className="text-xs text-muted-foreground mt-0.5">{doc.duration} · {completedSteps.size}/{doc.steps.length} steps</p>
+            <p className="text-xs text-muted-foreground mt-0.5">{t("docViews.durationStepsProgress", { duration: doc.duration, completed: completedSteps.size, total: doc.steps.length })}</p>
           </div>
           <button
             onClick={() => setAiSheet(true)}
-            aria-label="Open AI tools"
+            aria-label={t("docViews.openAiTools")}
             className="p-2 rounded-full hover:bg-lavender-light transition-colors"
           >
             <Sparkles size={18} className="text-lavender-deep" />
@@ -260,7 +263,7 @@ export function TrainingDocDetail({
             >
               {done ? <CheckCircle size={18} className="text-sage-deep mt-0.5 shrink-0" /> : <Circle size={18} className="text-muted-foreground mt-0.5 shrink-0" />}
               <div>
-                <p className="text-xs font-semibold text-muted-foreground mb-0.5">Step {index + 1}</p>
+                <p className="text-xs font-semibold text-muted-foreground mb-0.5">{t("docViews.step", { n: index + 1 })}</p>
                 <p className={cn("text-sm leading-relaxed", done ? "text-sage-deep" : "text-foreground")}>{step}</p>
               </div>
             </button>
@@ -269,15 +272,15 @@ export function TrainingDocDetail({
         {allDone && (
           <div className="card-surface p-5 text-center border-sage/30 bg-sage-light animate-fade-in">
             <CheckCircle size={24} className="text-sage-deep mx-auto mb-2" />
-            <p className="text-sm font-medium text-sage-deep">Module complete.</p>
-            <p className="text-xs text-sage-deep/70 mt-1">Well done. This module has been marked as completed.</p>
+            <p className="text-sm font-medium text-sage-deep">{t("docViews.moduleComplete")}</p>
+            <p className="text-xs text-sage-deep/70 mt-1">{t("docViews.moduleCompleteNotice")}</p>
             <button
               onClick={() => {
                 setCompletedSteps(new Set());
               }}
               className="mt-3 text-xs text-sage-deep/70 underline hover:text-sage-deep transition-colors"
             >
-              Mark as incomplete
+              {t("docViews.markIncomplete")}
             </button>
           </div>
         )}
@@ -285,7 +288,7 @@ export function TrainingDocDetail({
       {aiSheet && (
         <AIActionsSheet
           docTitle={doc.title}
-          sourceLabel="training module"
+          sourceLabel={t("aiSheet.trainingModule")}
           sourceText={`${doc.title}\n\n${doc.steps.join("\n\n")}`}
           onClose={() => setAiSheet(false)}
         />

--- a/src/pages/infohub/InfohubShared.tsx
+++ b/src/pages/infohub/InfohubShared.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
 
 import { supabase } from "@/lib/supabase";
+import i18n from "@/lib/i18n";
 import { useAuth } from "@/contexts/AuthContext";
 import { isInfohubAiResult, type InfohubAiAction, type InfohubAiResult } from "@/lib/infohub-ai";
 import { canAccessInfohubContent, type InfohubAccessControl, type InfohubPrincipal } from "@/lib/infohub-access";
@@ -77,6 +79,7 @@ export function MoveToFolderSheet({
   onClose: () => void;
   onMove: (targetFolderId: string | null) => void;
 }) {
+  const { t } = useTranslation("infohub");
   const [search, setSearch] = useState("");
   const q = search.toLowerCase();
 
@@ -88,7 +91,7 @@ export function MoveToFolderSheet({
     <CenteredModalShell onClose={onClose}>
       <div className="space-y-3">
         <div className="flex items-center justify-between mb-1">
-          <h3 className="font-display text-base text-foreground">Move to folder</h3>
+          <h3 className="font-display text-base text-foreground">{t("shared.moveToFolder.heading")}</h3>
           <button onClick={onClose} className="btn-icon">
             <X size={18} className="text-muted-foreground" />
           </button>
@@ -97,7 +100,7 @@ export function MoveToFolderSheet({
           <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
           <input
             type="text"
-            placeholder="Search folders"
+            placeholder={t("shared.moveToFolder.searchPlaceholder")}
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             className="w-full pl-9 pr-4 py-2.5 text-sm bg-muted rounded-xl border-0 focus:outline-none focus:ring-1 focus:ring-ring"
@@ -110,7 +113,7 @@ export function MoveToFolderSheet({
               className="w-full flex items-center gap-3 px-2 py-3 text-left hover:bg-muted/30 transition-colors rounded-lg"
             >
               <FolderOpen size={16} className="text-muted-foreground" />
-              <span className="text-sm text-foreground">Root (no folder)</span>
+              <span className="text-sm text-foreground">{t("shared.moveToFolder.rootOption")}</span>
             </button>
           )}
           {filteredFolders.map((folder) => (
@@ -135,7 +138,7 @@ export function MoveToFolderSheet({
             </div>
           ))}
         </div>
-        {filteredFolders.length === 0 && <p className="text-sm text-muted-foreground text-center py-4">No folders found.</p>}
+        {filteredFolders.length === 0 && <p className="text-sm text-muted-foreground text-center py-4">{t("shared.moveToFolder.noFoldersFound")}</p>}
       </div>
     </CenteredModalShell>
   );
@@ -192,19 +195,20 @@ export function CreateFolderModal({
   onClose: () => void;
   onSave: (name: string, parentId: string | null) => void;
 }) {
+  const { t } = useTranslation("infohub");
   const [name, setName] = useState("");
   return (
     <CenteredModalShell onClose={onClose}>
       <div className="space-y-4">
         <div className="flex items-center justify-between">
-          <h3 className="font-display text-base text-foreground">New folder</h3>
+          <h3 className="font-display text-base text-foreground">{t("shared.newFolder.heading")}</h3>
           <button onClick={onClose} className="btn-icon">
             <X size={18} className="text-muted-foreground" />
           </button>
         </div>
         <div className="space-y-2">
-          <label className="text-xs font-medium text-muted-foreground">Folder name</label>
-          <Input autoFocus value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g. Health & Safety" />
+          <label className="text-xs font-medium text-muted-foreground">{t("shared.newFolder.nameLabel")}</label>
+          <Input autoFocus value={name} onChange={(e) => setName(e.target.value)} placeholder={t("shared.newFolder.namePlaceholder")} />
         </div>
         <button
           disabled={!name.trim()}
@@ -217,7 +221,7 @@ export function CreateFolderModal({
             name.trim() ? "bg-primary text-primary-foreground hover:bg-primary/90" : "bg-muted text-muted-foreground",
           )}
         >
-          Create folder
+          {t("shared.newFolder.create")}
         </button>
       </div>
     </CenteredModalShell>
@@ -233,18 +237,19 @@ export function RenameFolderModal({
   onClose: () => void;
   onSave: (newName: string) => void;
 }) {
+  const { t } = useTranslation("infohub");
   const [name, setName] = useState(currentName);
   return (
     <CenteredModalShell onClose={onClose}>
       <div className="space-y-4">
         <div className="flex items-center justify-between">
-          <h3 className="font-display text-base text-foreground">Rename folder</h3>
+          <h3 className="font-display text-base text-foreground">{t("shared.renameFolder.heading")}</h3>
           <button onClick={onClose} className="btn-icon">
             <X size={18} className="text-muted-foreground" />
           </button>
         </div>
         <div className="space-y-2">
-          <label className="text-xs font-medium text-muted-foreground">Folder name</label>
+          <label className="text-xs font-medium text-muted-foreground">{t("shared.renameFolder.nameLabel")}</label>
           <Input autoFocus value={name} onChange={(e) => setName(e.target.value)} />
         </div>
         <button
@@ -258,7 +263,7 @@ export function RenameFolderModal({
             name.trim() ? "bg-primary text-primary-foreground hover:bg-primary/90" : "bg-muted text-muted-foreground",
           )}
         >
-          Rename
+          {t("shared.renameFolder.save")}
         </button>
       </div>
     </CenteredModalShell>
@@ -276,6 +281,7 @@ export function CreateDocModal({
   onClose: () => void;
   onSave: (title: string, folderId: string, tags: string[]) => void;
 }) {
+  const { t } = useTranslation("infohub");
   const [title, setTitle] = useState("");
   const [selectedFolder, setSelectedFolder] = useState(folderId || folders[0]?.id || "");
   const [tagsInput, setTagsInput] = useState("");
@@ -283,17 +289,17 @@ export function CreateDocModal({
     <CenteredModalShell onClose={onClose}>
       <div className="space-y-4">
         <div className="flex items-center justify-between">
-          <h3 className="font-display text-base text-foreground">New document</h3>
+          <h3 className="font-display text-base text-foreground">{t("shared.newDocument.heading")}</h3>
           <button onClick={onClose} className="btn-icon">
             <X size={18} className="text-muted-foreground" />
           </button>
         </div>
         <div className="space-y-2">
-          <label className="text-xs font-medium text-muted-foreground">Title</label>
-          <Input data-testid="doc-title-input" autoFocus value={title} onChange={(e) => setTitle(e.target.value)} placeholder="e.g. Fire safety procedure" />
+          <label className="text-xs font-medium text-muted-foreground">{t("shared.newDocument.titleLabel")}</label>
+          <Input data-testid="doc-title-input" autoFocus value={title} onChange={(e) => setTitle(e.target.value)} placeholder={t("shared.newDocument.titlePlaceholder")} />
         </div>
         <div className="space-y-2">
-          <label className="text-xs font-medium text-muted-foreground">Folder</label>
+          <label className="text-xs font-medium text-muted-foreground">{t("shared.newDocument.folderLabel")}</label>
           <select
             value={selectedFolder}
             onChange={(e) => setSelectedFolder(e.target.value)}
@@ -305,8 +311,8 @@ export function CreateDocModal({
           </select>
         </div>
         <div className="space-y-2">
-          <label className="text-xs font-medium text-muted-foreground">Tags <span className="text-muted-foreground/60">(comma-separated, optional)</span></label>
-          <Input data-testid="doc-tags-input" value={tagsInput} onChange={(e) => setTagsInput(e.target.value)} placeholder="e.g. Safety, Weekly, Kitchen" />
+          <label className="text-xs font-medium text-muted-foreground">{t("shared.newDocument.tagsLabel")} <span className="text-muted-foreground/60">{t("shared.newDocument.tagsHint")}</span></label>
+          <Input data-testid="doc-tags-input" value={tagsInput} onChange={(e) => setTagsInput(e.target.value)} placeholder={t("shared.newDocument.tagsPlaceholder")} />
         </div>
         <button
           data-testid="create-doc-submit"
@@ -321,7 +327,7 @@ export function CreateDocModal({
             title.trim() && selectedFolder ? "bg-primary text-primary-foreground hover:bg-primary/90" : "bg-muted text-muted-foreground",
           )}
         >
-          Create document
+          {t("shared.newDocument.create")}
         </button>
       </div>
     </CenteredModalShell>
@@ -339,6 +345,7 @@ export function FilePreviewModal({
   title: string;
   onClose: () => void;
 }) {
+  const { t } = useTranslation("infohub");
   const isImage = fileType.startsWith("image/");
   const isPdf = fileType === "application/pdf";
 
@@ -352,11 +359,11 @@ export function FilePreviewModal({
             download={title}
             onClick={e => e.stopPropagation()}
             className="p-2 rounded-full hover:bg-muted transition-colors"
-            aria-label="Download"
+            aria-label={t("shared.filePreview.download")}
           >
             <Download size={18} className="text-muted-foreground" />
           </a>
-          <button onClick={onClose} className="p-2 rounded-full hover:bg-muted transition-colors" aria-label="Close preview">
+          <button onClick={onClose} className="p-2 rounded-full hover:bg-muted transition-colors" aria-label={t("shared.filePreview.closePreview")}>
             <X size={18} className="text-muted-foreground" />
           </button>
         </div>
@@ -383,14 +390,14 @@ export function FilePreviewModal({
             </div>
             <div>
               <p className="text-sm font-medium text-foreground">{title}</p>
-              <p className="text-xs text-muted-foreground mt-1">This file type can't be previewed in the browser.</p>
+              <p className="text-xs text-muted-foreground mt-1">{t("shared.filePreview.cannotPreview")}</p>
             </div>
             <a
               href={signedUrl}
               download={title}
               className="px-5 py-2.5 rounded-xl bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors"
             >
-              Download to open
+              {t("shared.filePreview.downloadToOpen")}
             </a>
           </div>
         )}
@@ -411,6 +418,7 @@ export function UploadDocModal({
   onClose: () => void;
   onSave: (title: string, folderId: string, filePath: string, fileType: string, tags: string[]) => void;
 }) {
+  const { t } = useTranslation("infohub");
   const { teamMember } = useAuth();
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [title, setTitle] = useState("");
@@ -425,7 +433,7 @@ export function UploadDocModal({
 
   function handleFile(file: File) {
     if (file.size > MAX_SIZE) {
-      setError("File is too large. Maximum size is 20 MB.");
+      setError(t("shared.upload.fileTooLarge"));
       return;
     }
     setError(null);
@@ -445,7 +453,7 @@ export function UploadDocModal({
   async function handleSubmit() {
     if (!selectedFile || !title.trim() || !selectedFolder) return;
     const orgId = teamMember?.organization_id;
-    if (!orgId) { setError("Not signed in."); return; }
+    if (!orgId) { setError(t("shared.upload.notSignedIn")); return; }
     setUploading(true);
     setError(null);
     try {
@@ -457,7 +465,7 @@ export function UploadDocModal({
       onSave(title.trim(), selectedFolder, path, selectedFile.type, tags);
       onClose();
     } catch (err: any) {
-      setError(err.message ?? "Upload failed. Please try again.");
+      setError(err.message ?? t("shared.upload.uploadFailed"));
     } finally {
       setUploading(false);
     }
@@ -469,7 +477,7 @@ export function UploadDocModal({
     <CenteredModalShell onClose={onClose}>
       <div className="space-y-4">
         <div className="flex items-center justify-between">
-          <h3 className="font-display text-base text-foreground">Upload file</h3>
+          <h3 className="font-display text-base text-foreground">{t("shared.upload.heading")}</h3>
           <button onClick={onClose} className="btn-icon">
             <X size={18} className="text-muted-foreground" />
           </button>
@@ -505,9 +513,9 @@ export function UploadDocModal({
             <>
               <Upload size={24} className="text-muted-foreground" />
               <p className="text-sm text-muted-foreground text-center">
-                Drag & drop or <span className="text-primary font-medium">browse</span>
+                {t("shared.upload.dragDropPrefix")} <span className="text-primary font-medium">{t("shared.upload.browse")}</span>
               </p>
-              <p className="text-xs text-muted-foreground">PDF, DOC, DOCX, images · max 20 MB</p>
+              <p className="text-xs text-muted-foreground">{t("shared.upload.fileTypesHint")}</p>
             </>
           )}
         </div>
@@ -515,11 +523,11 @@ export function UploadDocModal({
         {error && <p className="text-xs text-destructive">{error}</p>}
 
         <div className="space-y-2">
-          <label className="text-xs font-medium text-muted-foreground">Title</label>
-          <Input data-testid="upload-title-input" value={title} onChange={(e) => setTitle(e.target.value)} placeholder="e.g. Fire safety procedure" />
+          <label className="text-xs font-medium text-muted-foreground">{t("shared.newDocument.titleLabel")}</label>
+          <Input data-testid="upload-title-input" value={title} onChange={(e) => setTitle(e.target.value)} placeholder={t("shared.newDocument.titlePlaceholder")} />
         </div>
         <div className="space-y-2">
-          <label className="text-xs font-medium text-muted-foreground">Folder</label>
+          <label className="text-xs font-medium text-muted-foreground">{t("shared.newDocument.folderLabel")}</label>
           <select
             value={selectedFolder}
             onChange={(e) => setSelectedFolder(e.target.value)}
@@ -531,8 +539,8 @@ export function UploadDocModal({
           </select>
         </div>
         <div className="space-y-2">
-          <label className="text-xs font-medium text-muted-foreground">Tags <span className="text-muted-foreground/60">(comma-separated, optional)</span></label>
-          <Input value={tagsInput} onChange={(e) => setTagsInput(e.target.value)} placeholder="e.g. Safety, Weekly, Kitchen" />
+          <label className="text-xs font-medium text-muted-foreground">{t("shared.newDocument.tagsLabel")} <span className="text-muted-foreground/60">{t("shared.newDocument.tagsHint")}</span></label>
+          <Input value={tagsInput} onChange={(e) => setTagsInput(e.target.value)} placeholder={t("shared.newDocument.tagsPlaceholder")} />
         </div>
 
         <button
@@ -545,8 +553,8 @@ export function UploadDocModal({
           )}
         >
           {uploading ? (
-            <><Loader2 size={16} className="animate-spin" /> Uploading…</>
-          ) : "Upload file"}
+            <><Loader2 size={16} className="animate-spin" /> {t("shared.upload.uploading")}</>
+          ) : t("shared.upload.upload")}
         </button>
       </div>
     </CenteredModalShell>
@@ -554,11 +562,12 @@ export function UploadDocModal({
 }
 
 export function PlusMenu({ onClose, onAction }: { onClose: () => void; onAction: (action: "document" | "upload" | "folder") => void }) {
+  const { t } = useTranslation("infohub");
   return (
     <CenteredModalShell onClose={onClose} maxWidthClass="max-w-md">
       <div className="space-y-1">
         <div className="flex items-center justify-between mb-3">
-          <h3 className="font-display text-base text-foreground">Create new</h3>
+          <h3 className="font-display text-base text-foreground">{t("shared.plusMenu.heading")}</h3>
           <button onClick={onClose} className="btn-icon">
             <X size={18} className="text-muted-foreground" />
           </button>
@@ -568,8 +577,8 @@ export function PlusMenu({ onClose, onAction }: { onClose: () => void; onAction:
             <FileText size={16} className="text-sage-deep" />
           </div>
           <div>
-            <p className="text-sm font-medium text-foreground">New document</p>
-            <p className="text-xs text-muted-foreground">Create a new document from scratch</p>
+            <p className="text-sm font-medium text-foreground">{t("shared.plusMenu.newDocumentTitle")}</p>
+            <p className="text-xs text-muted-foreground">{t("shared.plusMenu.newDocumentDesc")}</p>
           </div>
         </button>
         <button onClick={() => onAction("upload")} className="w-full flex items-center gap-3 px-4 py-3.5 rounded-xl hover:bg-muted/50 transition-colors text-left">
@@ -577,8 +586,8 @@ export function PlusMenu({ onClose, onAction }: { onClose: () => void; onAction:
             <Upload size={16} className="text-lavender-deep" />
           </div>
           <div>
-            <p className="text-sm font-medium text-foreground">Upload file</p>
-            <p className="text-xs text-muted-foreground">Upload a PDF, DOC, or image</p>
+            <p className="text-sm font-medium text-foreground">{t("shared.plusMenu.uploadFileTitle")}</p>
+            <p className="text-xs text-muted-foreground">{t("shared.plusMenu.uploadFileDesc")}</p>
           </div>
         </button>
         <button onClick={() => onAction("folder")} className="w-full flex items-center gap-3 px-4 py-3.5 rounded-xl hover:bg-muted/50 transition-colors text-left">
@@ -586,8 +595,8 @@ export function PlusMenu({ onClose, onAction }: { onClose: () => void; onAction:
             <Folder size={16} className="text-muted-foreground" />
           </div>
           <div>
-            <p className="text-sm font-medium text-foreground">New folder</p>
-            <p className="text-xs text-muted-foreground">Organise documents into a folder</p>
+            <p className="text-sm font-medium text-foreground">{t("shared.plusMenu.newFolderTitle")}</p>
+            <p className="text-xs text-muted-foreground">{t("shared.plusMenu.newFolderDesc")}</p>
           </div>
         </button>
       </div>
@@ -610,6 +619,7 @@ export function ManageAccessModal({
   onClose: () => void;
   onSave: (access: InfohubAccessControl) => void;
 }) {
+  const { t } = useTranslation("infohub");
   const [accessScope, setAccessScope] = useState<InfohubAccessControl["accessScope"]>(target.access.accessScope);
   const [allowedTeamMemberIds, setAllowedTeamMemberIds] = useState<string[]>(target.access.allowedTeamMemberIds);
   const [allowedRoles, setAllowedRoles] = useState<string[]>(target.access.allowedRoles);
@@ -629,7 +639,7 @@ export function ManageAccessModal({
       <div className="space-y-4">
         <div className="flex items-center justify-between">
           <div>
-            <h3 className="font-display text-base text-foreground">Manage access</h3>
+            <h3 className="font-display text-base text-foreground">{t("shared.manageAccess.heading")}</h3>
             <p className="text-xs text-muted-foreground mt-1">{target.name}</p>
           </div>
           <button onClick={onClose} className="btn-icon">
@@ -642,22 +652,22 @@ export function ManageAccessModal({
             onClick={() => setAccessScope("org")}
             className={cn("rounded-xl border px-4 py-3 text-left transition-colors", accessScope === "org" ? "border-sage bg-sage-light" : "border-border hover:border-sage/40")}
           >
-            <p className="text-sm font-medium text-foreground">Org-wide access</p>
-            <p className="text-xs text-muted-foreground mt-1">Everyone in the organization can see this item.</p>
+            <p className="text-sm font-medium text-foreground">{t("shared.manageAccess.orgWideTitle")}</p>
+            <p className="text-xs text-muted-foreground mt-1">{t("shared.manageAccess.orgWideDesc")}</p>
           </button>
           <button
             type="button"
             onClick={() => setAccessScope("restricted")}
             className={cn("rounded-xl border px-4 py-3 text-left transition-colors", accessScope === "restricted" ? "border-sage bg-sage-light" : "border-border hover:border-sage/40")}
           >
-            <p className="text-sm font-medium text-foreground">Restricted access</p>
-            <p className="text-xs text-muted-foreground mt-1">Limit visibility by person, role, or location.</p>
+            <p className="text-sm font-medium text-foreground">{t("shared.manageAccess.restrictedTitle")}</p>
+            <p className="text-xs text-muted-foreground mt-1">{t("shared.manageAccess.restrictedDesc")}</p>
           </button>
         </div>
         {accessScope === "restricted" && (
           <div className="space-y-4">
             <div>
-              <p className="text-xs font-medium text-muted-foreground mb-2">Team members</p>
+              <p className="text-xs font-medium text-muted-foreground mb-2">{t("shared.manageAccess.teamMembers")}</p>
               <div className="grid gap-2 sm:grid-cols-2">
                 {teamMembers.map((member) => (
                   <button
@@ -676,7 +686,7 @@ export function ManageAccessModal({
               </div>
             </div>
             <div>
-              <p className="text-xs font-medium text-muted-foreground mb-2">Roles</p>
+              <p className="text-xs font-medium text-muted-foreground mb-2">{t("shared.manageAccess.roles")}</p>
               <div className="flex flex-wrap gap-2">
                 {roleOptions.map((role) => (
                   <button
@@ -694,7 +704,7 @@ export function ManageAccessModal({
               </div>
             </div>
             <div>
-              <p className="text-xs font-medium text-muted-foreground mb-2">Locations</p>
+              <p className="text-xs font-medium text-muted-foreground mb-2">{t("shared.manageAccess.locations")}</p>
               <div className="flex flex-wrap gap-2">
                 {locations.map((location) => (
                   <button
@@ -718,7 +728,7 @@ export function ManageAccessModal({
           onClick={save}
           className="w-full py-3 rounded-xl bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors"
         >
-          Save access
+          {t("shared.manageAccess.save")}
         </button>
       </div>
     </CenteredModalShell>
@@ -726,7 +736,7 @@ export function ManageAccessModal({
 }
 
 function describeCondition(rule: { comparator: string; value?: string | null; valueTo?: string | null }) {
-  if (rule.comparator === "unanswered") return "No response provided";
+  if (rule.comparator === "unanswered") return i18n.t("shared.noResponseProvided", { ns: "infohub" });
   if (!rule.valueTo) return rule.value ?? "";
   return `${rule.value ?? ""} - ${rule.valueTo}`;
 }
@@ -742,13 +752,14 @@ export function AIActionsSheet({
   sourceText: string;
   onClose: () => void;
 }) {
+  const { t } = useTranslation("infohub");
   const [loadingAction, setLoadingAction] = useState<InfohubAiAction | null>(null);
   const [result, setResult] = useState<InfohubAiResult | null>(null);
   const [error, setError] = useState("");
 
   const runAction = async (action: InfohubAiAction) => {
     if (!sourceText.trim()) {
-      setError("This document does not have enough content for AI generation.");
+      setError(t("aiSheet.notEnoughContent"));
       return;
     }
 
@@ -763,11 +774,11 @@ export function AIActionsSheet({
 
       if (fnError) throw new Error(fnError.message);
       if (data?.error) throw new Error(data.error);
-      if (!isInfohubAiResult(data)) throw new Error("Unexpected AI response. Please try again.");
+      if (!isInfohubAiResult(data)) throw new Error(t("aiSheet.unexpectedResponse"));
 
       setResult(data);
     } catch (err: any) {
-      setError(err?.message ?? "Something went wrong. Please try again.");
+      setError(err?.message ?? t("aiSheet.genericError"));
     } finally {
       setLoadingAction(null);
     }
@@ -779,14 +790,14 @@ export function AIActionsSheet({
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <Sparkles size={16} className="text-lavender-deep" />
-            <h3 className="font-display text-base text-foreground">AI Tools</h3>
+            <h3 className="font-display text-base text-foreground">{t("aiSheet.heading")}</h3>
           </div>
           <button onClick={onClose} className="btn-icon">
             <X size={18} className="text-muted-foreground" />
           </button>
         </div>
         <div className="px-4 py-3 bg-muted/50 rounded-xl">
-          <p className="text-xs text-muted-foreground">Generate study materials for "{docTitle}" from {sourceLabel} content.</p>
+          <p className="text-xs text-muted-foreground">{t("aiSheet.generateFrom", { title: docTitle, source: sourceLabel })}</p>
         </div>
         <div className="space-y-2">
           <button
@@ -798,8 +809,8 @@ export function AIActionsSheet({
               {loadingAction === "summary" ? <Loader2 size={16} className="text-lavender-deep animate-spin" /> : <Brain size={16} className="text-lavender-deep" />}
             </div>
             <div className="flex-1">
-              <p className="text-sm font-medium text-foreground">Generate summary</p>
-              <p className="text-xs text-muted-foreground">AI-powered key points from this content</p>
+              <p className="text-sm font-medium text-foreground">{t("aiSheet.summary.title")}</p>
+              <p className="text-xs text-muted-foreground">{t("aiSheet.summary.description")}</p>
             </div>
           </button>
           <button
@@ -811,8 +822,8 @@ export function AIActionsSheet({
               {loadingAction === "flashcards" ? <Loader2 size={16} className="text-sage-deep animate-spin" /> : <ListChecks size={16} className="text-sage-deep" />}
             </div>
             <div className="flex-1">
-              <p className="text-sm font-medium text-foreground">Create flashcards</p>
-              <p className="text-xs text-muted-foreground">Turn content into review flashcards</p>
+              <p className="text-sm font-medium text-foreground">{t("aiSheet.flashcards.title")}</p>
+              <p className="text-xs text-muted-foreground">{t("aiSheet.flashcards.description")}</p>
             </div>
           </button>
           <button
@@ -824,8 +835,8 @@ export function AIActionsSheet({
               {loadingAction === "quiz" ? <Loader2 size={16} className="text-muted-foreground animate-spin" /> : <HelpCircle size={16} className="text-muted-foreground" />}
             </div>
             <div className="flex-1">
-              <p className="text-sm font-medium text-foreground">Generate quiz</p>
-              <p className="text-xs text-muted-foreground">Test understanding with auto-generated questions</p>
+              <p className="text-sm font-medium text-foreground">{t("aiSheet.quiz.title")}</p>
+              <p className="text-xs text-muted-foreground">{t("aiSheet.quiz.description")}</p>
             </div>
           </button>
         </div>
@@ -837,7 +848,7 @@ export function AIActionsSheet({
         {result && result.type === "summary" && (
           <div className="space-y-3 rounded-2xl border border-border bg-background p-4">
             <div>
-              <p className="text-xs uppercase tracking-wide text-muted-foreground">Summary</p>
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">{t("aiSheet.summary.sectionLabel")}</p>
               <h4 className="text-sm font-semibold text-foreground mt-1">{result.title}</h4>
             </div>
             <ul className="space-y-2">
@@ -849,7 +860,7 @@ export function AIActionsSheet({
               ))}
             </ul>
             <div className="rounded-xl bg-lavender-light px-4 py-3">
-              <p className="text-xs uppercase tracking-wide text-lavender-deep/70">Takeaway</p>
+              <p className="text-xs uppercase tracking-wide text-lavender-deep/70">{t("aiSheet.summary.takeawayLabel")}</p>
               <p className="text-sm text-lavender-deep mt-1">{result.takeaway}</p>
             </div>
           </div>
@@ -857,15 +868,15 @@ export function AIActionsSheet({
         {result && result.type === "flashcards" && (
           <div className="space-y-3 rounded-2xl border border-border bg-background p-4">
             <div>
-              <p className="text-xs uppercase tracking-wide text-muted-foreground">Flashcards</p>
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">{t("aiSheet.flashcards.sectionLabel")}</p>
               <h4 className="text-sm font-semibold text-foreground mt-1">{result.title}</h4>
             </div>
             <div className="space-y-2">
               {result.cards.map((card, idx) => (
                 <div key={idx} className="rounded-xl border border-border p-3">
-                  <p className="text-xs font-medium text-muted-foreground">Front</p>
+                  <p className="text-xs font-medium text-muted-foreground">{t("aiSheet.flashcards.front")}</p>
                   <p className="text-sm text-foreground mt-1">{card.front}</p>
-                  <p className="text-xs font-medium text-muted-foreground mt-3">Back</p>
+                  <p className="text-xs font-medium text-muted-foreground mt-3">{t("aiSheet.flashcards.back")}</p>
                   <p className="text-sm text-foreground mt-1">{card.back}</p>
                 </div>
               ))}
@@ -875,7 +886,7 @@ export function AIActionsSheet({
         {result && result.type === "quiz" && (
           <div className="space-y-3 rounded-2xl border border-border bg-background p-4">
             <div>
-              <p className="text-xs uppercase tracking-wide text-muted-foreground">Quiz</p>
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">{t("aiSheet.quiz.sectionLabel")}</p>
               <h4 className="text-sm font-semibold text-foreground mt-1">{result.title}</h4>
             </div>
             <div className="space-y-3">
@@ -906,6 +917,7 @@ export function SearchOverlay({
   onSelectLibDoc: (d: DocItem) => void;
   onSelectTrainingDoc: (d: TrainingDoc) => void;
 }) {
+  const { t } = useTranslation("infohub");
   const [query, setQuery] = useState("");
   const q = query.toLowerCase();
 
@@ -919,7 +931,7 @@ export function SearchOverlay({
         <input
           autoFocus
           type="text"
-          placeholder="Search all documents..."
+          placeholder={t("shared.searchOverlay.placeholder")}
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           className="flex-1 text-sm bg-transparent focus:outline-none"
@@ -929,16 +941,16 @@ export function SearchOverlay({
         </button>
       </header>
       <main className="flex-1 overflow-auto px-4 py-4 space-y-4">
-        {!q && <p className="text-sm text-muted-foreground text-center mt-8">Start typing to search across Library and Training.</p>}
+        {!q && <p className="text-sm text-muted-foreground text-center mt-8">{t("shared.searchOverlay.startTyping")}</p>}
         {q && libResults.length === 0 && trainResults.length === 0 && (
           <div className="text-center mt-8">
             <BookOpen size={24} className="text-muted-foreground mx-auto mb-2" />
-            <p className="text-sm text-muted-foreground">No results found.</p>
+            <p className="text-sm text-muted-foreground">{t("shared.searchOverlay.noResults")}</p>
           </div>
         )}
         {libResults.length > 0 && (
           <>
-            <p className="section-label">Library</p>
+            <p className="section-label">{t("shared.searchOverlay.library")}</p>
             <div className="card-surface divide-y divide-border">
               {libResults.map((doc) => (
                 <button
@@ -958,7 +970,7 @@ export function SearchOverlay({
         )}
         {trainResults.length > 0 && (
           <>
-            <p className="section-label">Training</p>
+            <p className="section-label">{t("shared.searchOverlay.training")}</p>
             <div className="card-surface divide-y divide-border">
               {trainResults.map((doc) => (
                 <button
@@ -969,7 +981,7 @@ export function SearchOverlay({
                   <GraduationCap size={16} className="text-lavender-deep shrink-0" />
                   <div className="flex-1 min-w-0">
                     <p className="text-sm font-medium text-foreground">{doc.title}</p>
-                    <p className="text-xs text-muted-foreground">{doc.duration} · {doc.steps.length} steps</p>
+                    <p className="text-xs text-muted-foreground">{t("shared.searchOverlay.durationSteps", { duration: doc.duration, count: doc.steps.length })}</p>
                   </div>
                 </button>
               ))}
@@ -990,6 +1002,7 @@ export function FolderBreadcrumb<T extends { id: string; name: string; parentId:
   currentId: string | null;
   onNavigate: (id: string | null) => void;
 }) {
+  const { t } = useTranslation("infohub");
   if (!currentId) return null;
   const path: T[] = [];
   let cur = currentId;
@@ -1002,7 +1015,7 @@ export function FolderBreadcrumb<T extends { id: string; name: string; parentId:
 
   return (
     <div className="flex items-center gap-1 text-xs text-muted-foreground flex-wrap">
-      <button onClick={() => onNavigate(null)} className="hover:text-foreground transition-colors">All folders</button>
+      <button onClick={() => onNavigate(null)} className="hover:text-foreground transition-colors">{t("shared.breadcrumbAllFolders")}</button>
       {path.map((folder, idx) => (
         <span key={folder.id} className="flex items-center gap-1">
           <ChevronRight size={10} />


### PR DESCRIPTION
Covers the entire Infohub area (2157 lines across 3 files): the main page shell (search, tabs, folder/document lists, restricted badges, counts, empty states, archived section, folder/doc context menu actions), and every shared modal in `InfohubShared.tsx` (Move to folder, New/Rename folder, New document, File preview, Upload file, the Plus menu, Manage access, the AI Tools sheet with its summary/flashcards/quiz result panels, the full-screen search overlay, and the folder breadcrumb), plus the document detail views (library doc view/edit/AI-tools, training module step checklist and completion state).

New `infohub` i18n namespace. `describeCondition()` in `InfohubShared.tsx` is a plain function (not a component), so it pulls from the i18n singleton like the other non-component helpers established earlier in this sweep.

Real Spanish translations throughout.

## Test plan
- [x] `bun run lint` — 0 errors
- [x] `bun run test:ci` — 90/90 files, 1383/1383 tests passing
- [x] `bun run build` — succeeds
- [x] Full Infohub test suite run (86/86 across 3 test files) before the full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
