### PR TITLE
Fix kiosk-escape redirect leaving stale landing page behind /kiosk URL

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,18 @@ if (restoredGitHubPagesPath) {
   window.history.replaceState(null, "", restoredGitHubPagesPath);
 }
 
+// Same "must run before createBrowserRouter reads window.location" reason as
+// above — and the same class of bug it's meant to prevent (#574): a device
+// configured as a kiosk must never render the marketing/login/signup route,
+// even for one frame. Doing this redirect only after RootLayout mounts (see
+// the useLayoutEffect below) still lets that route's lazy chunk finish
+// loading and paint before Kiosk's own lazy chunk has loaded — the URL flips
+// to /kiosk immediately, but the old page stays on screen until Kiosk's
+// chunk arrives, which can take a moment on a slow connection (#631).
+if (shouldRedirectToKiosk(window.location.pathname, Boolean(localStorage.getItem("kiosk_location_id")))) {
+  window.history.replaceState(null, "", `${import.meta.env.BASE_URL}kiosk`.replace(/\/{2,}/g, "/"));
+}
+
 const SundayRemixSite = lazy(() => import("./pages/experiments/SundayRemixSite"));
 const Dashboard = lazy(() => import("./pages/Dashboard"));
 const Checklists = lazy(() => import("./pages/Checklists"));
@@ -75,6 +87,10 @@ function RootLayout() {
   // testing kiosk mode on their own laptop — to the kiosk picker any time
   // they clicked back to the homepage from an ordinary marketing page like
   // /privacy, which has nothing to do with an actual kiosk device.
+  //
+  // The module-scope check above (#631) now handles the common "fresh page
+  // load" case before the router even matches "/" — this effect is a
+  // defense-in-depth backstop for it, not the primary mechanism anymore.
   const kioskMountCheckDone = useRef(false);
   useLayoutEffect(() => {
     if (kioskMountCheckDone.current) return;


### PR DESCRIPTION
Fixes #631.

## Bug
On a device configured as a kiosk (`kiosk_location_id` in localStorage), navigating to `/` directly (e.g. editing the address bar) correctly bounces the URL back to `/kiosk`, but the landing page still renders — so you see marketing content under the `/kiosk` URL.

## Cause
`shouldRedirectToKiosk` was only checked in `RootLayout`'s `useLayoutEffect`, which runs after the `/` route has already matched, its lazy chunk loaded, and painted. `navigate("/kiosk", {replace:true})` updates the URL immediately but the visible route lags behind until `Kiosk`'s own lazy chunk finishes loading.

## Fix
Run the same check at module scope in `src/App.tsx`, before `createBrowserRouter` reads `window.location` — same pattern already used for the GitHub Pages 404-fallback restore right above it. `/` is never matched by the router at all on a configured kiosk device, so the landing page's chunk is never fetched. The existing `useLayoutEffect` guard stays as a backstop.

No behavior change for non-kiosk devices, and `shouldRedirectToKiosk`/`KIOSK_ESCAPE_ROUTES` themselves are untouched (already covered by `kiosk-guard.test.ts`).

## Test plan
- [x] `shouldRedirectToKiosk` logic unchanged, existing unit tests still cover it
- [ ] CI (lint/test/build) green
- [ ] Manual: on a browser with `kiosk_location_id` set, navigate to `oliahq.com/` → lands directly on the kiosk grid, no landing-page flash, URL is `/kiosk`
