### PR TITLE
Fix app looking stretched/elongated on iPad portrait and other tall viewports

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -120,8 +120,12 @@ export function Layout({ children, title, subtitle, headerRight, headerLeft }: L
           <SidebarNav />
 
           {/* Only this column scrolls */}
-          <main ref={mainRef} className="flex-1 min-w-0 overflow-y-auto overflow-x-hidden pb-24 pt-5 animate-fade-in md:pb-8">
-            <div className={cn(contentWidthClass, "min-w-0 space-y-4")}>
+          <main ref={mainRef} className="flex-1 min-w-0 overflow-y-auto overflow-x-hidden pb-24 pt-5 animate-fade-in md:pb-8 flex flex-col">
+            {/* my-auto centers content vertically when it's shorter than the
+                pane (e.g. a short list on a tall tablet screen) — auto margins
+                collapse to 0 once content overflows, so long pages still start
+                at the top and scroll normally. */}
+            <div className={cn(contentWidthClass, "min-w-0 space-y-4 my-auto")}>
               {children}
             </div>
           </main>

--- a/src/pages/Kiosk.tsx
+++ b/src/pages/Kiosk.tsx
@@ -919,7 +919,12 @@ export default function Kiosk() {
       )}
 
       {/* Checklist grid */}
-      <div className="px-5 sm:px-6 lg:px-8 flex-1 pb-6 mt-2">
+      <div data-testid="kiosk-checklist-grid" className="px-5 sm:px-6 lg:px-8 flex-1 pb-6 mt-2 flex flex-col">
+        {/* my-auto centers a short state (loading/empty/"nothing due") within
+            the available space on a tall tablet screen; once real checklist
+            cards overflow that space, the margin collapses to 0 and the list
+            starts at the top and scrolls normally. */}
+        <div className="my-auto">
         {checklistsLoading ? (
           <div className="flex items-center justify-center py-12 gap-2 text-muted-foreground">
             <Loader2 size={16} className="animate-spin" />
@@ -1041,6 +1046,7 @@ export default function Kiosk() {
             )}
           </div>
         )}
+        </div>
       </div>
 
       {/* Footer */}

--- a/src/test/components/Layout.test.tsx
+++ b/src/test/components/Layout.test.tsx
@@ -82,6 +82,18 @@ describe("Layout", () => {
     expect(screen.getByText("Right Btn")).toBeInTheDocument();
   });
 
+  it("vertically centers short page content via a flex column + auto-margin wrapper, so a short page doesn't strand content at the top with a large empty gap below on a tall (e.g. tablet-portrait) viewport", () => {
+    renderWithProviders(<Layout title="T"><p>content</p></Layout>);
+    const contentText = screen.getByText("content");
+    const main = contentText.closest("main");
+    expect(main).not.toBeNull();
+    expect(main).toHaveClass("flex", "flex-col");
+    // The immediate wrapper around children carries my-auto: its margin
+    // collapses to 0 once content overflows the pane (long pages still
+    // start at the top and scroll normally), but centers a short page.
+    expect(contentText.parentElement).toHaveClass("my-auto");
+  });
+
   it("renders the BottomNav", () => {
     renderWithProviders(<Layout title="T"><span /></Layout>);
     expect(screen.getAllByText("Dashboard").length).toBeGreaterThanOrEqual(1);

--- a/src/test/pages/Kiosk.test.tsx
+++ b/src/test/pages/Kiosk.test.tsx
@@ -410,6 +410,15 @@ describe("Kiosk — Grid Screen", () => {
     expect(screen.getByRole("heading", { name: "Terrace" })).toBeInTheDocument();
   });
 
+  it("vertically centers a short checklist state (e.g. 'nothing due') via a flex column + auto-margin wrapper, so it isn't stranded at the top with a large empty gap below on a tall tablet screen", async () => {
+    await renderGridScreen();
+    const grid = screen.getByTestId("kiosk-checklist-grid");
+    expect(grid).toHaveClass("flex", "flex-col");
+    // my-auto's margin collapses to 0 once real checklist cards overflow
+    // the pane, so a busy kiosk still lists from the top and scrolls.
+    expect(grid.firstElementChild).toHaveClass("my-auto");
+  });
+
   it("shows a device-scoped language picker defaulting to English", async () => {
     await renderGridScreen();
     expect(screen.getByRole("combobox")).toHaveTextContent("EN");


### PR DESCRIPTION
## Summary
- Full responsive sweep across phone/tablet/laptop/desktop breakpoints and Chromium/WebKit/Firefox using the existing Playwright e2e mocks (`e2e/fixtures/`), triggered by a report that the app looks "elongated"/doesn't fit the screen on iPad in portrait.
- Root cause: `Layout.tsx`'s scrollable content pane (and `Kiosk.tsx`'s checklist grid, which has its own standalone layout) top-anchor their content with no minimum-fill behavior. Any page shorter than the viewport leaves a blank void below it — present at every size, but only visually jarring on tall/tablet-portrait screens (768–1024×1024–1366) where the absolute leftover space is largest. Nothing was actually broken, clipped, or distorted — confirmed across the full breakpoint × browser matrix.
- Fix: both wrap their content in a flex column with an auto-margin (`my-auto`) wrapper. Short content centers vertically (reads as intentional). The margin collapses to 0 once content overflows the pane, so busy/long pages are unaffected and still start at the top and scroll normally.

Fixes #641

## Test plan
- [x] `bun run lint` — 0 errors
- [x] `bun run test:ci` — 1397 tests pass (91 files), including 2 new tests asserting the flex/my-auto wrapper classes on both Layout and Kiosk
- [x] `bun run build` — succeeds
- [x] Manual Playwright screenshot sweep (deleted before commit, not part of the diff): iPhone SE/14 Pro, Android, iPad mini/Pro 11"/Pro 12.9" portrait+landscape, laptop, desktop — Dashboard, Checklists, Reporting, Infohub, Admin (all tabs), Kiosk grid, Landing, Login — on Chromium, WebKit, and Firefox. Confirmed the void is gone on short pages and long/data-rich pages (Reporting, populated Admin/Users) are pixel-identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)