### PR TITLE
Fix add-team-member modal closing on tab switch and PIN regenerating on role change

### DIFF
--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -4,7 +4,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { hasActiveKioskAdminSession } from "@/lib/kiosk-admin-session";
 
 export function ProtectedRoute({ children }: { children: React.ReactNode }) {
-  const { user, loading, setupError, signOut } = useAuth();
+  const { user, teamMember, loading, setupError, signOut } = useAuth();
   const navigate = useNavigate();
 
   // Navigate first, then sign out. Calling signOut first fires SIGNED_OUT
@@ -37,7 +37,13 @@ export function ProtectedRoute({ children }: { children: React.ReactNode }) {
     return <Navigate to="/kiosk" replace />;
   }
 
-  if (loading) {
+  // Only show the full-page blocker while there's no authenticated content to
+  // keep on screen yet. Once teamMember has loaded once, a later loading=true
+  // (e.g. Supabase re-firing an auth event on browser tab refocus) is just a
+  // background re-validation of the same session — unmounting `children` here
+  // would blow away any open modal or in-progress local state on the page for
+  // no user-visible reason (see #team-member-modal-tab-switch).
+  if (loading && !teamMember) {
     return (
       <div className="min-h-screen bg-background flex items-center justify-center">
         <p className="text-sm text-muted-foreground">Loading…</p>

--- a/src/pages/admin/SharedUI.tsx
+++ b/src/pages/admin/SharedUI.tsx
@@ -2,7 +2,7 @@
 // BottomSheet, ModalHeader, FormField, SaveButton, DepartmentRolePicker,
 // ConfirmModal, StaffProfileModal, TeamMemberModal, LocationModal
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import {
@@ -366,11 +366,6 @@ export function TeamMemberModal({
       setRevealLoading(false);
     }
   };
-
-  useEffect(() => {
-    if (member?.id) return;
-    setPin(generatePin());
-  }, [member?.id, role]);
 
   const toggleLocation = (id: string) => {
     setLocationIds(prev => prev.includes(id) ? prev.filter(l => l !== id) : [...prev, id]);

--- a/src/test/components/ProtectedRoute.test.tsx
+++ b/src/test/components/ProtectedRoute.test.tsx
@@ -54,6 +54,28 @@ describe("ProtectedRoute", () => {
     expect(screen.getByText("Protected content")).toBeInTheDocument();
   });
 
+  it("keeps rendering children through a background loading=true once teamMember has already loaded (e.g. tab refocus re-firing the auth event)", () => {
+    // Regression test: switching browser tabs and back can make Supabase
+    // re-fire an auth event for the same session, which briefly sets
+    // loading=true again while teamMember is re-fetched. That must not blank
+    // out and unmount already-rendered protected content — doing so would
+    // wipe any open modal or local state on the page for no visible reason.
+    mockUseAuth.mockReturnValue({
+      user: { id: "user-1" },
+      teamMember: { id: "user-1", name: "Sarah" },
+      loading: true,
+      setupError: null,
+      signOut: vi.fn(),
+    });
+    renderWithProviders(
+      <ProtectedRoute>
+        <p>Protected content</p>
+      </ProtectedRoute>
+    );
+    expect(screen.getByText("Protected content")).toBeInTheDocument();
+    expect(screen.queryByText(/loading/i)).not.toBeInTheDocument();
+  });
+
   it("navigates to /login when no user and not loading", () => {
     mockUseAuth.mockReturnValue({ user: null, loading: false, setupError: null, signOut: vi.fn() });
     render(

--- a/src/test/pages/admin/SharedUI.test.tsx
+++ b/src/test/pages/admin/SharedUI.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { TeamMemberModal } from "@/pages/admin/SharedUI";
+
+vi.mock("@/lib/supabase", () => ({
+  supabase: {
+    rpc: vi.fn().mockResolvedValue({ data: null, error: null }),
+  },
+}));
+
+vi.mock("@/components/ui/sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+describe("TeamMemberModal", () => {
+  it("keeps the generated PIN when switching roles instead of regenerating it", () => {
+    render(
+      <TeamMemberModal
+        member={null}
+        locations={[]}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+      />
+    );
+
+    const pinInput = screen.getByPlaceholderText("4-digit PIN") as HTMLInputElement;
+    const initialPin = pinInput.value;
+    expect(initialPin).toMatch(/^\d{4}$/);
+
+    fireEvent.click(screen.getByRole("button", { name: "Manager" }));
+    expect(pinInput.value).toBe(initialPin);
+
+    fireEvent.click(screen.getByRole("button", { name: "Owner" }));
+    expect(pinInput.value).toBe(initialPin);
+  });
+
+  it("keeps a manually-typed PIN when switching roles", () => {
+    render(
+      <TeamMemberModal
+        member={null}
+        locations={[]}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+      />
+    );
+
+    const pinInput = screen.getByPlaceholderText("4-digit PIN") as HTMLInputElement;
+    fireEvent.change(pinInput, { target: { value: "1234" } });
+    expect(pinInput.value).toBe("1234");
+
+    fireEvent.click(screen.getByRole("button", { name: "Member" }));
+    expect(pinInput.value).toBe("1234");
+  });
+
+  it("still lets Generate produce a new PIN on demand", () => {
+    render(
+      <TeamMemberModal
+        member={null}
+        locations={[]}
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+      />
+    );
+
+    const pinInput = screen.getByPlaceholderText("4-digit PIN") as HTMLInputElement;
+    fireEvent.change(pinInput, { target: { value: "1234" } });
+    fireEvent.click(screen.getByRole("button", { name: "Generate" }));
+    expect(pinInput.value).toMatch(/^\d{4}$/);
+  });
+});


### PR DESCRIPTION
## Summary
- `ProtectedRoute` was unmounting all page content on any `loading=true`, including a transient background auth re-validation (e.g. Supabase re-firing the auth event on browser tab refocus) — this wiped the Add Team Member modal's local open/edit state, closing it. It now only shows the full-page blocker before `teamMember` has ever loaded.
- `TeamMemberModal` regenerated the PIN via a `useEffect` on every role change, discarding a manually-typed or already-generated PIN. Removed the effect — the PIN is generated once on open, stays put through role switches, and saves with the rest of the form via the existing submit button.

Fixes #639

## Test plan
- [x] `bun run lint` — 0 errors
- [x] `bun run test:ci` — 1395 tests pass (91 files), including new tests for both fixes
- [x] `bun run build` — succeeds
- [x] New test: PIN persists across role switches (generated and manually-typed cases), Generate button still works
- [x] New test: `ProtectedRoute` keeps rendering children through `loading=true` once `teamMember` is already loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)